### PR TITLE
feat: Add Support For Feature Flag Payloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ test/posthog.log
 .phpunit.result.cache
 clover.xml
 xdebug.log
+.DS_Store

--- a/bin/posthog
+++ b/bin/posthog
@@ -25,7 +25,8 @@ $options = getopt(
         'groupType:',
         'groupKey:',
         'no-ssl',
-        'debug'
+        'debug',
+        'flag:'
     )
 );
 
@@ -81,6 +82,18 @@ switch ($options['type']) {
         );
         break;
 
+    case 'getFeatureFlag':
+        $result = PostHog::getFeatureFlag($options['flag'] ?? 'test-flag', $options['distinctId'] ?? "test-distinct-id");
+        echo "RESULT: ";
+        var_dump($result);
+        break;
+
+    case 'getFeatureFlagPayload':
+        $result = PostHog::getFeatureFlagPayload($options['flag'] ?? 'test-flag', $options['distinctId'] ?? "test-distinct-id");
+        echo "RESULT: ";
+        var_dump($result);
+        break;
+
     default:
         error(usage());
         break;
@@ -101,6 +114,8 @@ function usage(): string
         "\n    posthog --type identify --distinctId \"id\" --properties '{ \"json\": \"object\" }'" .
         "\n    posthog --type alias --distinctId \"id\" --alias \"alias\"" .
         "\n    posthog --type groupIdentify --groupType \"organization\" --groupKey \"id:5\" --properties '{ \"json\": \"object\" }'" .
+        "\n    posthog --type getFeatureFlag --flag some-flag --apiKey phc_... --host localhost:8010 --no-ssl" .
+        "\n    posthog --type getFeatureFlag --flag some-flag --apiKey phc_... --host localhost:8010 --no-ssl" .
         "\n\n\n";
 }
 

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -322,13 +322,12 @@ class Client
 
         $payload = $results['featureFlagPayloads'][$key] ?? null;
 
