### PR TITLE
Upgrade to PHPUnit 9

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: php-actions/composer@v5
+      - uses: php-actions/composer@v6
 
       - uses: php-actions/phpunit@v3
         with:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -6,9 +6,26 @@ on:
       - "**.php"
       - "bin/posthog"
       - "phpcs.xml"
+      - "phpunit.xml"
       - ".github/workflows/php.yml"
 
 jobs:
+  phpunit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: php-actions/composer@v5
+
+      - uses: php-actions/phpunit@v3
+        with:
+          php_extensions: xdebug
+          bootstrap: vendor/autoload.php
+          configuration: phpunit.xml
+          args: --coverage-text
+        env:
+          XDEBUG_MODE: coverage
+
   phpcs:
     runs-on: ubuntu-latest
     steps:

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 	},
 	"require-dev": {
 		"overtrue/phplint": "^2.3",
-		"phpunit/phpunit": "~8.0",
+		"phpunit/phpunit": "^9.0",
 		"squizlabs/php_codesniffer": "^3.6"
 	},
 	"autoload": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,35 +1,36 @@
-<phpunit
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.0/phpunit.xsd"
-    backupGlobals="true"
-    backupStaticAttributes="false"
-    cacheTokens="false"
-    colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    forceCoversAnnotation="false"
-    processIsolation="false"
-    stopOnError="false"
-    stopOnFailure="false"
-    stopOnIncomplete="false"
-    stopOnSkipped="false"
-    stopOnRisky="false"
-    timeoutForSmallTests="1"
-    timeoutForMediumTests="10"
-    timeoutForLargeTests="60"
-    verbose="false">
-    <testsuites>
-        <testsuite name="posthog-php">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./lib</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-clover" target="clover.xml"/>
-    </logging>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="true"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         forceCoversAnnotation="false"
+         processIsolation="false"
+         stopOnError="false"
+         stopOnFailure="false"
+         stopOnIncomplete="false"
+         stopOnSkipped="false"
+         stopOnRisky="false"
+         timeoutForSmallTests="1"
+         timeoutForMediumTests="10"
+         timeoutForLargeTests="60"
+         verbose="false"
+>
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./lib</directory>
+    </include>
+    <report>
+      <text outputFile="php://stdout" showUncoveredFiles="true"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="posthog-php">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/test/ConsumerFileTest.php
+++ b/test/ConsumerFileTest.php
@@ -33,9 +33,9 @@ class ConsumerFileTest extends TestCase
         }
     }
 
