### PR TITLE
Set the timeout config for HttpClient curl

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,4 +1,10 @@
 
+2.0.6 / 2021-10-05
+==================
+
+  * Separate timeout from maxBackoffDuration
+  * Set the timeout config for HttpClient curl
+
 2.0.5 / 2021-07-13
 ==================
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "posthog/posthog-php",
-	"version": "2.0.5",
+	"version": "2.0.6",
 	"description": "PostHog PHP Library",
 	"keywords": [
 		"posthog"

--- a/lib/HttpClient.php
+++ b/lib/HttpClient.php
@@ -80,6 +80,8 @@ class HttpClient
             curl_setopt($ch, CURLOPT_HTTPHEADER, array_merge($headers, $extraHeaders));
             curl_setopt($ch, CURLOPT_URL, $protocol . $this->host . $path);
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($ch, CURLOPT_TIMEOUT_MS, $this->maximumBackoffDuration);
+            curl_setopt($ch, CURLOPT_CONNECTTIMEOUT_MS, $this->maximumBackoffDuration);
 
             // retry failed requests just once to diminish impact on performance
             $httpResponse = $this->executePost($ch);

--- a/lib/HttpClient.php
+++ b/lib/HttpClient.php
@@ -35,13 +35,19 @@ class HttpClient
      */
     private $debug;
 
+    /**
+     * @var int The maximum number of milliseconds to allow cURL functions to execute / wait.
+     */
+    private $curlTimeoutMilliseconds;
+
     public function __construct(
         string $host,
         bool $useSsl = true,
         int $maximumBackoffDuration = 10000,
         bool $compressRequests = false,
         bool $debug = false,
-        ?Closure $errorHandler = null
+        ?Closure $errorHandler = null,
+        int $curlTimeoutMilliseconds = 10000
     ) {
         $this->host = $host;
         $this->useSsl = $useSsl;
@@ -49,6 +55,7 @@ class HttpClient
         $this->compressRequests = $compressRequests;
         $this->debug = $debug;
         $this->errorHandler = $errorHandler;
+        $this->curlTimeoutMilliseconds = $curlTimeoutMilliseconds;
     }
 
     /**
@@ -80,8 +87,8 @@ class HttpClient
             curl_setopt($ch, CURLOPT_HTTPHEADER, array_merge($headers, $extraHeaders));
             curl_setopt($ch, CURLOPT_URL, $protocol . $this->host . $path);
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-            curl_setopt($ch, CURLOPT_TIMEOUT_MS, $this->maximumBackoffDuration);
-            curl_setopt($ch, CURLOPT_CONNECTTIMEOUT_MS, $this->maximumBackoffDuration);
+            curl_setopt($ch, CURLOPT_TIMEOUT_MS, $this->curlTimeoutMilliseconds);
+            curl_setopt($ch, CURLOPT_CONNECTTIMEOUT_MS, $this->curlTimeoutMilliseconds);
 
             // retry failed requests just once to diminish impact on performance
             $httpResponse = $this->executePost($ch);

--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -6,7 +6,7 @@ use Exception;
 
 class PostHog
 {
-    public const VERSION = '2.0.5';
+    public const VERSION = '2.0.6';
     public const ENV_API_KEY = "POSTHOG_API_KEY";
     public const ENV_HOST = "POSTHOG_HOST";
 


### PR DESCRIPTION
Currently the `$maximumBackoffDuration` is only used to retry failed requests (those that are not 200) - this means hanging requests can block the PHP request for minutes (depending on the OS, `curl` default timeout ranges between 2-5 minutes). 

This adds a setting (`$curlTimeoutMilliseconds`) to define a maximum amount of time to wait for connection / timeout. This is currently defaults to `10000ms` in your lib, but we want to lower that to `750ms`