### PR TITLE
Remove default arg from feature flag functions

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,4 +1,14 @@
 
+3.0.0 / 2022-08-12
+==================
+  * Requires posthog 1.38
+  * Local Evaluation: isFeatureEnabled and getFeatureFlag accept group and person properties now which will evaluate relevant flags locally.
+  * isFeatureEnabled and getFeatureFlag also have new parameters:
+    onlyEvaluateLocally (bool) - turns on and off local evaluation
+    sendFeatureFlagEvents (bool) - turns on and off $feature_flag_called events
+  * Removes default parametere from isFeatureEnabled and getFeatureFlag. Returns null instead
+
+
 2.1.1 / 2022-01-21
 ==================
 

--- a/History.md
+++ b/History.md
@@ -1,14 +1,3 @@
-
-3.0.0 / 2022-08-12
-==================
-  * Requires posthog 1.38
-  * Local Evaluation: isFeatureEnabled and getFeatureFlag accept group and person properties now which will evaluate relevant flags locally.
-  * isFeatureEnabled and getFeatureFlag also have new parameters:
-    onlyEvaluateLocally (bool) - turns on and off local evaluation
-    sendFeatureFlagEvents (bool) - turns on and off $feature_flag_called events
-  * Removes default parametere from isFeatureEnabled and getFeatureFlag. Returns null instead
-
-
 2.1.1 / 2022-01-21
 ==================
 

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -139,7 +139,6 @@ class Client
      *
      * @param string $key
      * @param string $distinctId
-     * @param mixed $defaultValue
      * @param array $groups
      * @param array $personProperties
      * @param array $groupProperties
