### PR TITLE
Add feature flags

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"php": ">=7.1"
 	},
 	"require-dev": {
-		"overtrue/phplint": "^2.3",
+		"overtrue/phplint": "^3.0",
 		"phpunit/phpunit": "^9.0",
 		"squizlabs/php_codesniffer": "^3.6"
 	},

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "posthog/posthog-php",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"description": "PostHog PHP Library",
 	"keywords": [
 		"posthog"

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
 	},
 	"autoload-dev": {
 		"psr-4": {
-			"PostHog\\Test\\": "test/"
+			"PostHog\\Test\\": "test/",
+			"PostHog\\Test\\Assets\\": "test/assests"
 		}
 	},
 	"bin": [

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -30,8 +30,6 @@ class Client
      * @var Consumer
      */
     protected $consumer;
-
-    protected $featureFlags = null;
     
     /**
      * @var HttpClient

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -59,8 +59,11 @@ class Client
         $this->consumer = new $Consumer($apiKey, $options);
         $this->personalApiKey = $options["personal_api_key"] ?? null;
         $this->httpClient = new HttpClient(
-            $this->options['host'] ?? "app.posthog.com",
-            $this->options['ssl'] ?? true
+            $options['host'] ?? "app.posthog.com",
+            $options['ssl'] ?? true,
+            10000,
+            false,
+            $options["debug"] ?? false
         );
     }
 
@@ -307,8 +310,8 @@ class Client
     private function loadFeatureFlags(): void
     {
         $response = $this->httpClient->sendRequest(
-            '/api/feature_flag/',
-            '',
+            '/api/feature_flag',
+            null,
             [
                 "Authorization: Bearer $this->personalApiKey",
             ]

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -51,16 +51,15 @@ class Client
      *
      * @param string $apiKey
      * @param array $options array of consumer options [optional]
-     * @param string Consumer constructor to use, libcurl by default.
-     *
+     * @param HttpClient|null $httpClient
      */
-    public function __construct(string $apiKey, array $options = [])
+    public function __construct(string $apiKey, array $options = [], ?HttpClient $httpClient = null)
     {
         $this->apiKey = $apiKey;
         $Consumer = self::CONSUMERS[$options["consumer"] ?? "lib_curl"];
         $this->consumer = new $Consumer($apiKey, $options);
         $this->personalApiKey = $options["personal_api_key"] ?? null;
-        $this->httpClient = new HttpClient(
+        $this->httpClient = $httpClient !== null ? $httpClient : new HttpClient(
             $options['host'] ?? "app.posthog.com",
             $options['ssl'] ?? true,
             10000,

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -342,6 +342,6 @@ class Client
         }
         $hexValueOfHash = sha1("$key.$distinctId", false);
         $integerRepresentationOfHashSubset = intval(substr($hexValueOfHash, 0, 15), 16);
-        return ($integerRepresentationOfHashSubset / 0xFFFFFFFFFFFFFFF) <= ($rolloutPercentage / 100);
+        return ($integerRepresentationOfHashSubset / self::LONG_SCALE) <= ($rolloutPercentage / 100);
     }
 }

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -334,7 +334,7 @@ class Client
         $this->featureFlags = $responseBody['results'];
     }
 
-    private function isSimpleFlagEnabled(string $key, string $distinctId, int $rolloutPercentage): bool
+    private function isSimpleFlagEnabled(string $key, string $distinctId, ?int $rolloutPercentage): bool
     {
         if (! (bool) $rolloutPercentage) {
             return true;

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -56,9 +56,13 @@ class Client
             10000,
             false,
             $options["debug"] ?? false
-        );
+        );   
     }
 
+    public function __destruct()
+    {
+        $this->consumer->__destruct();
+    }
 
     /**
      * Captures a user action

--- a/lib/Consumer/ForkCurl.php
+++ b/lib/Consumer/ForkCurl.php
@@ -47,13 +47,9 @@ class ForkCurl extends QueueConsumer
         $payload = escapeshellarg($payload);
 
         $protocol = $this->ssl() ? "https://" : "http://";
-        if ($this->host) {
-            $host = $this->host;
-        } else {
-            $host = "t.posthog.com";
-        }
+
         $path = "/batch/";
-        $url = $protocol . $host . $path;
+        $url = $protocol . $this->host . $path;
 
         $cmd = "curl -X POST -H 'Content-Type: application/json'";
 

--- a/lib/Consumer/LibCurl.php
+++ b/lib/Consumer/LibCurl.php
@@ -2,11 +2,16 @@
 
 namespace PostHog\Consumer;
 
+use PostHog\HttpClient;
 use PostHog\QueueConsumer;
 
 class LibCurl extends QueueConsumer
 {
     protected $type = "LibCurl";
+    /**
+     * @var HttpClient
+     */
+    private $httpClient;
 
     /**
      * Creates a new queued libcurl consumer
@@ -16,9 +21,14 @@ class LibCurl extends QueueConsumer
      *     number   "max_queue_size" - the max size of messages to enqueue
      *     number   "batch_size" - how many messages to send in a single request
      */
