### PR TITLE
Support environment variables

### DIFF
--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -7,17 +7,21 @@ use Exception;
 class PostHog
 {
     public const VERSION = '2.0.0';
+    public const ENV_API_KEY = "POSTHOG_API_KEY";
 
     private static $client;
 
     /**
      * Initializes the default client to use. Uses the libcurl consumer by default.
-     * @param string $apiKey your project's API key
+     * @param string|null $apiKey your project's API key
      * @param array $options passed straight to the client
      * @throws Exception
      */
-    public static function init($apiKey, $options = array())
+    public static function init(string $apiKey = null, array $options = []): void
     {
+        // Check the env vars to see if the API key is set, if not, default to the parameter passed to init()
+        $apiKey = getenv(self::ENV_API_KEY) ?: $apiKey;
+
         self::assert($apiKey, "PostHog::init() requires an apiKey");
         self::$client = new Client($apiKey, $options);
     }

--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -113,11 +113,11 @@ class PostHog
     }
 
     /**
-     * @param string $apiKey
+     * @param string|null $apiKey
      * @param array $options
      * @return array
      */
-    private static function overrideConfigWithEnv(string $apiKey, array $options): array
+    private static function overrideConfigWithEnv(?string $apiKey, array $options): array
     {
         // Check the env vars to see if the API key is set, if not, default to the parameter passed to init()
         $apiKey = getenv(self::ENV_API_KEY) ?: $apiKey;

--- a/lib/QueueConsumer.php
+++ b/lib/QueueConsumer.php
@@ -4,8 +4,6 @@ namespace PostHog;
 
 abstract class QueueConsumer extends Consumer
 {
-    public const ENV_HOST = "POSTHOG_HOST";
-
     protected $type = "QueueConsumer";
 
     protected $queue;
@@ -32,10 +30,8 @@ abstract class QueueConsumer extends Consumer
             $this->batch_size = $options["batch_size"];
         }
 
-        $envHost = getenv(self::ENV_HOST) ?: null;
-        $optionsHost = $options["host"] ?? null;
-        if (null !== $envHost || null !== $optionsHost) {
-            $this->host = $envHost ?? $optionsHost;
+        if (isset($options["host"])) {
+            $this->host = $options["host"];
 
             if ($this->host && preg_match("/^https?:\\/\\//i", $this->host)) {
                 $this->options['ssl'] = substr($this->host, 0, 5) == 'https';

--- a/lib/QueueConsumer.php
+++ b/lib/QueueConsumer.php
@@ -4,6 +4,8 @@ namespace PostHog;
 
 abstract class QueueConsumer extends Consumer
 {
+    public const ENV_HOST = "POSTHOG_HOST";
+
     protected $type = "QueueConsumer";
 
     protected $queue;
@@ -30,8 +32,10 @@ abstract class QueueConsumer extends Consumer
             $this->batch_size = $options["batch_size"];
         }
 
-        if (isset($options["host"])) {
-            $this->host = $options["host"];
+        $envHost = getenv(self::ENV_HOST) ?: null;
+        $optionsHost = $options["host"] ?? null;
+        if (null !== $envHost || null !== $optionsHost) {
+            $this->host = $envHost ?? $optionsHost;
 
             if ($this->host && preg_match("/^https?:\\/\\//i", $this->host)) {
                 $this->options['ssl'] = substr($this->host, 0, 5) == 'https';

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -2,6 +2,7 @@
 
 namespace PostHog\Test;
 
+use Exception;
 use PHPUnit\Framework\TestCase;
 use PostHog\PostHog;
 
@@ -11,6 +12,29 @@ class PostHogTest extends TestCase
     {
         date_default_timezone_set("UTC");
         PostHog::init("BrpS4SctoaCCsyjlnlun3OzyNJAafdlv__jUWaaJWXg", array("debug" => true));
+    }
+
+    public function testInitWithParamApiKey(): void
+    {
+        $this->expectNotToPerformAssertions();
+        PostHog::init("BrpS4SctoaCCsyjlnlun3OzyNJAafdlv__jUWaaJWXg", array("debug" => true));
+    }
+
+    public function testInitWithEnvApiKey(): void
+    {
+        $this->expectNotToPerformAssertions();
+        putenv(PostHog::ENV_API_KEY . "=BrpS4SctoaCCsyjlnlun3OzyNJAafdlv__jUWaaJWXg");
+        PostHog::init(null, array("degug" => true));
+
+        // Clear the environment variable
+        putenv(PostHog::ENV_API_KEY);
+    }
+
+    public function testInitThrowsExceptionWithNoApiKey(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("PostHog::init() requires an apiKey");
+        PostHog::init(null);
     }
 
     public function testCapture(): void


### PR DESCRIPTION
# Notes

Libraries such as Symfony heavily make use of environment variables and encourage their usage. This PR allows for the two major settings in the PHP implementation (api key, and host) to be setup using environment variables. The major benefit of this is allowing different configuration across environments (local, staging and prod for example).

This has no breaking changes, if the environment variables are set it will use them, if not, it will default to the previous methods.

Before:

```php
PostHog::init("<ph_project_api_key>",
  array('host' => '<ph_instance_address>') // You can remove this line if you're using app.posthog.com
);
```

After:
```env
POSTHOG_API_KEY=<ph_project_api_key>
POSTHOG_HOST=<ph_instance_address> # You can remove this line if you're using app.posthog.com
```

```php
PostHog::init();
```

I think this could also do with a PR to update the docs at https://posthog.com/docs/libraries/php, but I wanted to validate this PR first...