### PR TITLE
fix(flags): Safe access flags in decide v2

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -231,7 +231,11 @@ class Client
         if (!$flagWasEvaluatedLocally && !$onlyEvaluateLocally) {
             try {
                 $featureFlags = $this->fetchFeatureVariants($distinctId, $groups, $personProperties, $groupProperties);
-                $result = $featureFlags[$key] ?? null;
+                if(array_key_exists($key, $featureFlags)) {
+                    $result = $featureFlags[$key];
+                } else {
+                    $result = null;
+                }
             } catch (Exception $e) {
                 error_log("[PostHog][Client] Unable to get feature variants:" . $e->getMessage());
                 $result = null;

--- a/test/FeatureFlagTest.php
+++ b/test/FeatureFlagTest.php
@@ -11,7 +11,7 @@ use PostHog\Test\Assets\MockedResponses;
 use PostHog\InconclusiveMatchException;
 use PostHog\SizeLimitedHash;
 
-class FeatureFlagMatch extends TestCase
+class FeatureFlagTest extends TestCase
 {
     const FAKE_API_KEY = "random_key";
 
@@ -514,6 +514,23 @@ class FeatureFlagMatch extends TestCase
 
         $this->assertEquals(PostHog::getFeatureFlag('feature-1', 'some-distinct'), 'decide-fallback-value');
         $this->assertEquals(PostHog::getFeatureFlag('feature-2', 'some-distinct'), 'decide-fallback-value');
+    }
+
+    public function testFlagFallbackToDecideWithFalseFlag()
+    {
+        $this->http_client = new MockedHttpClient(host: "app.posthog.com", flagEndpointResponse: MockedResponses::FALLBACK_TO_DECIDE_REQUEST);
+        $this->client = new Client(
+            self::FAKE_API_KEY,
+            [
+                "debug" => true,
+            ],
+            $this->http_client,
+            "test"
+        );
+        PostHog::init(null, null, $this->client);
+
+        $this->assertEquals(PostHog::getFeatureFlag('unknown-flag???', 'some-distinct'), null);
+        $this->assertEquals(PostHog::getFeatureFlag('false-flag', 'some-distinct'), null);
     }
 
     public function testFeatureFlagDefaultsComeIntoPlayOnlyWhenDecideErrorsOut()

--- a/test/FeatureFlagTest.php
+++ b/test/FeatureFlagTest.php
@@ -2,6 +2,9 @@
 // phpcs:ignoreFile
 namespace PostHog\Test;
 
+// comment out below to print all logs instead of failing tests
+require_once 'test/error_log_mock.php';
+
 use Exception;
 use PHPUnit\Framework\TestCase;
 use PostHog\FeatureFlag;
@@ -21,6 +24,16 @@ class FeatureFlagTest extends TestCase
     public function setUp(): void
     {
         date_default_timezone_set("UTC");
+
+        // Reset the errorMessages array before each test
+        global $errorMessages;
+        $errorMessages = [];
+    }
+
+    public function checkEmptyErrorLogs(): void
+    {
+        global $errorMessages;
+        $this->assertTrue(empty($errorMessages), "Error logs are not empty: " . implode("\n", $errorMessages));
     }
 
     public function testMatchPropertyEquals(): void
@@ -455,6 +468,8 @@ class FeatureFlagTest extends TestCase
 
         $this->assertTrue(PostHog::getFeatureFlag('person-flag', 'some-distinct-id', [], ["region" => "USA"]));
         $this->assertFalse(PostHog::getFeatureFlag('person-flag', 'some-distinct-id-2', [], ["region" => "Canada"]));
+
+        $this->checkEmptyErrorLogs();
     }
 
     public function testFlagGroupProperties()
@@ -514,6 +529,8 @@ class FeatureFlagTest extends TestCase
 
         $this->assertEquals(PostHog::getFeatureFlag('feature-1', 'some-distinct'), 'decide-fallback-value');
         $this->assertEquals(PostHog::getFeatureFlag('feature-2', 'some-distinct'), 'decide-fallback-value');
+
+        $this->checkEmptyErrorLogs();
     }
 
     public function testFlagFallbackToDecideWithFalseFlag()
@@ -531,6 +548,8 @@ class FeatureFlagTest extends TestCase
 
         $this->assertEquals(PostHog::getFeatureFlag('unknown-flag???', 'some-distinct'), null);
         $this->assertEquals(PostHog::getFeatureFlag('false-flag', 'some-distinct'), null);
+
+        $this->checkEmptyErrorLogs();
     }
 
     public function testFeatureFlagDefaultsComeIntoPlayOnlyWhenDecideErrorsOut()

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -16,7 +16,7 @@ class PostHogTest extends TestCase
 
     private $http_client;
     private $client;
-    
+
     public function setUp(): void
     {
         date_default_timezone_set("UTC");

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -2,6 +2,9 @@
 
 namespace PostHog\Test;
 
+// comment out below to print all logs instead of failing tests
+require_once 'test/error_log_mock.php';
+
 use Exception;
 use PHPUnit\Framework\TestCase;
 use PostHog\Client;
@@ -27,6 +30,16 @@ class PostHogTest extends TestCase
             "test"
         );
         PostHog::init(null, null, $this->client);
+
+        // Reset the errorMessages array before each test
+        global $errorMessages;
+        $errorMessages = [];
+    }
+
+    public function checkEmptyErrorLogs(): void
+    {
+        global $errorMessages;
+        $this->assertEmpty($errorMessages);
     }
 
     public function testInitWithParamApiKey(): void
@@ -167,6 +180,8 @@ class PostHogTest extends TestCase
     public function testGetFeatureFlagDefault()
     {
         $this->assertEquals(PostHog::getFeatureFlag('blah', 'user-id'), null);
+
+        $this->checkEmptyErrorLogs();
     }
 
     public function testGetFeatureFlagGroups()

--- a/test/error_log_mock.php
+++ b/test/error_log_mock.php
@@ -2,12 +2,11 @@
 
 namespace PostHog;
 
-
 // The $errorMessages array captures logged messages.
 $errorMessages = [];
 
-function error_log($message) {
+function error_log($message)
+{
     global $errorMessages;
     $errorMessages[] = $message;
 }
-

--- a/test/error_log_mock.php
+++ b/test/error_log_mock.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace PostHog;
+
+
+// The $errorMessages array captures logged messages.
+$errorMessages = [];
+
+function error_log($message) {
+    global $errorMessages;
+    $errorMessages[] = $message;
+}
+

--- a/test/error_log_mock.php
+++ b/test/error_log_mock.php
@@ -1,5 +1,6 @@
 <?php
 
+// phpcs:disable PSR1.Files.SideEffects
 namespace PostHog;
 
 // The $errorMessages array captures logged messages.


### PR DESCRIPTION
Since decide v2 doesn't return all flags, but just true flags, this leads to an error when you're checking for a false flag:

```
Unable to get feature variants:Undefined array key "flag-key"
```

This PR defends against this.