-    public function __construct($apiKey, $options = array())
+    public function __construct($apiKey, $options = [])
     {
         parent::__construct($apiKey, $options);
+        $this->httpClient = new HttpClient(
+            $this->host,
+            $this->ssl(),
+            $this->maximum_backoff_duration
+        );
     }
 
     /**
@@ -57,7 +67,7 @@ class LibCurl extends QueueConsumer
             $payload = gzencode($payload);
         }
 
-        return $this->sendRequest(
+        return $this->httpClient->sendRequest(
             '/batch/',
             $payload,
             [
@@ -77,73 +87,6 @@ class LibCurl extends QueueConsumer
             $payload = gzencode($payload);
         }
 
-        return $this->sendRequest('/decide/', $payload);
-    }
-
-    /**
-     * @param string $path
-     * @param string|null $payload
-     * @param array $extraHeaders
-     * @return mixed
-     */
-    public function sendRequest(string $path, string $payload, array $extraHeaders = [])
-    {
-        $protocol = $this->ssl() ? "https://" : "http://";
-
-        $backoff = 100;     // Set initial waiting time to 100ms
-
-        while ($backoff < $this->maximum_backoff_duration) {
-            // open connection
-            $ch = curl_init();
-
-
-            curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
-
-
-            $headers = [];
-            $headers[] = 'Content-Type: application/json';
-            if ($this->compress_request) {
-                $headers[] = 'Content-Encoding: gzip';
-            }
-
-            curl_setopt($ch, CURLOPT_HTTPHEADER, array_merge($headers, $extraHeaders));
-            curl_setopt($ch, CURLOPT_URL, $protocol . $this->host . $path);
-            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-
-            // retry failed requests just once to diminish impact on performance
-            [$httpResponse, $httpResponseCode] = $this->executePost($ch);
-
-            //close connection
-            curl_close($ch);
-
-            if (200 != $httpResponseCode) {
-                // log error
-                $this->handleError($ch, $httpResponseCode);
-
-                if (($httpResponseCode >= 500 && $httpResponseCode <= 600) || 429 == $httpResponseCode) {
-                    // If status code is greater than 500 and less than 600, it indicates server error
-                    // Error code 429 indicates rate limited.
-                    // Retry uploading in these cases.
-                    usleep($backoff * 1000);
-                    $backoff *= 2;
-                } elseif ($httpResponseCode >= 400) {
-                    break;
-                } elseif ($httpResponseCode == 0) {
-                    break;
-                }
-            } else {
-                break;  // no error
-            }
-        }
-
-        return $httpResponse;
-    }
-
-    public function executePost($ch): array
-    {
-        return [
-            curl_exec($ch),
-            curl_getinfo($ch, CURLINFO_RESPONSE_CODE)
-        ];
+        return $this->httpClient->sendRequest('/decide/', $payload);
     }
 }

