### PR TITLE
Fix PHP 8.4 deprecation on Client.php constructor (Backwards Compatible)

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -80,7 +80,7 @@ class Client
         string $apiKey,
         array $options = [],
         ?HttpClient $httpClient = null,
-        string $personalAPIKey = null,
+        ?string $personalAPIKey = null,
         bool $loadFeatureFlags = true,
     ) {
         $this->apiKey = $apiKey;


### PR DESCRIPTION
Sentry give me tons of warnings on my site running on PHP 8.4 Hope you can merge it. It is backwards compatible.

You were already doing ?HttpClient 1 line above

As a side comment, with your composer targeting minimum PHP 8.0, perhaps you should use some of the newer syntax

Thank you