### PR TITLE
Make the feature flag fetch optional

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -80,7 +80,8 @@ class Client
         string $apiKey,
         array $options = [],
         ?HttpClient $httpClient = null,
-        string $personalAPIKey = null
+        string $personalAPIKey = null,
+        bool $loadFeatureFlags = true,
     ) {
         $this->apiKey = $apiKey;
         $this->personalAPIKey = $personalAPIKey;
@@ -102,7 +103,11 @@ class Client
         $this->distinctIdsFeatureFlagsReported = new SizeLimitedHash(SIZE_LIMIT);
 
         // Populate featureflags and grouptypemapping if possible
-        if (count($this->featureFlags) == 0 && !is_null($this->personalAPIKey)) {
+        if (
+            count($this->featureFlags) == 0
+            && !is_null($this->personalAPIKey)
+            && $loadFeatureFlags
+        ) {
             $this->loadFlags();
         }
     }


### PR DESCRIPTION
Currently, when a `personalAPIKey` is passed, it will **immediately** try and fetch the feature flags. As there is no way to provide an initial list of `->featureFlags` (the constructor sets to an empty array), it makes it difficult to maintain and hydrate a local cache when using Local Evaluation. 

This change it pretty simple and should have no breaking changes. 