@@ -149,14 +148,13 @@ class Client
     public function isFeatureEnabled(
         string $key,
         string $distinctId,
-        $defaultValue = false,
         array $groups = array(),
         array $personProperties = array(),
         array $groupProperties = array(),
         bool $onlyEvaluateLocally = false,
         bool $sendFeatureFlagEvents = true
     ): bool {
-        return boolval($this->getFeatureFlag($key, $distinctId, $defaultValue, $groups, $personProperties, $groupProperties, $onlyEvaluateLocally, $sendFeatureFlagEvents));
+        return boolval($this->getFeatureFlag($key, $distinctId, $groups, $personProperties, $groupProperties, $onlyEvaluateLocally, $sendFeatureFlagEvents));
     }
 
     /**
@@ -164,7 +162,6 @@ class Client
      *
      * @param string $key
      * @param string $distinctId
-     * @param mixed $defaultValue
      * @param array $groups
      * @param array $personProperties
      * @param array $groupProperties
@@ -174,13 +171,12 @@ class Client
     public function getFeatureFlag(
         string $key,
         string $distinctId,
-        bool $defaultValue = false,
         array $groups = array(),
         array $personProperties = array(),
         array $groupProperties = array(),
         bool $onlyEvaluateLocally = false,
         bool $sendFeatureFlagEvents = true
-    ): bool | string {
+    ): null | bool | string {
         $result = null;
 
         foreach ($this->featureFlags as $flag) {
@@ -207,10 +203,10 @@ class Client
         if (!$flagWasEvaluatedLocally && !$onlyEvaluateLocally) {
             try {
                 $featureFlags = $this->fetchFeatureVariants($distinctId, $groups, $personProperties, $groupProperties);
-                $result = $featureFlags[$key] ?? $defaultValue;
+                $result = $featureFlags[$key];
             } catch (Exception $e) {
                 error_log("[PostHog][Client] Unable to get feature variants:" . $e->getMessage());
-                $result = $defaultValue;
+                $result = null;
             }
         }
 
@@ -226,7 +222,7 @@ class Client
         if (!is_null($result)) {
             return $result;
         }
-        return $defaultValue;
+        return null;
     }
 
     /**

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -161,8 +161,14 @@ class Client
         array $groupProperties = array(),
         bool $onlyEvaluateLocally = false,
         bool $sendFeatureFlagEvents = true
-    ): bool {
-        return boolval($this->getFeatureFlag($key, $distinctId, $groups, $personProperties, $groupProperties, $onlyEvaluateLocally, $sendFeatureFlagEvents));
+    ): null | bool {
+        $result = $this->getFeatureFlag($key, $distinctId, $groups, $personProperties, $groupProperties, $onlyEvaluateLocally, $sendFeatureFlagEvents);
+
+        if (is_null($result)) {
+            return $result;
+        } else {
+            return boolval($result);
+        }
     }
 
     /**
@@ -226,6 +232,7 @@ class Client
                 ],
                 "distinct_id" => $distinctId,
                 "event" => '$feature_flag_called',
+                "groups" => $groups
             ]);
             $this->distinctIdsFeatureFlagsReported->add($key, $distinctId);
         }

--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -169,7 +169,7 @@ class PostHog
         bool $onlyEvaluateLocally = false
     ): array {
         self::checkClient();
-        return self::$client->GetAllFlags($distinctId, $groups, $personProperties, $groupProperties, $onlyEvaluateLocally);
+        return self::$client->getAllFlags($distinctId, $groups, $personProperties, $groupProperties, $onlyEvaluateLocally);
     }
 
 

--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -122,7 +122,7 @@ class PostHog
         array $groupProperties = array(),
         bool $onlyEvaluateLocally = false,
         bool $sendFeatureFlagEvents = true
-    ): bool {
+    ): null | bool {
         self::checkClient();
         return self::$client->isFeatureEnabled($key, $distinctId, $groups, $personProperties, $groupProperties, $onlyEvaluateLocally, $sendFeatureFlagEvents);
     }

--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -108,7 +108,6 @@ class PostHog
      *
      * @param string $key
      * @param string $distinctId
-     * @param mixed $default
      * @param array $groups
      * @param array $personProperties
      * @param array $groupProperties
@@ -118,7 +117,6 @@ class PostHog
     public static function isFeatureEnabled(
         string $key,
         string $distinctId,
-        bool $default = false,
         array $groups = array(),
         array $personProperties = array(),
         array $groupProperties = array(),
@@ -126,7 +124,7 @@ class PostHog
         bool $sendFeatureFlagEvents = true
     ): bool {
         self::checkClient();
-        return self::$client->isFeatureEnabled($key, $distinctId, $default, $groups, $personProperties, $groupProperties, $onlyEvaluateLocally, $sendFeatureFlagEvents);
+        return self::$client->isFeatureEnabled($key, $distinctId, $groups, $personProperties, $groupProperties, $onlyEvaluateLocally, $sendFeatureFlagEvents);
     }
 
     /**
@@ -134,7 +132,6 @@ class PostHog
      *
      * @param string $key
      * @param string $distinctId
-     * @param mixed $default
      * @param array $groups
      * @param array $personProperties
      * @param array $groupProperties
@@ -144,15 +141,14 @@ class PostHog
     public static function getFeatureFlag(
         string $key,
         string $distinctId,
-        bool $default = false,
         array $groups = array(),
         array $personProperties = array(),
         array $groupProperties = array(),
         bool $onlyEvaluateLocally = false,
         bool $sendFeatureFlagEvents = true
-    ): bool | string {
+    ): null | bool | string {
         self::checkClient();
-        return self::$client->GetFeatureFlag($key, $distinctId, $default, $groups, $personProperties, $groupProperties, $onlyEvaluateLocally, $sendFeatureFlagEvents);
+        return self::$client->GetFeatureFlag($key, $distinctId, $groups, $personProperties, $groupProperties, $onlyEvaluateLocally, $sendFeatureFlagEvents);
     }
 
         /**

--- a/lib/SizeLimitedHash.php
+++ b/lib/SizeLimitedHash.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace PostHog;
+
+class SizeLimitedHash
+{
+    /**
+     * @var int
+     */
+    private $size;
+
+    /**
+     * @var array
+     */
+    private $mapping;
+
+    public function __construct($size)
+    {
+        $this->size = $size;
+        $this->mapping = [];
+    }
+
+    public function add($key, $element)
+    {
+
+        if (count($this->mapping) >= $this->size) {
+            $this->mapping = [];
+        }
+
+        if (array_key_exists($key, $this->mapping)) {
+            array_push($this->mapping, $element);
+        } else {
+            $this->mapping[$key] = [$element];
+        }
+    }
+
+    public function contains($key, $element)
+    {
+        if (array_key_exists($key, $this->mapping) && array_key_exists($element, $this->mapping[$key])) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function count()
+    {
+        return count($this->mapping);
+    }
+}