--- a/lib/Consumer/LibCurl.php
+++ b/lib/Consumer/LibCurl.php
@@ -42,7 +42,6 @@ class LibCurl extends QueueConsumer
     {
         $body = $this->payload($messages);
         $payload = json_encode($body);
-        $apiKey = $this->apiKey;
 
         // Verify message size is below than 32KB
         if (strlen($payload) >= 32 * 1024) {
@@ -58,64 +57,79 @@ class LibCurl extends QueueConsumer
             $payload = gzencode($payload);
         }
 
-        $protocol = $this->ssl() ? "https://" : "http://";
-        if ($this->host) {
-            $host = $this->host;
-        } else {
-            $host = "t.posthog.com";
+        return $this->sendRequest(
+            '/batch/',
+            $payload,
+            [
+                "User-Agent: {$messages['library']}/{$messages['library_version']}",
+            ]
+        );
+    }
+
+    public function decide(string $distinctId)
+    {
+        $payload = json_encode([
+            'api_key' => $this->apiKey,
+            'distinct_id' => $distinctId,
+        ]);
+
+        if ($this->compress_request) {
+            $payload = gzencode($payload);
         }
-        $path = "/batch/";
-        $url = $protocol . $host . $path;
+
+        return $this->sendRequest('/decide/', $payload);
+    }
+
+    /**
+     * @param string $path
+     * @param string|null $payload
+     * @param array $extraHeaders
+     * @return mixed
+     */
+    public function sendRequest(string $path, string $payload, array $extraHeaders = [])
+    {
+        $protocol = $this->ssl() ? "https://" : "http://";
+        $host = $this->host ?? "t.posthog.com";
 
         $backoff = 100;     // Set initial waiting time to 100ms
 
         while ($backoff < $this->maximum_backoff_duration) {
-            $start_time = microtime(true);
-
             // open connection
             $ch = curl_init();
 
-            // set the url, number of POST vars, POST data
+
             curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
 
-            // set variables for headers
-            $header = array();
-            $header[] = 'Content-Type: application/json';
 
+            $headers = [];
+            $headers[] = 'Content-Type: application/json';
             if ($this->compress_request) {
-                $header[] = 'Content-Encoding: gzip';
+                $headers[] = 'Content-Encoding: gzip';
             }
 
-            // Send user agent in the form of {library_name}/{library_version} as per RFC 7231.
-            $libName = $messages[0]['library'];
-            $libVersion = $messages[0]['library_version'];
-            $header[] = "User-Agent: ${libName}/${libVersion}";
-
-            curl_setopt($ch, CURLOPT_HTTPHEADER, $header);
-            curl_setopt($ch, CURLOPT_URL, $url);
+            curl_setopt($ch, CURLOPT_HTTPHEADER, array_merge($headers, $extraHeaders));
+            curl_setopt($ch, CURLOPT_URL, $protocol . $host . $path);
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 
             // retry failed requests just once to diminish impact on performance
-            $httpResponse = $this->executePost($ch);
+            [$httpResponse, $httpResponseCode] = $this->executePost($ch);
 
             //close connection
             curl_close($ch);
 
-            $elapsed_time = microtime(true) - $start_time;
-
-            if (200 != $httpResponse) {
+            if (200 != $httpResponseCode) {
                 // log error
-                $this->handleError($ch, $httpResponse);
+                $this->handleError($ch, $httpResponseCode);
 
-                if (($httpResponse >= 500 && $httpResponse <= 600) || 429 == $httpResponse) {
+                if (($httpResponseCode >= 500 && $httpResponseCode <= 600) || 429 == $httpResponseCode) {
                     // If status code is greater than 500 and less than 600, it indicates server error
                     // Error code 429 indicates rate limited.
                     // Retry uploading in these cases.
                     usleep($backoff * 1000);
                     $backoff *= 2;
-                } elseif ($httpResponse >= 400) {
+                } elseif ($httpResponseCode >= 400) {
                     break;
-                } elseif ($httpResponse == 0) {
+                } elseif ($httpResponseCode == 0) {
                     break;
                 }
             } else {
@@ -126,11 +140,11 @@ class LibCurl extends QueueConsumer
         return $httpResponse;
     }
 
-    public function executePost($ch)
+    public function executePost($ch): array
     {
-        curl_exec($ch);
-        $httpCode = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
-
-        return $httpCode;
+        return [
+            curl_exec($ch),
+            curl_getinfo($ch, CURLINFO_RESPONSE_CODE)
+        ];
     }
 }

--- a/lib/Consumer/LibCurl.php
+++ b/lib/Consumer/LibCurl.php
@@ -74,7 +74,8 @@ class LibCurl extends QueueConsumer
             '/batch/',
             $payload,
             [
-                "User-Agent: {$messages['library']}/{$messages['library_version']}",
+                // Send user agent in the form of {library_name}/{library_version} as per RFC 7231.
+                "User-Agent: {$messages[0]['library']}/{$messages[0]['library_version']}",
             ]
         )->getResponse();
     }

--- a/lib/Consumer/LibCurl.php
+++ b/lib/Consumer/LibCurl.php
@@ -27,7 +27,10 @@ class LibCurl extends QueueConsumer
         $this->httpClient = new HttpClient(
             $this->host,
             $this->ssl(),
-            $this->maximum_backoff_duration
+            $this->maximum_backoff_duration,
+            $this->compress_request,
+            $this->debug(),
+            $this->options['error_handler'] ?? null
         );
     }
 
@@ -73,20 +76,6 @@ class LibCurl extends QueueConsumer
             [
                 "User-Agent: {$messages['library']}/{$messages['library_version']}",
             ]
-        );
-    }
-
-    public function decide(string $distinctId)
-    {
-        $payload = json_encode([
-            'api_key' => $this->apiKey,
-            'distinct_id' => $distinctId,
-        ]);
-
-        if ($this->compress_request) {
-            $payload = gzencode($payload);
-        }
-
-        return $this->httpClient->sendRequest('/decide/', $payload);
+        )->getResponse();
     }
 }

