### PR TITLE
Allow to configure the HttpClient maximumBackoffDuration

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -53,7 +53,7 @@ class Client
         $this->httpClient = $httpClient !== null ? $httpClient : new HttpClient(
             $options['host'] ?? "app.posthog.com",
             $options['ssl'] ?? true,
-            10000,
+            (int) ($options['maximum_backoff_duration'] ?? 10000),
             false,
             $options["debug"] ?? false
         );

--- a/lib/HttpClient.php
+++ b/lib/HttpClient.php
@@ -68,9 +68,9 @@ class HttpClient
     {
         $protocol = $this->useSsl ? "https://" : "http://";
 
-        $backoff = 100;     // Set initial waiting time to 100ms
+        $backoff = 100; // Set initial waiting time to 100ms
 
-        while ($backoff < $this->maximumBackoffDuration) {
+        do {
             // open connection
             $ch = curl_init();
 
@@ -115,7 +115,7 @@ class HttpClient
             } else {
                 break;  // no error
             }
-        }
+        } while ($backoff < $this->maximumBackoffDuration);
 
         return $httpResponse;
     }

--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -6,7 +6,7 @@ use Exception;
 
 class PostHog
 {
-    public const VERSION = '2.1.0';
+    public const VERSION = '2.1.1';
     public const ENV_API_KEY = "POSTHOG_API_KEY";
     public const ENV_HOST = "POSTHOG_HOST";
 

--- a/lib/QueueConsumer.php
+++ b/lib/QueueConsumer.php
@@ -30,6 +30,10 @@ abstract class QueueConsumer extends Consumer
             $this->batch_size = $options["batch_size"];
         }
 
+        if (isset($options["maximum_backoff_duration"])) {
+            $this->maximum_backoff_duration = (int) $options["maximum_backoff_duration"];
+        }
+
         if (isset($options["host"])) {
             $this->host = $options["host"];
 


### PR DESCRIPTION
Hi there,

I work with @allan-simon, who reported [this issue](https://github.com/PostHog/posthog-php/issues/32), and reducing the timeout is a bit useless if there's a retry mechanism we can't configure.

Our integration is sync so we can't afford blocking 17s+ for a retry that will most likely fail anyway.

The do/while is for when I want to set `maximum_backoff_duration` to `0`, so it could at least try once.