-        $json = json_decode($payload, true);
-
-        if (is_array($json)) {
-            return $json;
+        if ($payload === null) {
+            return null;
         }
 
-        return $payload;
+        # feature flag payloads are always JSON encoded strings.
+        return json_decode($payload, true);
     }
 
     /**

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -69,11 +69,6 @@ class Client
     public $distinctIdsFeatureFlagsReported;
 
     /**
-     * @var string
-     */
-    public $decideVersion;
-
-    /**
      * Create a new posthog object with your app's API key
      * key
      *
@@ -106,7 +101,6 @@ class Client
         $this->groupTypeMapping = [];
         $this->cohorts = [];
         $this->distinctIdsFeatureFlagsReported = new SizeLimitedHash(SIZE_LIMIT);
-        $this->decideVersion = $options["decide_version"] ?? '2';
 
         // Populate featureflags and grouptypemapping if possible
         if (
@@ -508,7 +502,7 @@ class Client
         }
 
         return $this->httpClient->sendRequest(
-            '/decide/?v=' . $this->decideVersion,
+            '/decide/?v=3',
             json_encode($payload),
             [
                 // Send user agent in the form of {library_name}/{library_version} as per RFC 7231.

--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -171,7 +171,31 @@ class PostHog
         );
     }
 
-        /**
+    /**
+     * @param string $key
+     * @param string $distinctId
+     * @param array $groups
+     * @param array $personProperties
+     * @param array $groupProperties
+     * @return mixed
+     */
+    public static function getFeatureFlagPayload(
+        string $key,
+        string $distinctId,
+        array $groups = array(),
+        array $personProperties = array(),
+        array $groupProperties = array(),
+    ): mixed {
+        return self::$client->getFeatureFlagPayload(
+            $key,
+            $distinctId,
+            $groups,
+            $personProperties,
+            $groupProperties
+        );
+    }
+
+    /**
      * get all enabled flags for distinct_id
      *
      * @param string $distinctId

--- a/test/FeatureFlagTest.php
+++ b/test/FeatureFlagTest.php
@@ -3793,7 +3793,7 @@ class FeatureFlagTest extends TestCase
     {
         $this->http_client = new MockedHttpClient(
             host: "app.posthog.com",
-            flagEndpointResponse: MockedResponses::DECIDE_REQUEST_WITH_PAYLOAD_JSON
+            decideEndpointResponse: MockedResponses::DECIDE_REQUEST_WITH_PAYLOAD_JSON
         );
 
         $this->client = new Client(
@@ -3815,7 +3815,7 @@ class FeatureFlagTest extends TestCase
     {
         $this->http_client = new MockedHttpClient(
             host: "app.posthog.com",
-            flagEndpointResponse: MockedResponses::DECIDE_REQUEST_WITH_PAYLOAD_INTEGER
+            decideEndpointResponse: MockedResponses::DECIDE_REQUEST_WITH_PAYLOAD_INTEGER
         );
 
         $this->client = new Client(
@@ -3837,7 +3837,7 @@ class FeatureFlagTest extends TestCase
     {
         $this->http_client = new MockedHttpClient(
             host: "app.posthog.com",
-            flagEndpointResponse: MockedResponses::DECIDE_REQUEST_WITH_PAYLOAD_STRING
+            decideEndpointResponse: MockedResponses::DECIDE_REQUEST_WITH_PAYLOAD_STRING
         );
 
         $this->client = new Client(
@@ -3859,7 +3859,7 @@ class FeatureFlagTest extends TestCase
     {
         $this->http_client = new MockedHttpClient(
             host: "app.posthog.com",
-            flagEndpointResponse: MockedResponses::DECIDE_REQUEST_WITH_PAYLOAD_JSON_FLAG_DISABLED
+            decideEndpointResponse: MockedResponses::DECIDE_REQUEST_WITH_PAYLOAD_JSON_FLAG_DISABLED
         );
 
         $this->client = new Client(
@@ -3881,7 +3881,7 @@ class FeatureFlagTest extends TestCase
     {
         $this->http_client = new MockedHttpClient(
             host: "app.posthog.com",
-            flagEndpointResponse: MockedResponses::DECIDE_REQUEST_WITH_PAYLOAD_JSON
+            decideEndpointResponse: MockedResponses::DECIDE_REQUEST_WITH_PAYLOAD_JSON
         );
 
         $this->client = new Client(

--- a/test/FeatureFlagTest.php
+++ b/test/FeatureFlagTest.php
@@ -13,6 +13,12 @@ use PostHog\SizeLimitedHash;
 
 class FeatureFlagMatch extends TestCase
 {
+    protected const FAKE_API_KEY = "random_key";
+
+    protected Client $client;
+
+    protected MockedHttpClient $http_client;
+
     public function setUp(): void
     {
         date_default_timezone_set("UTC");
@@ -2881,5 +2887,115 @@ class FeatureFlagMatch extends TestCase
             $testResult = PostHog::getFeatureFlag('multivariate-flag', sprintf('distinct_id_%s', $number));
             $this->assertEquals($testResult, $result[$number]);
         }
+    }
+
+    public function testGetFeatureFlagPayloadHandlesJson(): void
+    {
+        $this->http_client = new MockedHttpClient(
+            host: "app.posthog.com",
+            flagEndpointResponse: MockedResponses::DECIDE_REQUEST_WITH_PAYLOAD_JSON
+        );
+
+        $this->client = new Client(
+            apiKey: self::FAKE_API_KEY,
+            options: [
+                "debug" => true,
+                "decide_version" => 3,
+            ],
+            httpClient: $this->http_client,
+            personalAPIKey: "test"
+        );
+
+        PostHog::init(null, null, $this->client);
+
+        $this->assertSame(['key' => 'value'], PostHog::getFeatureFlagPayload('payload-flag', 'some-distinct'));
+    }
+
+    public function testGetFeatureFlagPayloadHandlesIntegers(): void
+    {
+        $this->http_client = new MockedHttpClient(
+            host: "app.posthog.com",
+            flagEndpointResponse: MockedResponses::DECIDE_REQUEST_WITH_PAYLOAD_INTEGER
+        );
+
+        $this->client = new Client(
+            apiKey: self::FAKE_API_KEY,
+            options: [
+                "debug" => true,
+                "decide_version" => 3,
+            ],
+            httpClient: $this->http_client,
+            personalAPIKey: "test"
+        );
+
+        PostHog::init(null, null, $this->client);
+
+        $this->assertSame(2500, PostHog::getFeatureFlagPayload('payload-flag', 'some-distinct'));
+    }
+
+    public function testGetFeatureFlagPayloadHandlesString(): void
+    {
+        $this->http_client = new MockedHttpClient(
+            host: "app.posthog.com",
+            flagEndpointResponse: MockedResponses::DECIDE_REQUEST_WITH_PAYLOAD_STRING
+        );
+
+        $this->client = new Client(
+            apiKey: self::FAKE_API_KEY,
+            options: [
+                "debug" => true,
+                "decide_version" => 3,
+            ],
+            httpClient: $this->http_client,
+            personalAPIKey: "test"
+        );
+
+        PostHog::init(null, null, $this->client);
+
+        $this->assertSame('A String', PostHog::getFeatureFlagPayload('payload-flag', 'some-distinct'));
+    }
+
+    public function testGetFeatureFlagPayloadHandlesFlagDisabled(): void
+    {
+        $this->http_client = new MockedHttpClient(
+            host: "app.posthog.com",
+            flagEndpointResponse: MockedResponses::DECIDE_REQUEST_WITH_PAYLOAD_JSON_FLAG_DISABLED
+        );
+
+        $this->client = new Client(
+            apiKey: self::FAKE_API_KEY,
+            options: [
+                "debug" => true,
+                "decide_version" => 3,
+            ],
+            httpClient: $this->http_client,
+            personalAPIKey: "test"
+        );
+
+        PostHog::init(null, null, $this->client);
+
+        $this->assertNull(PostHog::getFeatureFlagPayload('payload-flag', 'some-distinct'));
+    }
+
+    public function testGetFeatureFlagPayloadHandlesFlagNotInResults(): void
+    {
+        $this->http_client = new MockedHttpClient(
+            host: "app.posthog.com",
+            flagEndpointResponse: MockedResponses::DECIDE_REQUEST_WITH_PAYLOAD_JSON
+        );
+
+        $this->client = new Client(
+            apiKey: self::FAKE_API_KEY,
+            options: [
+                "debug" => true,
+                "decide_version" => 3,
+            ],
+            httpClient: $this->http_client,
+            personalAPIKey: "test"
+        );
+
+        PostHog::init(null, null, $this->client);
+
+        $this->assertNull(PostHog::getFeatureFlagPayload('non-existent-flag', 'some-distinct'));
     }
 }

--- a/test/FeatureFlagTest.php
+++ b/test/FeatureFlagTest.php
@@ -1607,7 +1607,7 @@ class FeatureFlagTest extends TestCase
             $this->http_client->calls,
             array(
                 0 => array(
-                    "path" => "/decide/?v=2",
+                    "path" => "/decide/?v=3",
                     'payload' => '{"api_key":"random_key","distinct_id":"some-distinct-id","person_properties":{"distinct_id":"some-distinct-id","region":"USA","other":"thing"}}',
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),

--- a/test/MockedHttpClient.php
+++ b/test/MockedHttpClient.php
@@ -42,14 +42,7 @@ class MockedHttpClient extends \PostHog\HttpClient
         array_push($this->calls, array("path" => $path, "payload" => $payload, "extraHeaders" => $extraHeaders, "requestOptions" => $requestOptions));
 
         if (str_starts_with($path, "/decide/")) {
-            return new HttpResponse(
-                json_encode(
-                    !empty($this->flagEndpointResponse)
-                        ? $this->flagEndpointResponse
-                        : MockedResponses::DECIDE_REQUEST
-                ),
-                200
-            );
+            return new HttpResponse(json_encode(MockedResponses::DECIDE_REQUEST), 200);
         }
 
         if (str_starts_with($path, "/api/feature_flag/local_evaluation")) {

--- a/test/MockedHttpClient.php
+++ b/test/MockedHttpClient.php
@@ -39,7 +39,7 @@ class MockedHttpClient extends \PostHog\HttpClient
         array_push($this->calls, array("path" => $path, "payload" => $payload));
 
         if (str_starts_with($path, "/decide/")) {
-            return new HttpResponse(json_encode(MockedResponses::DECIDE_REQUEST), 200);
+            return new HttpResponse(json_encode($this->flagEndpointResponse ?? MockedResponses::DECIDE_REQUEST), 200);
         }
 
         if (str_starts_with($path, "/api/feature_flag/local_evaluation")) {

--- a/test/MockedHttpClient.php
+++ b/test/MockedHttpClient.php
@@ -20,7 +20,8 @@ class MockedHttpClient extends \PostHog\HttpClient
         bool $debug = false,
         ?Closure $errorHandler = null,
         int $curlTimeoutMilliseconds = 750,
-        array $flagEndpointResponse = []
+        array $flagEndpointResponse = [],
+        array $decideEndpointResponse = []
     ) {
         parent::__construct(
             $host,
@@ -32,6 +33,7 @@ class MockedHttpClient extends \PostHog\HttpClient
             $curlTimeoutMilliseconds
         );
         $this->flagEndpointResponse = $flagEndpointResponse;
+        $this->decideEndpointResponse = !empty($decideEndpointResponse) ? $decideEndpointResponse : MockedResponses::DECIDE_REQUEST;
     }
 
     public function sendRequest(string $path, ?string $payload, array $extraHeaders = [], array $requestOptions = []): HttpResponse
@@ -42,7 +44,7 @@ class MockedHttpClient extends \PostHog\HttpClient
         array_push($this->calls, array("path" => $path, "payload" => $payload, "extraHeaders" => $extraHeaders, "requestOptions" => $requestOptions));
 
         if (str_starts_with($path, "/decide/")) {
-            return new HttpResponse(json_encode(MockedResponses::DECIDE_REQUEST), 200);
+            return new HttpResponse(json_encode($this->decideEndpointResponse), 200);
         }
 
         if (str_starts_with($path, "/api/feature_flag/local_evaluation")) {

--- a/test/MockedHttpClient.php
+++ b/test/MockedHttpClient.php
@@ -42,7 +42,14 @@ class MockedHttpClient extends \PostHog\HttpClient
         array_push($this->calls, array("path" => $path, "payload" => $payload, "extraHeaders" => $extraHeaders, "requestOptions" => $requestOptions));
 
         if (str_starts_with($path, "/decide/")) {
-            return new HttpResponse(json_encode($this->flagEndpointResponse ?? MockedResponses::DECIDE_REQUEST), 200);
+            return new HttpResponse(
+                json_encode(
+                    !empty($this->flagEndpointResponse)
+                        ? $this->flagEndpointResponse
+                        : MockedResponses::DECIDE_REQUEST
+                ),
+                200
+            );
         }
 
         if (str_starts_with($path, "/api/feature_flag/local_evaluation")) {

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -117,7 +117,7 @@ class PostHogTest extends TestCase
                         "requestOptions" => array(),
                     ),
                     1 => array (
-                        "path" => "/decide/?v=2",
+                        "path" => "/decide/?v=3",
                         "payload" => sprintf('{"api_key":"%s","distinct_id":"john"}', self::FAKE_API_KEY),
                         "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                         "requestOptions" => array("timeout" => 1234, "shouldRetry" => false),
@@ -265,7 +265,7 @@ class PostHogTest extends TestCase
                     "requestOptions" => array(),
                 ),
                 1 => array(
-                    "path" => "/decide/?v=2",
+                    "path" => "/decide/?v=3",
                     "payload" => sprintf('{"api_key":"%s","distinct_id":"user-id","person_properties":{"distinct_id":"user-id"}}', self::FAKE_API_KEY),
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),
@@ -288,7 +288,7 @@ class PostHogTest extends TestCase
                     "requestOptions" => array(),
                 ),
                 1 => array(
-                    "path" => "/decide/?v=2",
+                    "path" => "/decide/?v=3",
                     "payload" => sprintf(
                         '{"api_key":"%s","distinct_id":"user-id","groups":{"company":"id:5"},"person_properties":{"distinct_id":"user-id"},"group_properties":{"company":{"$group_key":"id:5"}}}',
                         self::FAKE_API_KEY
@@ -313,7 +313,7 @@ class PostHogTest extends TestCase
                     "requestOptions" => array(),
                 ),
                 1 => array(
-                    "path" => "/decide/?v=2",
+                    "path" => "/decide/?v=3",
                     "payload" => sprintf('{"api_key":"%s","distinct_id":"user-id","person_properties":{"distinct_id":"user-id"}}', self::FAKE_API_KEY),
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),
@@ -346,7 +346,7 @@ class PostHogTest extends TestCase
                     "requestOptions" => array(),
                 ),
                 1 => array(
-                    "path" => "/decide/?v=2",
+                    "path" => "/decide/?v=3",
                     "payload" => sprintf(
                         '{"api_key":"%s","distinct_id":"user-id","groups":{"company":"id:5"},"person_properties":{"distinct_id":"user-id"},"group_properties":{"company":{"$group_key":"id:5"}}}',
                         self::FAKE_API_KEY
@@ -516,7 +516,7 @@ class PostHogTest extends TestCase
                     "requestOptions" => array(),
                 ),
                 1 => array(
-                    "path" => "/decide/?v=2",
+                    "path" => "/decide/?v=3",
                     "payload" => sprintf('{"api_key":"%s","distinct_id":"some_id","groups":{"company":"id:5","instance":"app.posthog.com"},"person_properties":{"distinct_id":"some_id","x1":"y1"},"group_properties":{"company":{"$group_key":"id:5","x":"y"},"instance":{"$group_key":"app.posthog.com"}}}', self::FAKE_API_KEY),
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),
@@ -538,7 +538,7 @@ class PostHogTest extends TestCase
             $this->http_client->calls,
             array(
                 0 => array(
-                    "path" => "/decide/?v=2",
+                    "path" => "/decide/?v=3",
                     "payload" => sprintf('{"api_key":"%s","distinct_id":"some_id","groups":{"company":"id:5","instance":"app.posthog.com"},"person_properties":{"distinct_id":"override"},"group_properties":{"company":{"$group_key":"group_override"},"instance":{"$group_key":"app.posthog.com"}}}', self::FAKE_API_KEY),
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),
@@ -554,7 +554,7 @@ class PostHogTest extends TestCase
             $this->http_client->calls,
             array(
                 0 => array(
-                    "path" => "/decide/?v=2",
+                    "path" => "/decide/?v=3",
                     "payload" => sprintf('{"api_key":"%s","distinct_id":"some_id","groups":{"company":"id:5"},"person_properties":{"distinct_id":"some_id"},"group_properties":{"company":{"$group_key":"id:5"}}}', self::FAKE_API_KEY),
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),
@@ -570,7 +570,7 @@ class PostHogTest extends TestCase
             $this->http_client->calls,
             array(
                 0 => array(
-                    "path" => "/decide/?v=2",
+                    "path" => "/decide/?v=3",
                     "payload" => sprintf('{"api_key":"%s","distinct_id":"some_id","groups":{"company":"id:5","instance":"app.posthog.com"},"person_properties":{"distinct_id":"some_id","x1":"y1"},"group_properties":{"company":{"$group_key":"id:5","x":"y"},"instance":{"$group_key":"app.posthog.com"}}}', self::FAKE_API_KEY),
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),

--- a/test/assests/MockedResponses.php
+++ b/test/assests/MockedResponses.php
@@ -104,7 +104,7 @@ class MockedResponses
         ],
         'sessionRecording' => false,
         'featureFlagPayloads' => [
-            'payload-flag' => 2500,
+            'payload-flag' => "2500",
         ]
     ];
 
@@ -128,7 +128,7 @@ class MockedResponses
         ],
         'sessionRecording' => false,
         'featureFlagPayloads' => [
-            'payload-flag' => 'A String',
+            'payload-flag' => '"A String"',
         ]
     ];
 

--- a/test/assests/MockedResponses.php
+++ b/test/assests/MockedResponses.php
@@ -36,6 +36,102 @@ class MockedResponses
         'sessionRecording' => false,
     ];
 
+    public const DECIDE_REQUEST_WITH_PAYLOAD_JSON = [
+        'config' => [
+            'enable_collect_everything' => true,
+        ],
+        'editorParams' => [
+        ],
+        'isAuthenticated' => false,
+        'supportedCompression' => [
+            0 => 'gzip',
+            1 => 'gzip-js',
+            2 => 'lz64',
+        ],
+        'featureFlags' => [
+            'payload-flag' => true,
+            'having_fun' => false,
+            'enabled-flag' => true,
+            'disabled-flag' => false,
+        ],
+        'sessionRecording' => false,
+        'featureFlagPayloads' => [
+            'payload-flag' => '{"key":"value"}',
+        ]
+    ];
+
+    public const DECIDE_REQUEST_WITH_PAYLOAD_JSON_FLAG_DISABLED = [
+        'config' => [
+            'enable_collect_everything' => true,
+        ],
+        'editorParams' => [
+        ],
+        'isAuthenticated' => false,
+        'supportedCompression' => [
+            0 => 'gzip',
+            1 => 'gzip-js',
+            2 => 'lz64',
+        ],
+        'featureFlags' => [
+            'payload-flag' => false,
+            'having_fun' => false,
+            'enabled-flag' => true,
+            'disabled-flag' => false,
+        ],
+        'sessionRecording' => false,
+        'featureFlagPayloads' => [
+            'payload-flag' => '{"key":"value"}',
+        ]
+    ];
+
+    public const DECIDE_REQUEST_WITH_PAYLOAD_INTEGER = [
+        'config' => [
+            'enable_collect_everything' => true,
+        ],
+        'editorParams' => [
+        ],
+        'isAuthenticated' => false,
+        'supportedCompression' => [
+            0 => 'gzip',
+            1 => 'gzip-js',
+            2 => 'lz64',
+        ],
+        'featureFlags' => [
+            'payload-flag' => true,
+            'having_fun' => false,
+            'enabled-flag' => true,
+            'disabled-flag' => false,
+        ],
+        'sessionRecording' => false,
+        'featureFlagPayloads' => [
+            'payload-flag' => 2500,
+        ]
+    ];
+
+    public const DECIDE_REQUEST_WITH_PAYLOAD_STRING = [
+        'config' => [
+            'enable_collect_everything' => true,
+        ],
+        'editorParams' => [
+        ],
+        'isAuthenticated' => false,
+        'supportedCompression' => [
+            0 => 'gzip',
+            1 => 'gzip-js',
+            2 => 'lz64',
+        ],
+        'featureFlags' => [
+            'payload-flag' => true,
+            'having_fun' => false,
+            'enabled-flag' => true,
+            'disabled-flag' => false,
+        ],
+        'sessionRecording' => false,
+        'featureFlagPayloads' => [
+            'payload-flag' => 'A String',
+        ]
+    ];
+
     public const LOCAL_EVALUATION_REQUEST = [
         'count' => 1,
         'next' => null,


### PR DESCRIPTION
This PR enables support for retrieving the payloads of feature flags, by leveraging the `.../decide/?v=3` query parameter.

The decide version can now be customized by passing a version number in the options parameter when initializing PostHog. This enables the decide call to return the `featureFlagPayloads` object in the payload. The version defaults to `2` if no value is specified.

Usage:
```php
PostHog::init(
    apiKey: '...',
    options: [
        'decide_version' => 3,
    ],
);

PostHog::getFeatureFlagPayload('payload-flag', 'distinct-id');
```
&nbsp;

### Tests

Tests are included for the following scenarios
- Feature flag disabled - payload should be null
- Feature flag enabled - json payload
- Feature flag enabled - integer payload
- Feature flag enabled - string payload