--- a/lib/Consumer/LibCurl.php
+++ b/lib/Consumer/LibCurl.php
@@ -89,7 +89,6 @@ class LibCurl extends QueueConsumer
     public function sendRequest(string $path, string $payload, array $extraHeaders = [])
     {
         $protocol = $this->ssl() ? "https://" : "http://";
-        $host = $this->host ?? "t.posthog.com";
 
         $backoff = 100;     // Set initial waiting time to 100ms
 
@@ -108,7 +107,7 @@ class LibCurl extends QueueConsumer
             }
 
             curl_setopt($ch, CURLOPT_HTTPHEADER, array_merge($headers, $extraHeaders));
-            curl_setopt($ch, CURLOPT_URL, $protocol . $host . $path);
+            curl_setopt($ch, CURLOPT_URL, $protocol . $this->host . $path);
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 
             // retry failed requests just once to diminish impact on performance

--- a/lib/Consumer/Socket.php
+++ b/lib/Consumer/Socket.php
@@ -24,10 +24,6 @@ class Socket extends QueueConsumer
             $options["timeout"] = 5;
         }
 
-        if (!isset($options["host"])) {
-            $options["host"] = "t.posthog.com";
-        }
-
         parent::__construct($apiKey, $options);
     }
 
@@ -52,7 +48,7 @@ class Socket extends QueueConsumer
         $payload = $this->payload($batch);
         $payload = json_encode($payload);
 
-        $body = $this->createBody($this->options["host"], $payload);
+        $body = $this->createBody($this->host, $payload);
         if (false === $body) {
             return false;
         }
@@ -67,7 +63,6 @@ class Socket extends QueueConsumer
         }
 
         $protocol = $this->ssl() ? "ssl" : "tcp";
-        $host = $this->options["host"];
         $port = $this->ssl() ? 443 : 80;
         $timeout = $this->options["timeout"];
 
