### PR TITLE
fix: reflect the correct version number

### DIFF
--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -6,7 +6,7 @@ use Exception;
 
 class PostHog
 {
-    public const VERSION = '2.1.0';
+    public const VERSION = '3.0.0';
     public const ENV_API_KEY = "POSTHOG_API_KEY";
     public const ENV_HOST = "POSTHOG_HOST";
 


### PR DESCRIPTION
PostHog::VERSION still returns 2.1.0 even though the package is at 3.0.0 now.