### PR TITLE
Add support for 'verify_batch_events_request=>false'

### DIFF
--- a/lib/Consumer/LibCurl.php
+++ b/lib/Consumer/LibCurl.php
@@ -76,6 +76,9 @@ class LibCurl extends QueueConsumer
             [
                 // Send user agent in the form of {library_name}/{library_version} as per RFC 7231.
                 "User-Agent: {$messages[0]['library']}/{$messages[0]['library_version']}",
+            ],
+            [
+                'shouldVerify' => $this->options['verify_batch_events_request'] ?? true,
             ]
         )->getResponse();
     }

--- a/test/FeatureFlagTest.php
+++ b/test/FeatureFlagTest.php
@@ -1369,7 +1369,7 @@ class FeatureFlagTest extends TestCase
                         "path" => "/batch/",
                         'payload' => '{"batch":[{"properties":{"$feature\/simple-flag":true,"$active_feature_flags":["simple-flag"],"$feature_flag":"simple-flag","$feature_flag_response":true,"$lib":"posthog-php","$lib_version":"3.0.3","$lib_consumer":"LibCurl","$groups":[]},"distinct_id":"some-distinct-id","event":"$feature_flag_called","$groups":[],"library":"posthog-php","library_version":"3.0.3","library_consumer":"LibCurl","groups":[],"timestamp":"2022-05-01T00:00:00+00:00","type":"capture"}],"api_key":"random_key"}',
                         "extraHeaders" => array(0 => 'User-Agent: posthog-php/3.0.3'),
-                        "requestOptions" => array(),
+                        "requestOptions" => array('shouldVerify' => true),
                     ),
                 )
             );

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -126,7 +126,7 @@ class PostHogTest extends TestCase
                         "path" => "/batch/",
                         "payload" => '{"batch":[{"event":"Module PHP Event","send_feature_flags":true,"properties":{"$feature\/simpleFlag":true,"$feature\/having_fun":false,"$feature\/enabled-flag":true,"$feature\/disabled-flag":false,"$feature\/multivariate-simple-test":"variant-simple-value","$feature\/simple-test":true,"$feature\/multivariate-test":"variant-value","$feature\/group-flag":"decide-fallback-value","$feature\/complex-flag":"decide-fallback-value","$feature\/beta-feature":"decide-fallback-value","$feature\/beta-feature2":"alakazam","$feature\/feature-1":"decide-fallback-value","$feature\/feature-2":"decide-fallback-value","$feature\/variant-1":"variant-1","$feature\/variant-3":"variant-3","$active_feature_flags":["simpleFlag","enabled-flag","multivariate-simple-test","simple-test","multivariate-test","group-flag","complex-flag","beta-feature","beta-feature2","feature-1","feature-2","variant-1","variant-3"],"$lib":"posthog-php","$lib_version":"3.0.3","$lib_consumer":"LibCurl"},"library":"posthog-php","library_version":"3.0.3","library_consumer":"LibCurl","distinct_id":"john","groups":[],"timestamp":"2022-05-01T00:00:00+00:00","type":"capture"}],"api_key":"random_key"}',
                         "extraHeaders" => array(0 => 'User-Agent: posthog-php/3.0.3'),
-                        "requestOptions" => array(),
+                        "requestOptions" => array('shouldVerify' => true),
                     ),
                 )
             );
@@ -181,7 +181,7 @@ class PostHogTest extends TestCase
                         "path" => "/batch/",
                         "payload" => '{"batch":[{"event":"Module PHP Event","properties":{"$feature\/true-flag":true,"$active_feature_flags":["true-flag"],"$lib":"posthog-php","$lib_version":"3.0.3","$lib_consumer":"LibCurl"},"library":"posthog-php","library_version":"3.0.3","library_consumer":"LibCurl","distinct_id":"john","groups":[],"timestamp":"2022-05-01T00:00:00+00:00","type":"capture"}],"api_key":"random_key"}',
                         "extraHeaders" => array(0 => 'User-Agent: posthog-php/3.0.3'),
-                        "requestOptions" => array(),
+                        "requestOptions" => array('shouldVerify' => true),
                     ),
                 )
             );
@@ -230,7 +230,7 @@ class PostHogTest extends TestCase
                         "path" => "/batch/",
                         "payload" => '{"batch":[{"event":"Module PHP Event","properties":{"$feature\/true-flag":"random-override","$active_feature_flags":["true-flag"],"$lib":"posthog-php","$lib_version":"3.0.3","$lib_consumer":"LibCurl"},"library":"posthog-php","library_version":"3.0.3","library_consumer":"LibCurl","distinct_id":"john","groups":[],"timestamp":"2022-05-01T00:00:00+00:00","type":"capture"}],"api_key":"random_key"}',
                         "extraHeaders" => array(0 => 'User-Agent: posthog-php/3.0.3'),
-                        "requestOptions" => array(),
+                        "requestOptions" => array('shouldVerify' => true),
                     ),
                 )
             );


### PR DESCRIPTION
See https://posthog.slack.com/archives/C03P7NL6RMW/p1741208127179239
See https://posthog.slack.com/archives/C07L8G1HVQR/p1741196816062289

## Changes

Adds support for a `'verify_batch_events_request' => false` setting when initializing PostHog. This will allow batch events requests to be sent in a non-blocking manner when using the LibCurl default transport.

## Testing

To test, add some delay to the deprecated capture endpoint on your local PostHog install:

```diff
diff --git a/posthog/api/capture.py b/posthog/api/capture.py
index 8a1397c113..c6fe4cdf06 100644
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -405,6 +405,8 @@ def lib_version_from_query_params(request) -> str:
 def get_event(request):
     structlog.contextvars.unbind_contextvars("team_id")
 
+    time.sleep(20)
+
     # handle cors request
     if request.method == "OPTIONS":
         return cors_response(request, JsonResponse({"status": 1}))

```

Then, download this test script to somewhere you can run PHP and apply an API key:

```php
<?php

require_once __DIR__ . '/vendor/autoload.php';

use PostHog\PostHog;

const POSTHOG_API_KEY = "your_api_key";

PostHog::init(
    POSTHOG_API_KEY,
    array('host' => 'http://localhost:8000', 'ssl' => false, 'verify_batch_events_request' => false),
);

$distinctId = uniqid();

PostHog::capture(array(
    'distinctId' => $distinctId,
    'event' => 'php-test user signed up - ' . $distinctId
));
error_log('captured ' . $distinctId);

```

With `'verify_batch_events_request' => false`, the test script should execute right away and your event should appear in your activity log.

With `'verify_batch_events_request' => true`, the test script should take ~20s to execute and your event should appear in your activity log.