-    public function testCapture()
+    public function testCapture(): void
     {
-        $this->assertTrue(
+        self::assertTrue(
             $this->client->capture(
                 array(
                     "distinctId" => "some-user",
@@ -47,9 +47,9 @@ class ConsumerFileTest extends TestCase
         $this->checkWritten("capture");
     }
 
-    public function testIdentify()
+    public function testIdentify(): void
     {
-        $this->assertTrue(
+        self::assertTrue(
             $this->client->identify(
                 array(
                     "distinctId" => "Calvin",
@@ -64,9 +64,9 @@ class ConsumerFileTest extends TestCase
         $this->checkWritten("identify");
     }
 
-    public function testAlias()
+    public function testAlias(): void
     {
-        $this->assertTrue(
+        self::assertTrue(
             $this->client->alias(
                 array(
                     "alias" => "previous-id",
@@ -74,10 +74,11 @@ class ConsumerFileTest extends TestCase
                 )
             )
         );
+
         $this->checkWritten("alias");
     }
 
-    public function testSend()
+    public function testSend(): void
     {
         for ($i = 0; $i < 200; ++$i) {
             $this->client->capture(
@@ -88,11 +89,11 @@ class ConsumerFileTest extends TestCase
             );
         }
         exec("php send.php --apiKey BrpS4SctoaCCsyjlnlun3OzyNJAafdlv__jUWaaJWXg --file /tmp/posthog.log", $output);
-        $this->assertSame("sent 200 from 200 requests successfully", trim(join('', $output)));
-        $this->assertFileNotExists($this->filename());
+        self::assertSame("sent 200 from 200 requests successfully", trim(implode('', $output)));
+        self::assertFileDoesNotExist($this->filename());
     }
 
-    public function testProductionProblems()
+    public function testProductionProblems(): void
     {
         // Open to a place where we should not have write access.
         $client = new Client(
@@ -104,21 +105,21 @@ class ConsumerFileTest extends TestCase
         );
 
         $captured = $client->capture(array("distinctId" => "some-user", "event" => "my event"));
-        $this->assertFalse($captured);
+        self::assertFalse($captured);
     }
 
-    public function checkWritten($type)
+    private function checkWritten($type): void
     {
         exec("wc -l " . $this->filename, $output);
         $out = trim($output[0]);
-        $this->assertSame($out, "1 " . $this->filename);
+        self::assertSame($out, "1 " . $this->filename);
         $str = file_get_contents($this->filename);
         $json = json_decode(trim($str));
-        $this->assertSame($type, $json->type);
+        self::assertSame($type, $json->type);
         unlink($this->filename);
     }
 
-    public function filename()
+    public function filename(): string
     {
         return '/tmp/posthog.log';
     }

--- a/test/ConsumerForkCurlTest.php
+++ b/test/ConsumerForkCurlTest.php
@@ -21,9 +21,9 @@ class ConsumerForkCurlTest extends TestCase
         );
     }
 
-    public function testCapture()
+    public function testCapture(): void
     {
-        $this->assertTrue(
+        self::assertTrue(
             $this->client->capture(
                 array(
                     "distinctId" => "some-user",
@@ -33,9 +33,9 @@ class ConsumerForkCurlTest extends TestCase
         );
     }
 
-    public function testIdentify()
+    public function testIdentify(): void
     {
-        $this->assertTrue(
+        self::assertTrue(
             $this->client->identify(
                 array(
                     "distinctId" => "user-id",
@@ -49,9 +49,9 @@ class ConsumerForkCurlTest extends TestCase
         );
     }
 
-    public function testAlias()
+    public function testAlias(): void
     {
-        $this->assertTrue(
+        self::assertTrue(
             $this->client->alias(
                 array(
                     "alias" => "alias-id",

--- a/test/ConsumerLibCurlTest.php
+++ b/test/ConsumerLibCurlTest.php
@@ -21,9 +21,9 @@ class ConsumerLibCurlTest extends TestCase
         );
     }
 
-    public function testCapture()
+    public function testCapture(): void
     {
-        $this->assertTrue(
+        self::assertTrue(
             $this->client->capture(
                 array(
                     "distinctId" => "lib-curl-capture",
@@ -33,9 +33,9 @@ class ConsumerLibCurlTest extends TestCase
         );
     }
 
-    public function testIdentify()
+    public function testIdentify(): void
     {
-        $this->assertTrue(
+        self::assertTrue(
             $this->client->identify(
                 array(
                     "distinctId" => "lib-curl-identify",
@@ -49,9 +49,9 @@ class ConsumerLibCurlTest extends TestCase
         );
     }
 
-    public function testAlias()
+    public function testAlias(): void
     {
-        $this->assertTrue(
+        self::assertTrue(
             $this->client->alias(
                 array(
                     "alias" => "lib-curl-alias",

--- a/test/ConsumerSocketTest.php
+++ b/test/ConsumerSocketTest.php
@@ -9,14 +9,12 @@ use RuntimeException;
 
 class ConsumerSocketTest extends TestCase
 {
-    private $client;
-
     public function setUp(): void
     {
         date_default_timezone_set("UTC");
     }
 
-    public function testCapture()
+    public function testCapture(): void
     {
         $client = new Client(
             "BrpS4SctoaCCsyjlnlun3OzyNJAafdlv__jUWaaJWXg",
@@ -24,7 +22,7 @@ class ConsumerSocketTest extends TestCase
                 "consumer" => "socket",
             )
         );
-        $this->assertTrue(
+        self::assertTrue(
             $client->capture(
                 array(
                     "distinctId" => "some-user",
@@ -35,7 +33,7 @@ class ConsumerSocketTest extends TestCase
         $client->__destruct();
     }
 
-    public function testIdentify()
+    public function testIdentify(): void
     {
         $client = new Client(
             "BrpS4SctoaCCsyjlnlun3OzyNJAafdlv__jUWaaJWXg",
@@ -43,7 +41,7 @@ class ConsumerSocketTest extends TestCase
                 "consumer" => "socket",
             )
         );
-        $this->assertTrue(
+        self::assertTrue(
             $client->identify(
                 array(
                     "distinctId" => "Calvin",
@@ -57,7 +55,7 @@ class ConsumerSocketTest extends TestCase
         $client->__destruct();
     }
 
-    public function testShortTimeout()
+    public function testShortTimeout(): void
     {
         $client = new Client(
             "BrpS4SctoaCCsyjlnlun3OzyNJAafdlv__jUWaaJWXg",
@@ -67,7 +65,7 @@ class ConsumerSocketTest extends TestCase
             )
         );
 
-        $this->assertTrue(
+        self::assertTrue(
             $client->capture(
                 array(
                     "distinctId" => "some-user",
@@ -76,7 +74,7 @@ class ConsumerSocketTest extends TestCase
             )
         );
 
-        $this->assertTrue(
+        self::assertTrue(
             $client->identify(
                 array(
                     "distinctId" => "some-user",
@@ -88,7 +86,7 @@ class ConsumerSocketTest extends TestCase
         $client->__destruct();
     }
 
-    public function testProductionProblems()
+    public function testProductionProblems(): void
     {
         $client = new Client(
             "x",
@@ -103,11 +101,10 @@ class ConsumerSocketTest extends TestCase
         // Shouldn't error out without debug on.
         $client->capture(array("user_id" => "some-user", "event" => "Production Problems"));
         $client->__destruct();
-        $this->assertTrue(true);
+        self::assertTrue(true);
     }
 
-
-    public function testLargeMessage()
+    public function testLargeMessage(): void
     {
         $options = array(
             "debug" => true,
@@ -122,7 +119,7 @@ class ConsumerSocketTest extends TestCase
             $big_property .= "a";
         }
 
-        $this->assertTrue(
+        self::assertTrue(
             $client->capture(
                 array(
                     "distinctId" => "some-user",
@@ -135,7 +132,7 @@ class ConsumerSocketTest extends TestCase
         $client->__destruct();
     }
 
-    public function testConnectionError()
+    public function testConnectionError(): void
     {
         $this->expectException('RuntimeException');
         $client = new Client(

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -13,9 +13,9 @@ class PostHogTest extends TestCase
         PostHog::init("BrpS4SctoaCCsyjlnlun3OzyNJAafdlv__jUWaaJWXg", array("debug" => true));
     }
 
-    public function testCapture()
+    public function testCapture(): void
     {
-        $this->assertTrue(
+        self::assertTrue(
             PostHog::capture(
                 array(
                     "distinctId" => "john",
@@ -25,9 +25,9 @@ class PostHogTest extends TestCase
         );
     }
 
-    public function testIdentify()
+    public function testIdentify(): void
     {
-        $this->assertTrue(
+        self::assertTrue(
             PostHog::identify(
                 array(
                     "distinctId" => "doe",
@@ -40,9 +40,9 @@ class PostHogTest extends TestCase
         );
     }
 
-    public function testEmptyProperties()
+    public function testEmptyProperties(): void
     {
-        $this->assertTrue(
+        self::assertTrue(
             PostHog::identify(
                 array(
                     "distinctId" => "empty-properties",
@@ -50,7 +50,7 @@ class PostHogTest extends TestCase
             )
         );
 
-        $this->assertTrue(
+        self::assertTrue(
             PostHog::capture(
                 array(
                     "distinctId" => "user-id",
@@ -60,9 +60,9 @@ class PostHogTest extends TestCase
         );
     }
 
-    public function testEmptyArrayProperties()
+    public function testEmptyArrayProperties(): void
     {
-        $this->assertTrue(
+        self::assertTrue(
             PostHog::identify(
                 array(
                     "distinctId" => "empty-properties",
@@ -71,7 +71,7 @@ class PostHogTest extends TestCase
             )
         );
 
-        $this->assertTrue(
+        self::assertTrue(
             PostHog::capture(
                 array(
                     "distinctId" => "user-id",
@@ -82,9 +82,9 @@ class PostHogTest extends TestCase
         );
     }
 
-    public function testAlias()
+    public function testAlias(): void
     {
-        $this->assertTrue(
+        self::assertTrue(
             PostHog::alias(
                 array(
                     "alias" => "previous-id",
@@ -94,9 +94,9 @@ class PostHogTest extends TestCase
         );
     }
 
-    public function testTimestamps()
+    public function testTimestamps(): void
     {
-        $this->assertTrue(
+        self::assertTrue(
             PostHog::capture(
                 array(
                     "distinctId" => "user-id",
@@ -106,7 +106,7 @@ class PostHogTest extends TestCase
             )
         );
 
-        $this->assertTrue(
+        self::assertTrue(
             PostHog::capture(
                 array(
                     "distinctId" => "user-id",
@@ -116,7 +116,7 @@ class PostHogTest extends TestCase
             )
         );
 
-        $this->assertTrue(
+        self::assertTrue(
             PostHog::capture(
                 array(
                     "distinctId" => "user-id",
@@ -126,7 +126,7 @@ class PostHogTest extends TestCase
             )
         );
 
-        $this->assertTrue(
+        self::assertTrue(
             PostHog::capture(
                 array(
                     "distinctId" => "user-id",
@@ -136,7 +136,7 @@ class PostHogTest extends TestCase
             )
         );
 
-        $this->assertTrue(
+        self::assertTrue(
             PostHog::capture(
                 array(
                     "distinctId" => "user-id",


### PR DESCRIPTION
# Notes

Upgrades to PHPUnit 9 (using the automated PHPUnit config migration) & adds CI job to run unit tests / code coverage (fixes #8).

# Review Notes

This extends https://github.com/PostHog/posthog-php/pull/13 to avoid conflicts, so I suggest reviewing/merging that first.