### PR TITLE
Fix typehint

### DIFF
--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -178,7 +178,7 @@ class PostHog
      * @param array $groups
      * @param array $personProperties
      * @param array $groupProperties
-     * @return boolean | string
+     * @return array
      * @throws Exception
      */
     public static function getAllFlags(


### PR DESCRIPTION
`getAllFlags` was type-hinted as `string|bool` but it really returns an array.