### PR TITLE
fix(flags): Handle bool value matching

### DIFF
--- a/lib/FeatureFlag.php
+++ b/lib/FeatureFlag.php
@@ -35,11 +35,11 @@ class FeatureFlag
         }
 
         if ($operator == "icontains") {
-            return strpos(strtolower(strval($overrideValue)), strtolower(strval($value))) !== false;
+            return strpos(strtolower(FeatureFlag::valueToString($overrideValue)), strtolower(FeatureFlag::valueToString($value))) !== false;
         }
-
+        
         if ($operator == "not_icontains") {
-            return strpos(strtolower(strval($overrideValue)), strtolower(strval($value))) == false;
+            return strpos(strtolower(FeatureFlag::valueToString($overrideValue)), strtolower(FeatureFlag::valueToString($value))) == false;
         }
 
         if (in_array($operator, ["regex", "not_regex"])) {
@@ -65,12 +65,12 @@ class FeatureFlag
 
             if (!is_null($parsedValue) && !is_null($overrideValue)) {
                 if (is_string($overrideValue)) {
-                    return FeatureFlag::compare($overrideValue, strval($value), $operator);
+                    return FeatureFlag::compare($overrideValue, FeatureFlag::valueToString($value), $operator);
                 } else {
                     return FeatureFlag::compare($overrideValue, $parsedValue, $operator, "numeric");
                 }
             } else {
-                return FeatureFlag::compare(strval($overrideValue), strval($value), $operator);
+                return FeatureFlag::compare(FeatureFlag::valueToString($overrideValue), FeatureFlag::valueToString($value), $operator);
             }
         }
 
@@ -246,9 +246,18 @@ class FeatureFlag
     private static function computeExactMatch($value, $overrideValue)
     {
         if (is_array($value)) {
-            return in_array(strtolower(strval($overrideValue)), array_map('strtolower', $value));
+            return in_array(strtolower(FeatureFlag::valueToString($overrideValue)), array_map('strtolower', array_map(fn($val) => FeatureFlag::valueToString($val) , $value)));
         }
-        return strtolower(strval($value)) == strtolower(strval($overrideValue));
+        return strtolower(FeatureFlag::valueToString($value)) == strtolower(FeatureFlag::valueToString($overrideValue));
+    }
+
+    private static function valueToString($value)
+    {
+        if (is_bool($value)) {
+            return $value ? "true" : "false";
+        } else {
+            return strval($value);
+        }
     }
 
     private static function compare($lhs, $rhs, $operator, $type = "string")

--- a/test/assests/MockedResponses.php
+++ b/test/assests/MockedResponses.php
@@ -68,6 +68,98 @@ class MockedResponses
         ],
     ];
 
+    public const LOCAL_EVALUATION_BOOLEAN_REQUEST = [
+        'count' => 1,
+        'next' => null,
+        'previous' => null,
+        'flags' => [
+            [
+                "id" => 1,
+                "name" => "",
+                "key" => "person-flag",
+                "filters" => [
+                    "groups" => [
+                        [
+                            "properties" => [
+                                [
+                                    "key" => "region_array",
+                                    "value" => ["true"],
+                                    "operator" => "exact",
+                                    "type" => "person"
+                                ],
+                                [
+                                    "key" => "region",
+                                    "value" => "true",
+                                    "operator" => "exact",
+                                    "type" => "person"
+                                ],
+                            ],
+                            "rollout_percentage" => 100
+                        ]
+                    ]
+                ],
+                "deleted" => false,
+                "active" => true,
+                "is_simple_flag" => true,
+                "rollout_percentage" => null
+            ],
+            [
+                "id" => 2,
+                "name" => "",
+                "key" => "person-flag-with-boolean",
+                "filters" => [
+                    "groups" => [
+                        [
+                            "properties" => [
+                                [
+                                    "key" => "region_array",
+                                    "value" => [true],
+                                    "operator" => "exact",
+                                    "type" => "person"
+                                ],
+                                [
+                                    "key" => "region",
+                                    "value" => true,
+                                    "operator" => "exact",
+                                    "type" => "person"
+                                ],
+                            ],
+                            "rollout_percentage" => 100
+                        ]
+                    ]
+                ],
+                "deleted" => false,
+                "active" => true,
+                "is_simple_flag" => true,
+                "rollout_percentage" => null
+            ],
+            [
+                "id" => 2,
+                "name" => "",
+                "key" => "person-flag-with-boolean-icontains",
+                "filters" => [
+                    "groups" => [
+                        [
+                            "properties" => [
+                                [
+                                    "key" => "region",
+                                    "value" => true,
+                                    "operator" => "icontains",
+                                    "type" => "person"
+                                ],
+                            ],
+                            "rollout_percentage" => 100
+                        ]
+                    ]
+                ],
+                "deleted" => false,
+                "active" => true,
+                "is_simple_flag" => true,
+                "rollout_percentage" => null
+            ]
+        ],
+    ];
+
     public const LOCAL_EVALUATION_MULTIPLE_REQUEST = [
         'count' => 2,
         'next' => null,


### PR DESCRIPTION
In PHP, `strval(true) == 1` and not `'true'` so we need to handle this accordingly for flag matching, since in most cases the server would return "true" or "false" strings for local evaluation