### PR TITLE
Send user agent with decide request (prevent 403)

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -125,7 +125,7 @@ class Client
     }
 
 
-    /** 
+    /**
      * @param string $distinctId
      * @return array
      * @throws Exception
@@ -142,7 +142,14 @@ class Client
             'distinct_id' => $distinctId,
         ]);
 
-        return $this->httpClient->sendRequest('/decide/', $payload)->getResponse();
+        return $this->httpClient->sendRequest(
+            '/decide/',
+            $payload,
+            [
+                // Send user agent in the form of {library_name}/{library_version} as per RFC 7231.
+                "User-Agent: posthog-php/" . PostHog::VERSION,
+            ]
+        )->getResponse();
     }
 
     /**


### PR DESCRIPTION
To test:

With user-agent:

```
curl 'https://app.posthog.com' \
-d '{"api_key":"<KEY>","distinct_id":"<ID>"}' \
-H 'content-type: application/json' \
-H 'user-agent: posthog-php/2.0.5'
```

Without user-agent:

```
curl 'https://app.posthog.com' \
-d '{"api_key":"<KEY>","distinct_id":"<ID>"}' \
-H 'content-type: application/json'
```