--- a/test/FeatureFlagTest.php
+++ b/test/FeatureFlagTest.php
@@ -728,6 +728,23 @@ class FeatureFlagMatch extends TestCase
         ]);
     }
 
+    public function testEventCalled()
+    {
+        $this->http_client = new MockedHttpClient(host: "app.posthog.com", flagEndpointResponse: MockedResponses::LOCAL_EVALUATION_SIMPLE_REQUEST);
+        $this->client = new Client(
+            FAKE_API_KEY,
+            [
+                "debug" => true,
+            ],
+            $this->http_client,
+            "test"
+        );
+        PostHog::init(null, null, $this->client);
+
+        PostHog::getFeatureFlag('simple-flag', 'some-distinct-id');
+        $this->assertEquals($this->client->distinctIdsFeatureFlagsReported->count(), 1);
+    }
+
     public function testFlagConsistency()
     {
         $this->http_client = new MockedHttpClient(host: "app.posthog.com", flagEndpointResponse: MockedResponses::SIMPLE_PARTIAL_REQUEST);

--- a/test/FeatureFlagTest.php
+++ b/test/FeatureFlagTest.php
@@ -9,6 +9,7 @@ use PostHog\Client;
 use PostHog\PostHog;
 use PostHog\Test\Assets\MockedResponses;
 use PostHog\InconclusiveMatchException;
+use PostHog\SizeLimitedHash;
 
 class FeatureFlagMatch extends TestCase
 {
@@ -739,9 +740,14 @@ class FeatureFlagMatch extends TestCase
             $this->http_client,
             "test"
         );
+
+        $this->client->distinctIdsFeatureFlagsReported = new SizeLimitedHash(1);
         PostHog::init(null, null, $this->client);
 
         PostHog::getFeatureFlag('simple-flag', 'some-distinct-id');
+        $this->assertEquals($this->client->distinctIdsFeatureFlagsReported->count(), 1);
+
+        PostHog::getFeatureFlag('simple-flag', 'some-distinct-id2');
         $this->assertEquals($this->client->distinctIdsFeatureFlagsReported->count(), 1);
     }
 

--- a/test/FeatureFlagTest.php
+++ b/test/FeatureFlagTest.php
@@ -683,7 +683,7 @@ class FeatureFlagMatch extends TestCase
             array(),
             true,
             false
-        ), false);
+        ), null);
 
         # beta-feature2 should fallback to decide because region property not given with call
         # but doesn't because only_evaluate_locally is true

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -122,7 +122,7 @@ class PostHogTest extends TestCase
 
     public function testIsFeatureEnabledGroups()
     {
-        $this->assertFalse(PostHog::isFeatureEnabled('having_fun', 'user-id', false, array("company" => "id:5")));
+        $this->assertFalse(PostHog::isFeatureEnabled('having_fun', 'user-id', array("company" => "id:5")));
 
         $this->assertEquals(
             $this->http_client->calls,
@@ -159,12 +159,12 @@ class PostHogTest extends TestCase
 
     public function testGetFeatureFlagDefault()
     {
-        $this->assertTrue(PostHog::getFeatureFlag('blah', 'user-id', true));
+        $this->assertEquals(PostHog::getFeatureFlag('blah', 'user-id'), null);
     }
 
     public function testGetFeatureFlagGroups()
     {
-        $this->assertEquals("variant-value", PostHog::getFeatureFlag('multivariate-test', 'user-id', false, array("company" => "id:5")));
+        $this->assertEquals("variant-value", PostHog::getFeatureFlag('multivariate-test', 'user-id', array("company" => "id:5")));
 
         $this->assertEquals(
             $this->http_client->calls,


### PR DESCRIPTION
- removes defaultValue argument from feature flag functions and returns `null` instead when the function is inconclusive