@@ -75,7 +70,7 @@ class Socket extends QueueConsumer
             // Open our socket to the API Server.
             // Since we're try catch'ing prevent PHP logs.
             $socket = @pfsockopen(
-                $protocol . "://" . $host,
+                $protocol . "://" . $this->host,
                 $port,
                 $errno,
                 $errstr,

--- a/lib/HttpClient.php
+++ b/lib/HttpClient.php
@@ -57,7 +57,7 @@ class HttpClient
      * @param array $extraHeaders
      * @return HttpResponse
      */
-    public function sendRequest(string $path, ?string $payload, array $extraHeaders = [])
+    public function sendRequest(string $path, ?string $payload, array $extraHeaders = []): HttpResponse
     {
         $protocol = $this->useSsl ? "https://" : "http://";
 

--- a/lib/HttpClient.php
+++ b/lib/HttpClient.php
@@ -55,9 +55,9 @@ class HttpClient
      * @param string $path
      * @param string|null $payload
      * @param array $extraHeaders
-     * @return mixed
+     * @return HttpResponse
      */
-    public function sendRequest(string $path, string $payload, array $extraHeaders = [])
+    public function sendRequest(string $path, ?string $payload, array $extraHeaders = [])
     {
         $protocol = $this->useSsl ? "https://" : "http://";
 
@@ -67,9 +67,9 @@ class HttpClient
             // open connection
             $ch = curl_init();
 
-
-            curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
-
+            if (null !== $payload) {
+                curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
+            }
 
             $headers = [];
             $headers[] = 'Content-Type: application/json';

--- a/lib/HttpClient.php
+++ b/lib/HttpClient.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace PostHog;
+
+class HttpClient
+{
+    /**
+     * @var string
+     */
+    private $host;
+
+    /**
+     * @var bool
+     */
+    private $useSsl;
+    /**
+     * @var int
+     */
+    private $maximumBackoffDuration;
+
+    public function __construct(string $host, bool $useSsl = true, int $maximumBackoffDuration = 10000)
+    {
+        $this->host = $host;
+        $this->useSsl = $useSsl;
+        $this->maximumBackoffDuration = $maximumBackoffDuration;
+    }
+
+    /**
+     * @param string $path
+     * @param string|null $payload
+     * @param array $extraHeaders
+     * @return mixed
+     */
+    public function sendRequest(string $path, string $payload, array $extraHeaders = [])
+    {
+        $protocol = $this->useSsl ? "https://" : "http://";
+
+        $backoff = 100;     // Set initial waiting time to 100ms
+
+        while ($backoff < $this->maximumBackoffDuration) {
+            // open connection
+            $ch = curl_init();
+
+
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
+
+
+            $headers = [];
+            $headers[] = 'Content-Type: application/json';
+            if ($this->compress_request) {
+                $headers[] = 'Content-Encoding: gzip';
+            }
+
+            curl_setopt($ch, CURLOPT_HTTPHEADER, array_merge($headers, $extraHeaders));
+            curl_setopt($ch, CURLOPT_URL, $protocol . $this->host . $path);
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+
+            // retry failed requests just once to diminish impact on performance
+            [$httpResponse, $httpResponseCode] = $this->executePost($ch);
+
+            //close connection
+            curl_close($ch);
+
+            if (200 != $httpResponseCode) {
+                // log error
+                $this->handleError($ch, $httpResponseCode);
+
+                if (($httpResponseCode >= 500 && $httpResponseCode <= 600) || 429 == $httpResponseCode) {
+                    // If status code is greater than 500 and less than 600, it indicates server error
+                    // Error code 429 indicates rate limited.
+                    // Retry uploading in these cases.
+                    usleep($backoff * 1000);
+                    $backoff *= 2;
+                } elseif ($httpResponseCode >= 400) {
+                    break;
+                } elseif ($httpResponseCode == 0) {
+                    break;
+                }
+            } else {
+                break;  // no error
+            }
+        }
+
+        return $httpResponse;
+    }
+
+    private function executePost($ch): array
+    {
+        return [
+            curl_exec($ch),
+            curl_getinfo($ch, CURLINFO_RESPONSE_CODE)
+        ];
+    }
+}

--- a/lib/HttpResponse.php
+++ b/lib/HttpResponse.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace PostHog;
+
+class HttpResponse
+{
+    private $response;
+    private $responseCode;
+
+    public function __construct($response, $responseCode)
+    {
+        $this->response = $response;
+        $this->responseCode = $responseCode;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getResponseCode()
+    {
+        return $this->responseCode;
+    }
+}

--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -12,14 +12,19 @@ class PostHog
 
     /**
      * Initializes the default client to use. Uses the libcurl consumer by default.
-     * @param string $apiKey your project's API key
-     * @param array $options passed straight to the client
+     * @param string|null $apiKey your project's API key
+     * @param array|null $options passed straight to the client
+     * @param Client|null $client
      * @throws Exception
      */
-    public static function init(string $apiKey, array $options = [])
+    public static function init(?string $apiKey, ?array $options = [], ?Client $client = null)
     {
-        self::assert($apiKey, "PostHog::init() requires an apiKey");
-        self::$client = new Client($apiKey, $options);
+        if (null === $client) {
+            self::assert($apiKey, "PostHog::init() requires an apiKey");
+            self::$client = new Client($apiKey, $options);
+        } else {
+            self::$client = $client;
+        }
     }
 
     /**

--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -65,10 +65,10 @@ class PostHog
      * @return boolean whether the identify call succeeded
      * @throws Exception
      */
-    public static function decide(string $key, string $distinctId, $default = false): bool
+    public static function isFeatureEnabled(string $key, string $distinctId, $default = false): bool
     {
         self::checkClient();
-        return self::$client->decide($key, $distinctId, $default);
+        return self::$client->isFeatureEnabled($key, $distinctId, $default);
     }
 
     /**
@@ -77,10 +77,10 @@ class PostHog
      * @return array
      * @throws Exception
      */
-    public static function fetchAllowedFeatureFlags(string $distinctId): array
+    public static function fetchEnabledFeatureFlags(string $distinctId): array
     {
         self::checkClient();
-        return self::$client->fetchAllowedFeatureFlags($distinctId);
+        return self::$client->fetchEnabledFeatureFlags($distinctId);
     }
 
     /**

--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -16,7 +16,7 @@ class PostHog
      * @param array $options passed straight to the client
      * @throws Exception
      */
-    public static function init($apiKey, $options = array())
+    public static function init(string $apiKey, array $options = [])
     {
         self::assert($apiKey, "PostHog::init() requires an apiKey");
         self::$client = new Client($apiKey, $options);
@@ -53,6 +53,34 @@ class PostHog
         self::validate($message, "identify");
 
         return self::$client->identify($message);
+    }
+
+
+    /**
+     * decide if the feature flag is enabled for this distinct id.
+     *
+     * @param string $key
+     * @param string $distinctId
+     * @param mixed $default
+     * @return boolean whether the identify call succeeded
+     * @throws Exception
+     */
+    public static function decide(string $key, string $distinctId, $default = false): bool
+    {
+        self::checkClient();
+        return self::$client->decide($key, $distinctId, $default);
+    }
+
+    /**
+     *
+     * @param string $distinctId
+     * @return array
+     * @throws Exception
+     */
+    public static function fetchAllowedFeatureFlags(string $distinctId): array
+    {
+        self::checkClient();
+        return self::$client->fetchAllowedFeatureFlags($distinctId);
     }
 
     /**

--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -152,7 +152,6 @@ class PostHog
      */
     private static function overrideConfigWithEnv(?string $apiKey, array $options): array
     {
-        // Check the env vars to see if the API key is set, if not, default to the parameter passed to init()
         $apiKey = $apiKey ?: getenv(self::ENV_API_KEY);
 
         // Check the env vars to see if the host is set, and override the options if it is

--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -153,7 +153,7 @@ class PostHog
     private static function overrideConfigWithEnv(?string $apiKey, array $options): array
     {
         // Check the env vars to see if the API key is set, if not, default to the parameter passed to init()
-        $apiKey = getenv(self::ENV_API_KEY) ?: $apiKey;
+        $apiKey = $apiKey ?: getenv(self::ENV_API_KEY);
 
         // Check the env vars to see if the host is set, and override the options if it is
         $envHost = getenv(self::ENV_HOST) ?: null;

--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -71,7 +71,7 @@ class PostHog
      * @param string $key
      * @param string $distinctId
      * @param mixed $default
-     * @return boolean whether the identify call succeeded
+     * @return boolean
      * @throws Exception
      */
     public static function isFeatureEnabled(string $key, string $distinctId, $default = false): bool

--- a/lib/QueueConsumer.php
+++ b/lib/QueueConsumer.php
@@ -10,7 +10,7 @@ abstract class QueueConsumer extends Consumer
     protected $max_queue_size = 1000;
     protected $batch_size = 100;
     protected $maximum_backoff_duration = 10000;    // Set maximum waiting limit to 10s
-    protected $host = "t.posthog.com";
+    protected $host = "app.posthog.com";
     protected $compress_request = false;
 
     /**

--- a/test/ConsumerLibCurlTest.php
+++ b/test/ConsumerLibCurlTest.php
@@ -14,10 +14,11 @@ class ConsumerLibCurlTest extends TestCase
         date_default_timezone_set("UTC");
         $this->client = new Client(
             "BrpS4SctoaCCsyjlnlun3OzyNJAafdlv__jUWaaJWXg",
-            array(
+            [
                 "consumer" => "lib_curl",
                 "debug" => true,
-            )
+                "personal_api_key" => 'my very secret key',
+            ]
         );
     }
 
@@ -61,13 +62,13 @@ class ConsumerLibCurlTest extends TestCase
         );
     }
 
-    public function testFetchAllowedFeatureFlags()
+    public function testFetchEnabledFeatureFlags()
     {
-        $this->assertIsArray($this->client->fetchAllowedFeatureFlags('user-id'));
+        $this->assertIsArray($this->client->fetchEnabledFeatureFlags('user-id'));
     }
 
-    public function testDecide()
+    public function testIsFeatureEnabled()
     {
-        $this->assertFalse($this->client->decide('having_fun', 'user-id'));
+        $this->assertFalse($this->client->isFeatureEnabled('having_fun', 'user-id'));
     }
 }

--- a/test/ConsumerLibCurlTest.php
+++ b/test/ConsumerLibCurlTest.php
@@ -61,7 +61,6 @@ class ConsumerLibCurlTest extends TestCase
         );
     }
 
-
     public function testFetchAllowedFeatureFlags()
     {
         $this->assertIsArray($this->client->fetchAllowedFeatureFlags('user-id'));

--- a/test/ConsumerLibCurlTest.php
+++ b/test/ConsumerLibCurlTest.php
@@ -60,4 +60,15 @@ class ConsumerLibCurlTest extends TestCase
             )
         );
     }
+
+
+    public function testFetchAllowedFeatureFlags()
+    {
+        $this->assertIsArray($this->client->fetchAllowedFeatureFlags('user-id'));
+    }
+
+    public function testDecide()
+    {
+        $this->assertFalse($this->client->decide('having_fun', 'user-id'));
+    }
 }

--- a/test/ConsumerLibCurlTest.php
+++ b/test/ConsumerLibCurlTest.php
@@ -17,7 +17,6 @@ class ConsumerLibCurlTest extends TestCase
             [
                 "consumer" => "lib_curl",
                 "debug" => true,
-                "personal_api_key" => 'my very secret key',
             ]
         );
     }
@@ -60,15 +59,5 @@ class ConsumerLibCurlTest extends TestCase
                 )
             )
         );
-    }
-
-    public function testFetchEnabledFeatureFlags()
-    {
-        $this->assertIsArray($this->client->fetchEnabledFeatureFlags('user-id'));
-    }
-
-    public function testIsFeatureEnabled()
-    {
-        $this->assertFalse($this->client->isFeatureEnabled('having_fun', 'user-id'));
     }
 }

--- a/test/MockedHttpClient.php
+++ b/test/MockedHttpClient.php
@@ -7,22 +7,8 @@ use PostHog\Test\Assets\MockedResponses;
 
 class MockedHttpClient extends \PostHog\HttpClient
 {
-    private const ENDPOINTS_TO_MOCK = [
-        '/api/feature_flag'
-    ];
-
-    private const ENDPOINT_MOCKED_RESPONSE_MAPPING = [
-        '/api/feature_flag' => MockedResponses::SIMPLE_FLAG_EXAMPLE_REQUEST
-    ];
-
     public function sendRequest(string $path, ?string $payload, array $extraHeaders = []): HttpResponse
     {
-        if (in_array($path, self::ENDPOINTS_TO_MOCK)) {
-            return new HttpResponse(
-                json_encode(self::ENDPOINT_MOCKED_RESPONSE_MAPPING[$path]),
-                200
-            );
-        }
         return parent::sendRequest($path, $payload, $extraHeaders);
     }
 }

--- a/test/MockedHttpClient.php
+++ b/test/MockedHttpClient.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace PostHog\Test;
+
+use PostHog\HttpResponse;
+use PostHog\Test\Assets\MockedResponses;
+
+class MockedHttpClient extends \PostHog\HttpClient
+{
+    private const ENDPOINTS_TO_MOCK = [
+        '/api/feature_flag'
+    ];
+
+    private const ENDPOINT_MOCKED_RESPONSE_MAPPING = [
+        '/api/feature_flag' => MockedResponses::SIMPLE_FLAG_EXAMPLE_REQUEST
+    ];
+
+    public function sendRequest(string $path, ?string $payload, array $extraHeaders = []): HttpResponse
+    {
+        if (in_array($path, self::ENDPOINTS_TO_MOCK)) {
+            return new HttpResponse(
+                json_encode(self::ENDPOINT_MOCKED_RESPONSE_MAPPING[$path]),
+                200
+            );
+        }
+        return parent::sendRequest($path, $payload, $extraHeaders);
+    }
+}

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -15,8 +15,7 @@ class PostHogTest extends TestCase
         $client = new Client(
             "BrpS4SctoaCCsyjlnlun3OzyNJAafdlv__jUWaaJWXg",
             [
-                "debug" => true,
-                "personal_api_key" => 'my very secret key',
+                "debug" => true
             ],
             new MockedHttpClient("app.posthog.com")
         );
@@ -76,11 +75,6 @@ class PostHogTest extends TestCase
     public function testIsFeatureEnabled()
     {
         $this->assertFalse(PostHog::isFeatureEnabled('having_fun', 'user-id'));
-    }
-
-    public function testIsFeatureEnabledWithSimpleFlag()
-    {
-        $this->assertTrue(PostHog::isFeatureEnabled('simpleFlag', 'user-id'));
     }
 
     public function testFetchEnabledFeatureFlags()

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -78,6 +78,11 @@ class PostHogTest extends TestCase
         $this->assertFalse(PostHog::isFeatureEnabled('having_fun', 'user-id'));
     }
 
+    public function testIsFeatureEnabledWithSimpleFlag()
+    {
+        $this->assertTrue(PostHog::isFeatureEnabled('simpleFlag', 'user-id'));
+    }
+
     public function testFetchEnabledFeatureFlags()
     {
         $this->assertIsArray(PostHog::fetchEnabledFeatureFlags('user-id'));

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -3,6 +3,7 @@
 namespace PostHog\Test;
 
 use PHPUnit\Framework\TestCase;
+use PostHog\Client;
 use PostHog\PostHog;
 
 class PostHogTest extends TestCase
@@ -10,10 +11,15 @@ class PostHogTest extends TestCase
     public function setUp(): void
     {
         date_default_timezone_set("UTC");
-        PostHog::init("BrpS4SctoaCCsyjlnlun3OzyNJAafdlv__jUWaaJWXg", [
+        $client = new Client(
+            "BrpS4SctoaCCsyjlnlun3OzyNJAafdlv__jUWaaJWXg",
+            [
                 "debug" => true,
                 "personal_api_key" => 'my very secret key',
-            ]);
+            ],
+            new MockedHttpClient("app.posthog.com")
+        );
+        PostHog::init(null, null, $client);
     }
 
     public function testCapture(): void

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -40,6 +40,16 @@ class PostHogTest extends TestCase
         );
     }
 
+    public function testDecide()
+    {
+        $this->assertFalse(PostHog::decide('having_fun', 'user-id'));
+    }
+
+    public function testFetchAllowedFeatureFlags()
+    {
+        $this->assertIsArray(PostHog::fetchAllowedFeatureFlags('user-id'));
+    }
+
     public function testEmptyProperties(): void
     {
         self::assertTrue(

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -10,7 +10,10 @@ class PostHogTest extends TestCase
     public function setUp(): void
     {
         date_default_timezone_set("UTC");
-        PostHog::init("BrpS4SctoaCCsyjlnlun3OzyNJAafdlv__jUWaaJWXg", array("debug" => true));
+        PostHog::init("BrpS4SctoaCCsyjlnlun3OzyNJAafdlv__jUWaaJWXg", [
+                "debug" => true,
+                "personal_api_key" => 'my very secret key',
+            ]);
     }
 
     public function testCapture(): void
@@ -40,14 +43,14 @@ class PostHogTest extends TestCase
         );
     }
 
-    public function testDecide()
+    public function testIsFeatureEnabled()
     {
-        $this->assertFalse(PostHog::decide('having_fun', 'user-id'));
+        $this->assertFalse(PostHog::isFeatureEnabled('having_fun', 'user-id'));
     }
 
-    public function testFetchAllowedFeatureFlags()
+    public function testFetchEnabledFeatureFlags()
     {
-        $this->assertIsArray(PostHog::fetchAllowedFeatureFlags('user-id'));
+        $this->assertIsArray(PostHog::fetchEnabledFeatureFlags('user-id'));
     }
 
     public function testEmptyProperties(): void

--- a/test/assests/MockedResponses.php
+++ b/test/assests/MockedResponses.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace PostHog\Test\Assets;
+
+class MockedResponses
+{
+    public const SIMPLE_FLAG_EXAMPLE_REQUEST = [
+        "count" => 1,
+        "next" => null,
+        "previous" => null,
+        "results" => [
+            [
+                "id" => 719,
+                "name" => "",
+                "key" => "simpleFlag",
+                "filters" => [
+                    "groups" => [
+                        [
+                            "properties" => [],
+                            "rollout_percentage" => null
+                        ]
+                    ]
+                ],
+                "deleted" => false,
+                "active" => true,
+                "is_simple_flag" => true,
+                "rollout_percentage" => null
+            ],
+            [
+                "id" => 720,
+                "name" => "",
+                "key" => "enabled-flag",
+                "filters" => [
+                    "groups" => [
+                        [
+                            "properties" => [],
+                            "rollout_percentage" => null
+                        ]
+                    ]
+                ],
+                "deleted" => false,
+                "active" => true,
+                "is_simple_flag" => false,
+                "rollout_percentage" => null
+            ],
+            [
+                "id" => 721,
+                "name" => "",
+                "key" => "disabled-flag",
+                "filters" => [
+                    "groups" => [
+                        [
+                            "properties" => [],
+                            "rollout_percentage" => null
+                        ]
+                    ]
+                ],
+                "deleted" => false,
+                "active" => true,
+                "is_simple_flag" => false,
+                "rollout_percentage" => null
+            ],
+        ]
+    ];
+}


### PR DESCRIPTION
This supersedes #12 because @imhmdb is recovering from surgery (get better!) so I took over the PR and it doesn't allow edits by maintainers.

@imhmdb you will still get a gift card from us for this contribution. 

@posthog-bot please add @imhmdb for code. 

This simplifies the entire approach in #12. I sent @imhmdb in circles by sharing our feature flags spec without realizing PHP can't really do concurrent/parallel processing, making it so that we can't have the poller and leverage `is_simple_flag`. Therefore, this is a pretty simple implementation that just calls decide synchronously and checks the result that way each time.
