### PR TITLE
fix(groups): actually add groups support for capture

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -104,12 +104,12 @@ class Client
         $message = $this->message($message);
         $message["type"] = "capture";
 
+        if (array_key_exists('$groups', $message)) {
+            $message["properties"]['$groups'] = $message['$groups'];
+        }
+
         if (array_key_exists("send_feature_flags", $message) && $message["send_feature_flags"]) {
             $flags = $this->fetchFeatureVariants($message["distinct_id"], $message["groups"]);
-
-            if (!isset($message["properties"])) {
-                $message["properties"] = array();
-            }
 
             // Add all feature variants to event
             foreach ($flags as $flagKey => $flagValue) {
@@ -232,7 +232,7 @@ class Client
                 ],
                 "distinct_id" => $distinctId,
                 "event" => '$feature_flag_called',
-                "groups" => $groups
+                '$groups' => $groups
             ]);
             $this->distinctIdsFeatureFlagsReported->add($key, $distinctId);
         }

--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -224,7 +224,7 @@ class PostHog
     public static function validate($msg, $type)
     {
         $distinctId = !empty($msg["distinctId"]);
-        self::assert($distinctId, "PostHog::${type}() requires distinctId");
+        self::assert($distinctId, "PostHog::{$type}() requires distinctId");
     }
 
     /**


### PR DESCRIPTION
I added groups feature in https://github.com/PostHog/posthog-php/pull/26 but didn't add all the functionality I advertised.

Tested via:

```php
<?php

require_once __DIR__ . '/vendor/autoload.php';

use PostHog\PostHog;

PostHog::init("phc_DZgJcBXRIkZvPpwiwrKSyUqTVtz8qhiFzaED6ldjcT9", array('host' => 'http://localhost:8000', 'ssl' => false));

PostHog::capture(array(
  'distinctId' => 'user:123',
  'event' => 'movie played',
  '$groups' => array("organization" => "id:5")
));

PostHog::groupIdentify(array(
  'groupType' => 'organization',
  'groupKey' => 'id:5',
));

PostHog::flush();

?>
```

In posthog:

![image](https://user-images.githubusercontent.com/148820/212338637-4af19cea-9f77-495e-938b-f60feb73cedf.png)
