### PR TITLE
Group analytics: Feature flag support

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -121,7 +121,10 @@ class Client
             "event" => '$feature_flag_called',
         ]);
 
-        return $result ??  $defaultValue;
+        if ($result) {
+            return true;
+        }
+        return $defaultValue;
     }
 
 

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -103,12 +103,17 @@ class Client
      * @param string $key
      * @param string $distinctId
      * @param mixed $defaultValue
+     * @param array $groups
      * @return bool
      * @throws Exception
      */
-    public function isFeatureEnabled(string $key, string $distinctId, $defaultValue = false): bool
-    {
-        $flags = $this->fetchEnabledFeatureFlags($distinctId);
+    public function isFeatureEnabled(
+        string $key,
+        string $distinctId,
+        $defaultValue = false,
+        array $groups = array()
+    ): bool {
+        $flags = $this->fetchEnabledFeatureFlags($distinctId, $groups);
 
         $result = in_array($key, $flags);
 
@@ -130,24 +135,29 @@ class Client
 
     /**
      * @param string $distinctId
-     * @return array
+     * @param array $groups
+     * @return array of enabled feature flags
      * @throws Exception
      */
-    public function fetchEnabledFeatureFlags(string $distinctId): array
+    public function fetchEnabledFeatureFlags(string $distinctId, array $groups = array()): array
     {
-        return json_decode($this->decide($distinctId), true)['featureFlags'] ?? [];
+        return json_decode($this->decide($distinctId, $groups), true)['featureFlags'] ?? [];
     }
 
-    public function decide(string $distinctId)
+    public function decide(string $distinctId, array $groups = array())
     {
-        $payload = json_encode([
+        $payload = array(
             'api_key' => $this->apiKey,
             'distinct_id' => $distinctId,
-        ]);
+        );
+
+        if (!empty($groups)) {
+            $payload["groups"] = $groups;
+        }
 
         return $this->httpClient->sendRequest(
             '/decide/',
-            $payload,
+            json_encode($payload),
             [
                 // Send user agent in the form of {library_name}/{library_version} as per RFC 7231.
                 "User-Agent: posthog-php/" . PostHog::VERSION,

--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -112,10 +112,14 @@ class PostHog
      * @return boolean
      * @throws Exception
      */
-    public static function isFeatureEnabled(string $key, string $distinctId, $default = false): bool
-    {
+    public static function isFeatureEnabled(
+        string $key,
+        string $distinctId,
+        $default = false,
+        array $groups = array()
+    ): bool {
         self::checkClient();
-        return self::$client->isFeatureEnabled($key, $distinctId, $default);
+        return self::$client->isFeatureEnabled($key, $distinctId, $default, $groups);
     }
 
     /**
@@ -124,10 +128,10 @@ class PostHog
      * @return array
      * @throws Exception
      */
-    public static function fetchEnabledFeatureFlags(string $distinctId): array
+    public static function fetchEnabledFeatureFlags(string $distinctId, array $groups = array()): array
     {
         self::checkClient();
-        return self::$client->fetchEnabledFeatureFlags($distinctId);
+        return self::$client->fetchEnabledFeatureFlags($distinctId, $groups);
     }
 
     /**

--- a/test/MockedHttpClient.php
+++ b/test/MockedHttpClient.php
@@ -9,6 +9,11 @@ class MockedHttpClient extends \PostHog\HttpClient
 {
     public function sendRequest(string $path, ?string $payload, array $extraHeaders = []): HttpResponse
     {
+        if (!isset($this->calls)) {
+            $this->calls = array();
+        }
+        array_push($this->calls, array("path" => $path, "payload" => $payload));
+
         return parent::sendRequest($path, $payload, $extraHeaders);
     }
 }

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -6,20 +6,22 @@ use Exception;
 use PHPUnit\Framework\TestCase;
 use PostHog\Client;
 use PostHog\PostHog;
+use PostHog\Test\Assets\MockedResponses;
 
 class PostHogTest extends TestCase
 {
     public function setUp(): void
     {
         date_default_timezone_set("UTC");
-        $client = new Client(
-            "BrpS4SctoaCCsyjlnlun3OzyNJAafdlv__jUWaaJWXg",
+        $this->http_client = new MockedHttpClient("app.posthog.com");
+        $this->client = new Client(
+            "test-key",
             [
                 "debug" => true
             ],
-            new MockedHttpClient("app.posthog.com")
+            $this->http_client
         );
-        PostHog::init(null, null, $client);
+        PostHog::init(null, null, $this->client);
     }
 
     public function testInitWithParamApiKey(): void
@@ -32,7 +34,7 @@ class PostHogTest extends TestCase
     {
         $this->expectNotToPerformAssertions();
         putenv(PostHog::ENV_API_KEY . "=BrpS4SctoaCCsyjlnlun3OzyNJAafdlv__jUWaaJWXg");
-        PostHog::init(null, array("degug" => true));
+        PostHog::init(null, array("debug" => true));
 
         // Clear the environment variable
         putenv(PostHog::ENV_API_KEY);
@@ -75,11 +77,35 @@ class PostHogTest extends TestCase
     public function testIsFeatureEnabled()
     {
         $this->assertFalse(PostHog::isFeatureEnabled('having_fun', 'user-id'));
+        $this->assertEquals(
+            $this->http_client->calls,
+            array(
+                0 => array(
+                    "path" => "/decide/",
+                    "payload" => '{"api_key":"test-key","distinct_id":"user-id"}',
+                )
+            )
+        );
     }
 
     public function testIsFeatureEnabledDefault()
     {
-        $this->assertTrue(PostHog::isFeatureEnabled('having_fun', 'user-id', 77));
+        $this->assertTrue(PostHog::isFeatureEnabled('having_fun', 'user-id', true));
+    }
+
+    public function testIsFeatureEnabledGroups()
+    {
+        $this->assertFalse(PostHog::isFeatureEnabled('having_fun', 'user-id', false, array("company" => "id:5")));
+
+        $this->assertEquals(
+            $this->http_client->calls,
+            array(
+                0 => array(
+                    "path" => "/decide/",
+                    "payload" => '{"api_key":"test-key","distinct_id":"user-id","groups":{"company":"id:5"}}',
+                )
+            )
+        );
     }
 
     public function testFetchEnabledFeatureFlags()

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -77,6 +77,11 @@ class PostHogTest extends TestCase
         $this->assertFalse(PostHog::isFeatureEnabled('having_fun', 'user-id'));
     }
 
+    public function testIsFeatureEnabledDefault()
+    {
+        $this->assertTrue(PostHog::isFeatureEnabled('having_fun', 'user-id', 77));
+    }
+
     public function testFetchEnabledFeatureFlags()
     {
         $this->assertIsArray(PostHog::fetchEnabledFeatureFlags('user-id'));


### PR DESCRIPTION
Part of PostHog/posthog#7010

On the API side we only need to pass forward the "groups" argument.

Also fixes issue with default argument not working well.