### PR TITLE
chore(flags): use new `/flags` endpoint instead of `/decide`

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -469,7 +469,7 @@ class Client
         array $groups = [],
         array $personProperties = [],
         array $groupProperties = []
-    ): array {
+    ): ?array {
         return json_decode(
             $this->flags($distinctId, $groups, $personProperties, $groupProperties),
             true

--- a/test/FeatureFlagLocalEvaluationTest.php
+++ b/test/FeatureFlagLocalEvaluationTest.php
@@ -1174,7 +1174,7 @@ class FeatureFlagLocalEvaluationTest extends TestCase
         $this->assertFalse(PostHog::getFeatureFlag('complex-flag', 'some-distinct-within-rollout', [], ["region" => "USA", "email" => "a@b.com", "name" => "X", "doesnt_matter" => "1"], []));
     }
 
-    public function testFlagFallbackToFlags()
+    public function testFlagFallbackToDecide()
     {
         $this->http_client = new MockedHttpClient(host: "app.posthog.com", flagEndpointResponse: MockedResponses::FALLBACK_TO_DECIDE_REQUEST);
         $this->client = new Client(
@@ -1193,7 +1193,7 @@ class FeatureFlagLocalEvaluationTest extends TestCase
         $this->checkEmptyErrorLogs();
     }
 
-    public function testFlagFallbackToFlagsWithFalseFlag()
+    public function testFlagFallbackToDecideWithFalseFlag()
     {
         $this->http_client = new MockedHttpClient(host: "app.posthog.com", flagEndpointResponse: MockedResponses::FALLBACK_TO_DECIDE_REQUEST);
         $this->client = new Client(
@@ -1212,7 +1212,7 @@ class FeatureFlagLocalEvaluationTest extends TestCase
         $this->checkEmptyErrorLogs();
     }
 
-    public function testFeatureFlagDefaultsComeIntoPlayOnlyWhenFlagsErrorsOut()
+    public function testFeatureFlagDefaultsComeIntoPlayOnlyWhenDecideErrorsOut()
     {
         $this->client = new Client(
             self::FAKE_API_KEY,
@@ -1607,7 +1607,7 @@ class FeatureFlagLocalEvaluationTest extends TestCase
             $this->http_client->calls,
             array(
                 0 => array(
-                    "path" => "/flags/?v=2",
+                    "path" => "/decide/?v=4",
                     'payload' => '{"api_key":"random_key","distinct_id":"some-distinct-id","person_properties":{"distinct_id":"some-distinct-id","region":"USA","other":"thing"}}',
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),

--- a/test/FeatureFlagLocalEvaluationTest.php
+++ b/test/FeatureFlagLocalEvaluationTest.php
@@ -1174,7 +1174,7 @@ class FeatureFlagLocalEvaluationTest extends TestCase
         $this->assertFalse(PostHog::getFeatureFlag('complex-flag', 'some-distinct-within-rollout', [], ["region" => "USA", "email" => "a@b.com", "name" => "X", "doesnt_matter" => "1"], []));
     }
 
-    public function testFlagFallbackToDecide()
+    public function testFlagFallbackToFlags()
     {
         $this->http_client = new MockedHttpClient(host: "app.posthog.com", flagEndpointResponse: MockedResponses::FALLBACK_TO_DECIDE_REQUEST);
         $this->client = new Client(
@@ -1193,7 +1193,7 @@ class FeatureFlagLocalEvaluationTest extends TestCase
         $this->checkEmptyErrorLogs();
     }
 
-    public function testFlagFallbackToDecideWithFalseFlag()
+    public function testFlagFallbackToFlagsWithFalseFlag()
     {
         $this->http_client = new MockedHttpClient(host: "app.posthog.com", flagEndpointResponse: MockedResponses::FALLBACK_TO_DECIDE_REQUEST);
         $this->client = new Client(
@@ -1212,7 +1212,7 @@ class FeatureFlagLocalEvaluationTest extends TestCase
         $this->checkEmptyErrorLogs();
     }
 
-    public function testFeatureFlagDefaultsComeIntoPlayOnlyWhenDecideErrorsOut()
+    public function testFeatureFlagDefaultsComeIntoPlayOnlyWhenFlagsErrorsOut()
     {
         $this->client = new Client(
             self::FAKE_API_KEY,
@@ -1607,7 +1607,7 @@ class FeatureFlagLocalEvaluationTest extends TestCase
             $this->http_client->calls,
             array(
                 0 => array(
-                    "path" => "/decide/?v=4",
+                    "path" => "/flags/?v=2",
                     'payload' => '{"api_key":"random_key","distinct_id":"some-distinct-id","person_properties":{"distinct_id":"some-distinct-id","region":"USA","other":"thing"}}',
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),

--- a/test/FeatureFlagLocalEvaluationTest.php
+++ b/test/FeatureFlagLocalEvaluationTest.php
@@ -1214,12 +1214,13 @@ class FeatureFlagLocalEvaluationTest extends TestCase
 
     public function testFeatureFlagDefaultsComeIntoPlayOnlyWhenFlagsErrorsOut()
     {
+        $mockHttpClient = new MockedHttpClient("app.posthog.com", flagsEndpointResponse: null); // or configure to throw an exception
         $this->client = new Client(
             self::FAKE_API_KEY,
             [
                 "debug" => true,
             ],
-            null,
+            $mockHttpClient,
             null
         );
         PostHog::init(null, null, $this->client);

--- a/test/FeatureFlagLocalEvaluationTest.php
+++ b/test/FeatureFlagLocalEvaluationTest.php
@@ -1214,13 +1214,12 @@ class FeatureFlagLocalEvaluationTest extends TestCase
 
     public function testFeatureFlagDefaultsComeIntoPlayOnlyWhenFlagsErrorsOut()
     {
-        $mockHttpClient = new MockedHttpClient("app.posthog.com", flagsEndpointResponse: null); // or configure to throw an exception
         $this->client = new Client(
             self::FAKE_API_KEY,
             [
                 "debug" => true,
             ],
-            $mockHttpClient,
+            null,
             null
         );
         PostHog::init(null, null, $this->client);

--- a/test/FeatureFlagLocalEvaluationTest.php
+++ b/test/FeatureFlagLocalEvaluationTest.php
@@ -1176,7 +1176,7 @@ class FeatureFlagLocalEvaluationTest extends TestCase
 
     public function testFlagFallbackToDecide()
     {
-        $this->http_client = new MockedHttpClient(host: "app.posthog.com", flagEndpointResponse: MockedResponses::FALLBACK_TO_DECIDE_REQUEST);
+        $this->http_client = new MockedHttpClient(host: "app.posthog.com", flagEndpointResponse: MockedResponses::FALLBACK_TO_FLAGS_REQUEST);
         $this->client = new Client(
             self::FAKE_API_KEY,
             [
@@ -1195,7 +1195,7 @@ class FeatureFlagLocalEvaluationTest extends TestCase
 
     public function testFlagFallbackToDecideWithFalseFlag()
     {
-        $this->http_client = new MockedHttpClient(host: "app.posthog.com", flagEndpointResponse: MockedResponses::FALLBACK_TO_DECIDE_REQUEST);
+        $this->http_client = new MockedHttpClient(host: "app.posthog.com", flagEndpointResponse: MockedResponses::FALLBACK_TO_FLAGS_REQUEST);
         $this->client = new Client(
             self::FAKE_API_KEY,
             [
@@ -1378,7 +1378,7 @@ class FeatureFlagLocalEvaluationTest extends TestCase
 
     public function testFeatureFlagsDontFallbackToDecideWhenOnlyLocalEvaluationIsTrue()
     {
-        $this->http_client = new MockedHttpClient(host: "app.posthog.com", flagEndpointResponse: MockedResponses::FALLBACK_TO_DECIDE_REQUEST);
+        $this->http_client = new MockedHttpClient(host: "app.posthog.com", flagEndpointResponse: MockedResponses::FALLBACK_TO_FLAGS_REQUEST);
         $this->client = new Client(
             self::FAKE_API_KEY,
             [

--- a/test/FeatureFlagLocalEvaluationTest.php
+++ b/test/FeatureFlagLocalEvaluationTest.php
@@ -1607,7 +1607,7 @@ class FeatureFlagLocalEvaluationTest extends TestCase
             $this->http_client->calls,
             array(
                 0 => array(
-                    "path" => "/decide/?v=4",
+                    "path" => "/flags/?v=2",
                     'payload' => '{"api_key":"random_key","distinct_id":"some-distinct-id","person_properties":{"distinct_id":"some-distinct-id","region":"USA","other":"thing"}}',
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),

--- a/test/FeatureFlagTest.php
+++ b/test/FeatureFlagTest.php
@@ -20,10 +20,10 @@ class FeatureFlagTest extends TestCase
     private $http_client;
     private $client;
 
-    public function setUp($flagsEndpointResponse = MockedResponses::DECIDE_V3_RESPONSE, $personalApiKey = "test"): void
+    public function setUp($decideEndpointResponse = MockedResponses::DECIDE_V3_RESPONSE, $personalApiKey = "test"): void
     {
         date_default_timezone_set("UTC");
-        $this->http_client = new MockedHttpClient("app.posthog.com", flagsEndpointResponse: $flagsEndpointResponse);
+        $this->http_client = new MockedHttpClient("app.posthog.com", decideEndpointResponse: $decideEndpointResponse);        
         $this->client = new Client(
             self::FAKE_API_KEY,
             [

--- a/test/FeatureFlagTest.php
+++ b/test/FeatureFlagTest.php
@@ -23,7 +23,7 @@ class FeatureFlagTest extends TestCase
     public function setUp($decideEndpointResponse = MockedResponses::DECIDE_V3_RESPONSE, $personalApiKey = "test"): void
     {
         date_default_timezone_set("UTC");
-        $this->http_client = new MockedHttpClient("app.posthog.com", decideEndpointResponse: $decideEndpointResponse);        
+        $this->http_client = new MockedHttpClient("app.posthog.com", decideEndpointResponse: $decideEndpointResponse);
         $this->client = new Client(
             self::FAKE_API_KEY,
             [
@@ -70,7 +70,7 @@ class FeatureFlagTest extends TestCase
                     "requestOptions" => array(),
                 ),
                 1 => array(
-                    "path" => "/flags/?v=2",
+                    "path" => "/decide/?v=4",
                     "payload" => sprintf('{"api_key":"%s","distinct_id":"user-id","person_properties":{"distinct_id":"user-id"}}', self::FAKE_API_KEY),
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),
@@ -89,14 +89,14 @@ class FeatureFlagTest extends TestCase
                 $this->http_client->calls,
                 array(
                 0 => array(
-                    "path" => "/flags/?v=2",
+                    "path" => "/decide/?v=4",
                     "payload" => sprintf('{"api_key":"%s","distinct_id":"user-id","person_properties":{"distinct_id":"user-id"}}', self::FAKE_API_KEY),
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                         "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),
                     ),
                 1 => array(
                     "path" => "/batch/",
-                    "payload" => '{"batch":[{"properties":{"$active_feature_flags":[],"$feature_flag":"simple-test","$feature_flag_response":true,"$feature_flag_request_id":"98487c8a-287a-4451-a085-299cd76228dd","$feature_flag_id":6,"$feature_flag_version":1,"$feature_flag_reason":"Matched condition set 1","$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$groups":[]},"distinct_id":"user-id","event":"$feature_flag_called","$groups":[],"library":"posthog-php","library_version":"3.5.0","library_consumer":"LibCurl","groups":[],"timestamp":"2022-05-01T00:00:00+00:00","type":"capture"}],"api_key":"random_key"}',
+                    "payload" => '{"batch":[{"properties":{"$active_feature_flags":[],"$feature_flag":"simple-test","$feature_flag_response":true,"$feature_flag_request_id":"98487c8a-287a-4451-a085-299cd76228dd","$feature_flag_id":6,"$feature_flag_version":1,"$feature_flag_reason":"Matched condition set 1","$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$groups":[]},"distinct_id":"user-id","event":"$feature_flag_called","$groups":[],"library":"posthog-php","library_version":"3.4.0","library_consumer":"LibCurl","groups":[],"timestamp":"2022-05-01T00:00:00+00:00","type":"capture"}],"api_key":"random_key"}',
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array('shouldVerify' => true),
                     ),
@@ -123,7 +123,7 @@ class FeatureFlagTest extends TestCase
                     "requestOptions" => array(),
                 ),
                 1 => array(
-                    "path" => "/flags/?v=2",
+                    "path" => "/decide/?v=4",
                     "payload" => sprintf(
                         '{"api_key":"%s","distinct_id":"user-id","groups":{"company":"id:5"},"person_properties":{"distinct_id":"user-id"},"group_properties":{"company":{"$group_key":"id:5"}}}',
                         self::FAKE_API_KEY
@@ -152,7 +152,7 @@ class FeatureFlagTest extends TestCase
                     "requestOptions" => array(),
                 ),
                 1 => array(
-                    "path" => "/flags/?v=2",
+                    "path" => "/decide/?v=4",
                     "payload" => sprintf('{"api_key":"%s","distinct_id":"user-id","person_properties":{"distinct_id":"user-id"}}', self::FAKE_API_KEY),
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),
@@ -171,14 +171,14 @@ class FeatureFlagTest extends TestCase
                 $this->http_client->calls,
                 array(
                 0 => array(
-                    "path" => "/flags/?v=2",
+                    "path" => "/decide/?v=4",
                     "payload" => sprintf('{"api_key":"%s","distinct_id":"user-id","person_properties":{"distinct_id":"user-id"}}', self::FAKE_API_KEY),
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),
                 ),
                 1 => array(
                     "path" => "/batch/",
-                    "payload" => '{"batch":[{"properties":{"$active_feature_flags":[],"$feature_flag":"multivariate-test","$feature_flag_response":"variant-value","$feature_flag_request_id":"98487c8a-287a-4451-a085-299cd76228dd","$feature_flag_id":7,"$feature_flag_version":3,"$feature_flag_reason":"Matched condition set 2","$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$groups":[]},"distinct_id":"user-id","event":"$feature_flag_called","$groups":[],"library":"posthog-php","library_version":"3.5.0","library_consumer":"LibCurl","groups":[],"timestamp":"2022-05-01T00:00:00+00:00","type":"capture"}],"api_key":"random_key"}',
+                    "payload" => '{"batch":[{"properties":{"$active_feature_flags":[],"$feature_flag":"multivariate-test","$feature_flag_response":"variant-value","$feature_flag_request_id":"98487c8a-287a-4451-a085-299cd76228dd","$feature_flag_id":7,"$feature_flag_version":3,"$feature_flag_reason":"Matched condition set 2","$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$groups":[]},"distinct_id":"user-id","event":"$feature_flag_called","$groups":[],"library":"posthog-php","library_version":"3.4.0","library_consumer":"LibCurl","groups":[],"timestamp":"2022-05-01T00:00:00+00:00","type":"capture"}],"api_key":"random_key"}',
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array('shouldVerify' => true),
                 ),
@@ -219,7 +219,7 @@ class FeatureFlagTest extends TestCase
                     "requestOptions" => array(),
                 ),
                 1 => array(
-                    "path" => "/flags/?v=2",
+                    "path" => "/decide/?v=4",
                     "payload" => sprintf(
                         '{"api_key":"%s","distinct_id":"user-id","groups":{"company":"id:5"},"person_properties":{"distinct_id":"user-id"},"group_properties":{"company":{"$group_key":"id:5"}}}',
                         self::FAKE_API_KEY

--- a/test/FeatureFlagTest.php
+++ b/test/FeatureFlagTest.php
@@ -70,7 +70,7 @@ class FeatureFlagTest extends TestCase
                     "requestOptions" => array(),
                 ),
                 1 => array(
-                    "path" => "/decide/?v=4",
+                    "path" => "/flags/?v=2",
                     "payload" => sprintf('{"api_key":"%s","distinct_id":"user-id","person_properties":{"distinct_id":"user-id"}}', self::FAKE_API_KEY),
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),
@@ -89,7 +89,7 @@ class FeatureFlagTest extends TestCase
                 $this->http_client->calls,
                 array(
                 0 => array(
-                    "path" => "/decide/?v=4",
+                    "path" => "/flags/?v=2",
                     "payload" => sprintf('{"api_key":"%s","distinct_id":"user-id","person_properties":{"distinct_id":"user-id"}}', self::FAKE_API_KEY),
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                         "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),
@@ -123,7 +123,7 @@ class FeatureFlagTest extends TestCase
                     "requestOptions" => array(),
                 ),
                 1 => array(
-                    "path" => "/decide/?v=4",
+                    "path" => "/flags/?v=2",
                     "payload" => sprintf(
                         '{"api_key":"%s","distinct_id":"user-id","groups":{"company":"id:5"},"person_properties":{"distinct_id":"user-id"},"group_properties":{"company":{"$group_key":"id:5"}}}',
                         self::FAKE_API_KEY
@@ -152,7 +152,7 @@ class FeatureFlagTest extends TestCase
                     "requestOptions" => array(),
                 ),
                 1 => array(
-                    "path" => "/decide/?v=4",
+                    "path" => "/flags/?v=2",
                     "payload" => sprintf('{"api_key":"%s","distinct_id":"user-id","person_properties":{"distinct_id":"user-id"}}', self::FAKE_API_KEY),
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),
@@ -171,7 +171,7 @@ class FeatureFlagTest extends TestCase
                 $this->http_client->calls,
                 array(
                 0 => array(
-                    "path" => "/decide/?v=4",
+                    "path" => "/flags/?v=2",
                     "payload" => sprintf('{"api_key":"%s","distinct_id":"user-id","person_properties":{"distinct_id":"user-id"}}', self::FAKE_API_KEY),
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),
@@ -219,7 +219,7 @@ class FeatureFlagTest extends TestCase
                     "requestOptions" => array(),
                 ),
                 1 => array(
-                    "path" => "/decide/?v=4",
+                    "path" => "/flags/?v=2",
                     "payload" => sprintf(
                         '{"api_key":"%s","distinct_id":"user-id","groups":{"company":"id:5"},"person_properties":{"distinct_id":"user-id"},"group_properties":{"company":{"$group_key":"id:5"}}}',
                         self::FAKE_API_KEY

--- a/test/FeatureFlagTest.php
+++ b/test/FeatureFlagTest.php
@@ -96,7 +96,7 @@ class FeatureFlagTest extends TestCase
                     ),
                 1 => array(
                     "path" => "/batch/",
-                    "payload" => '{"batch":[{"properties":{"$active_feature_flags":[],"$feature_flag":"simple-test","$feature_flag_response":true,"$feature_flag_request_id":"98487c8a-287a-4451-a085-299cd76228dd","$feature_flag_id":6,"$feature_flag_version":1,"$feature_flag_reason":"Matched condition set 1","$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$groups":[]},"distinct_id":"user-id","event":"$feature_flag_called","$groups":[],"library":"posthog-php","library_version":"3.4.0","library_consumer":"LibCurl","groups":[],"timestamp":"2022-05-01T00:00:00+00:00","type":"capture"}],"api_key":"random_key"}',
+                    "payload" => '{"batch":[{"properties":{"$active_feature_flags":[],"$feature_flag":"simple-test","$feature_flag_response":true,"$feature_flag_request_id":"98487c8a-287a-4451-a085-299cd76228dd","$feature_flag_id":6,"$feature_flag_version":1,"$feature_flag_reason":"Matched condition set 1","$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$groups":[]},"distinct_id":"user-id","event":"$feature_flag_called","$groups":[],"library":"posthog-php","library_version":"3.5.0","library_consumer":"LibCurl","groups":[],"timestamp":"2022-05-01T00:00:00+00:00","type":"capture"}],"api_key":"random_key"}',
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array('shouldVerify' => true),
                     ),
@@ -178,7 +178,7 @@ class FeatureFlagTest extends TestCase
                 ),
                 1 => array(
                     "path" => "/batch/",
-                    "payload" => '{"batch":[{"properties":{"$active_feature_flags":[],"$feature_flag":"multivariate-test","$feature_flag_response":"variant-value","$feature_flag_request_id":"98487c8a-287a-4451-a085-299cd76228dd","$feature_flag_id":7,"$feature_flag_version":3,"$feature_flag_reason":"Matched condition set 2","$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$groups":[]},"distinct_id":"user-id","event":"$feature_flag_called","$groups":[],"library":"posthog-php","library_version":"3.4.0","library_consumer":"LibCurl","groups":[],"timestamp":"2022-05-01T00:00:00+00:00","type":"capture"}],"api_key":"random_key"}',
+                    "payload" => '{"batch":[{"properties":{"$active_feature_flags":[],"$feature_flag":"multivariate-test","$feature_flag_response":"variant-value","$feature_flag_request_id":"98487c8a-287a-4451-a085-299cd76228dd","$feature_flag_id":7,"$feature_flag_version":3,"$feature_flag_reason":"Matched condition set 2","$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$groups":[]},"distinct_id":"user-id","event":"$feature_flag_called","$groups":[],"library":"posthog-php","library_version":"3.5.0","library_consumer":"LibCurl","groups":[],"timestamp":"2022-05-01T00:00:00+00:00","type":"capture"}],"api_key":"random_key"}',
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array('shouldVerify' => true),
                 ),

--- a/test/FeatureFlagTest.php
+++ b/test/FeatureFlagTest.php
@@ -20,7 +20,7 @@ class FeatureFlagTest extends TestCase
     private $http_client;
     private $client;
 
-    public function setUp($flagsEndpointResponse = MockedResponses::DECIDE_V3_RESPONSE, $personalApiKey = "test"): void
+    public function setUp($flagsEndpointResponse = MockedResponses::FLAGS_RESPONSE, $personalApiKey = "test"): void
     {
         date_default_timezone_set("UTC");
         $this->http_client = new MockedHttpClient("app.posthog.com", flagsEndpointResponse: $flagsEndpointResponse);
@@ -48,8 +48,8 @@ class FeatureFlagTest extends TestCase
     public function decideResponseCases(): array
     {
         return [
-            'v3 response' => [MockedResponses::DECIDE_V3_RESPONSE],
-            'v4 response' => [MockedResponses::DECIDE_V4_RESPONSE]
+            'v3 response' => [MockedResponses::FLAGS_RESPONSE],
+            'v4 response' => [MockedResponses::FLAGS_V2_RESPONSE]
         ];
     }
 
@@ -82,7 +82,7 @@ class FeatureFlagTest extends TestCase
     public function testIsFeatureEnabledCapturesFeatureFlagCalledEventWithAdditionalMetadata()
     {
         ClockMock::executeAtFrozenDateTime(new \DateTime('2022-05-01'), function () {
-            $this->setUp(MockedResponses::DECIDE_V4_RESPONSE, personalApiKey: null);
+            $this->setUp(MockedResponses::FLAGS_V2_RESPONSE, personalApiKey: null);
             $this->assertTrue(PostHog::isFeatureEnabled('simple-test', 'user-id'));
             PostHog::flush();
             $this->assertEquals(
@@ -164,7 +164,7 @@ class FeatureFlagTest extends TestCase
     public function testGetFeatureFlagCapturesFeatureFlagCalledEventWithAdditionalMetadata()
     {
         ClockMock::executeAtFrozenDateTime(new \DateTime('2022-05-01'), function () {
-            $this->setUp(MockedResponses::DECIDE_V4_RESPONSE, personalApiKey: null);
+            $this->setUp(MockedResponses::FLAGS_V2_RESPONSE, personalApiKey: null);
             $this->assertEquals("variant-value", PostHog::getFeatureFlag('multivariate-test', 'user-id'));
             PostHog::flush();
             $this->assertEquals(

--- a/test/FeatureFlagTest.php
+++ b/test/FeatureFlagTest.php
@@ -96,7 +96,7 @@ class FeatureFlagTest extends TestCase
                     ),
                 1 => array(
                     "path" => "/batch/",
-                    "payload" => '{"batch":[{"properties":{"$active_feature_flags":[],"$feature_flag":"simple-test","$feature_flag_response":true,"$feature_flag_request_id":"98487c8a-287a-4451-a085-299cd76228dd","$feature_flag_id":6,"$feature_flag_version":1,"$feature_flag_reason":"Matched condition set 1","$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$groups":[]},"distinct_id":"user-id","event":"$feature_flag_called","$groups":[],"library":"posthog-php","library_version":"3.4.0","library_consumer":"LibCurl","groups":[],"timestamp":"2022-05-01T00:00:00+00:00","type":"capture"}],"api_key":"random_key"}',
+                    "payload" => '{"batch":[{"properties":{"$active_feature_flags":[],"$feature_flag":"simple-test","$feature_flag_response":true,"$feature_flag_request_id":"98487c8a-287a-4451-a085-299cd76228dd","$feature_flag_id":6,"$feature_flag_version":1,"$feature_flag_reason":"Matched condition set 1","$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$groups":[]},"distinct_id":"user-id","event":"$feature_flag_called","$groups":[],"library":"posthog-php","library_version":"' . PostHog::VERSION . '","library_consumer":"LibCurl","groups":[],"timestamp":"2022-05-01T00:00:00+00:00","type":"capture"}],"api_key":"random_key"}',
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array('shouldVerify' => true),
                     ),
@@ -178,7 +178,7 @@ class FeatureFlagTest extends TestCase
                 ),
                 1 => array(
                     "path" => "/batch/",
-                    "payload" => '{"batch":[{"properties":{"$active_feature_flags":[],"$feature_flag":"multivariate-test","$feature_flag_response":"variant-value","$feature_flag_request_id":"98487c8a-287a-4451-a085-299cd76228dd","$feature_flag_id":7,"$feature_flag_version":3,"$feature_flag_reason":"Matched condition set 2","$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$groups":[]},"distinct_id":"user-id","event":"$feature_flag_called","$groups":[],"library":"posthog-php","library_version":"3.4.0","library_consumer":"LibCurl","groups":[],"timestamp":"2022-05-01T00:00:00+00:00","type":"capture"}],"api_key":"random_key"}',
+                    "payload" => '{"batch":[{"properties":{"$active_feature_flags":[],"$feature_flag":"multivariate-test","$feature_flag_response":"variant-value","$feature_flag_request_id":"98487c8a-287a-4451-a085-299cd76228dd","$feature_flag_id":7,"$feature_flag_version":3,"$feature_flag_reason":"Matched condition set 2","$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$groups":[]},"distinct_id":"user-id","event":"$feature_flag_called","$groups":[],"library":"posthog-php","library_version":"' . PostHog::VERSION . '","library_consumer":"LibCurl","groups":[],"timestamp":"2022-05-01T00:00:00+00:00","type":"capture"}],"api_key":"random_key"}',
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array('shouldVerify' => true),
                 ),

--- a/test/FeatureFlagTest.php
+++ b/test/FeatureFlagTest.php
@@ -20,10 +20,10 @@ class FeatureFlagTest extends TestCase
     private $http_client;
     private $client;
 
-    public function setUp($decideEndpointResponse = MockedResponses::DECIDE_V3_RESPONSE, $personalApiKey = "test"): void
+    public function setUp($flagsEndpointResponse = MockedResponses::DECIDE_V3_RESPONSE, $personalApiKey = "test"): void
     {
         date_default_timezone_set("UTC");
-        $this->http_client = new MockedHttpClient("app.posthog.com", decideEndpointResponse: $decideEndpointResponse);
+        $this->http_client = new MockedHttpClient("app.posthog.com", flagsEndpointResponse: $flagsEndpointResponse);
         $this->client = new Client(
             self::FAKE_API_KEY,
             [
@@ -70,7 +70,7 @@ class FeatureFlagTest extends TestCase
                     "requestOptions" => array(),
                 ),
                 1 => array(
-                    "path" => "/decide/?v=4",
+                    "path" => "/flags/?v=2",
                     "payload" => sprintf('{"api_key":"%s","distinct_id":"user-id","person_properties":{"distinct_id":"user-id"}}', self::FAKE_API_KEY),
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),
@@ -89,7 +89,7 @@ class FeatureFlagTest extends TestCase
                 $this->http_client->calls,
                 array(
                 0 => array(
-                    "path" => "/decide/?v=4",
+                    "path" => "/flags/?v=2",
                     "payload" => sprintf('{"api_key":"%s","distinct_id":"user-id","person_properties":{"distinct_id":"user-id"}}', self::FAKE_API_KEY),
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                         "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),
@@ -123,7 +123,7 @@ class FeatureFlagTest extends TestCase
                     "requestOptions" => array(),
                 ),
                 1 => array(
-                    "path" => "/decide/?v=4",
+                    "path" => "/flags/?v=2",
                     "payload" => sprintf(
                         '{"api_key":"%s","distinct_id":"user-id","groups":{"company":"id:5"},"person_properties":{"distinct_id":"user-id"},"group_properties":{"company":{"$group_key":"id:5"}}}',
                         self::FAKE_API_KEY
@@ -152,7 +152,7 @@ class FeatureFlagTest extends TestCase
                     "requestOptions" => array(),
                 ),
                 1 => array(
-                    "path" => "/decide/?v=4",
+                    "path" => "/flags/?v=2",
                     "payload" => sprintf('{"api_key":"%s","distinct_id":"user-id","person_properties":{"distinct_id":"user-id"}}', self::FAKE_API_KEY),
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),
@@ -171,7 +171,7 @@ class FeatureFlagTest extends TestCase
                 $this->http_client->calls,
                 array(
                 0 => array(
-                    "path" => "/decide/?v=4",
+                    "path" => "/flags/?v=2",
                     "payload" => sprintf('{"api_key":"%s","distinct_id":"user-id","person_properties":{"distinct_id":"user-id"}}', self::FAKE_API_KEY),
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),
@@ -219,7 +219,7 @@ class FeatureFlagTest extends TestCase
                     "requestOptions" => array(),
                 ),
                 1 => array(
-                    "path" => "/decide/?v=4",
+                    "path" => "/flags/?v=2",
                     "payload" => sprintf(
                         '{"api_key":"%s","distinct_id":"user-id","groups":{"company":"id:5"},"person_properties":{"distinct_id":"user-id"},"group_properties":{"company":{"$group_key":"id:5"}}}',
                         self::FAKE_API_KEY

--- a/test/FeatureFlagTest.php
+++ b/test/FeatureFlagTest.php
@@ -20,10 +20,10 @@ class FeatureFlagTest extends TestCase
     private $http_client;
     private $client;
 
-    public function setUp($decideEndpointResponse = MockedResponses::DECIDE_V3_RESPONSE, $personalApiKey = "test"): void
+    public function setUp($flagsEndpointResponse = MockedResponses::DECIDE_V3_RESPONSE, $personalApiKey = "test"): void
     {
         date_default_timezone_set("UTC");
-        $this->http_client = new MockedHttpClient("app.posthog.com", decideEndpointResponse: $decideEndpointResponse);
+        $this->http_client = new MockedHttpClient("app.posthog.com", flagsEndpointResponse: $flagsEndpointResponse);
         $this->client = new Client(
             self::FAKE_API_KEY,
             [

--- a/test/MockedHttpClient.php
+++ b/test/MockedHttpClient.php
@@ -34,7 +34,7 @@ class MockedHttpClient extends \PostHog\HttpClient
             $curlTimeoutMilliseconds
         );
         $this->flagEndpointResponse = $flagEndpointResponse;
-        $this->flagsEndpointResponse = !empty($flagsEndpointResponse) ? $flagsEndpointResponse : MockedResponses::DECIDE_REQUEST;
+        $this->flagsEndpointResponse = !empty($flagsEndpointResponse) ? $flagsEndpointResponse : MockedResponses::FLAGS_REQUEST;
     }
 
     public function sendRequest(string $path, ?string $payload, array $extraHeaders = [], array $requestOptions = []): HttpResponse

--- a/test/MockedHttpClient.php
+++ b/test/MockedHttpClient.php
@@ -11,7 +11,7 @@ class MockedHttpClient extends \PostHog\HttpClient
     public $calls;
 
     private $flagEndpointResponse;
-    private $decideEndpointResponse;
+    private $flagsEndpointResponse;
 
     public function __construct(
         string $host,
@@ -22,7 +22,7 @@ class MockedHttpClient extends \PostHog\HttpClient
         ?Closure $errorHandler = null,
         int $curlTimeoutMilliseconds = 750,
         array $flagEndpointResponse = [],
-        array $decideEndpointResponse = []
+        array $flagsEndpointResponse = []
     ) {
         parent::__construct(
             $host,
@@ -34,7 +34,7 @@ class MockedHttpClient extends \PostHog\HttpClient
             $curlTimeoutMilliseconds
         );
         $this->flagEndpointResponse = $flagEndpointResponse;
-        $this->decideEndpointResponse = !empty($decideEndpointResponse) ? $decideEndpointResponse : MockedResponses::DECIDE_REQUEST;
+        $this->flagsEndpointResponse = !empty($flagsEndpointResponse) ? $flagsEndpointResponse : MockedResponses::DECIDE_REQUEST;
     }
 
     public function sendRequest(string $path, ?string $payload, array $extraHeaders = [], array $requestOptions = []): HttpResponse
@@ -44,8 +44,8 @@ class MockedHttpClient extends \PostHog\HttpClient
         }
         array_push($this->calls, array("path" => $path, "payload" => $payload, "extraHeaders" => $extraHeaders, "requestOptions" => $requestOptions));
 
-        if (str_starts_with($path, "/decide/")) {
-            return new HttpResponse(json_encode($this->decideEndpointResponse), 200);
+        if (str_starts_with($path, "/flags/")) {
+            return new HttpResponse(json_encode($this->flagsEndpointResponse), 200);
         }
 
         if (str_starts_with($path, "/api/feature_flag/local_evaluation")) {

--- a/test/MockedHttpClient.php
+++ b/test/MockedHttpClient.php
@@ -22,7 +22,7 @@ class MockedHttpClient extends \PostHog\HttpClient
         ?Closure $errorHandler = null,
         int $curlTimeoutMilliseconds = 750,
         array $flagEndpointResponse = [],
-        array $flagsEndpointResponse = []
+        array $decideEndpointResponse = []
     ) {
         parent::__construct(
             $host,
@@ -34,7 +34,7 @@ class MockedHttpClient extends \PostHog\HttpClient
             $curlTimeoutMilliseconds
         );
         $this->flagEndpointResponse = $flagEndpointResponse;
-        $this->flagsEndpointResponse = !empty($flagsEndpointResponse) ? $flagsEndpointResponse : MockedResponses::DECIDE_REQUEST;
+        $this->decideEndpointResponse = !empty($decideEndpointResponse) ? $decideEndpointResponse : MockedResponses::DECIDE_REQUEST;
     }
 
     public function sendRequest(string $path, ?string $payload, array $extraHeaders = [], array $requestOptions = []): HttpResponse

--- a/test/MockedHttpClient.php
+++ b/test/MockedHttpClient.php
@@ -22,7 +22,7 @@ class MockedHttpClient extends \PostHog\HttpClient
         ?Closure $errorHandler = null,
         int $curlTimeoutMilliseconds = 750,
         array $flagEndpointResponse = [],
-        array $decideEndpointResponse = []
+        array $flagsEndpointResponse = []
     ) {
         parent::__construct(
             $host,
@@ -34,7 +34,7 @@ class MockedHttpClient extends \PostHog\HttpClient
             $curlTimeoutMilliseconds
         );
         $this->flagEndpointResponse = $flagEndpointResponse;
-        $this->decideEndpointResponse = !empty($decideEndpointResponse) ? $decideEndpointResponse : MockedResponses::DECIDE_REQUEST;
+        $this->flagsEndpointResponse = !empty($flagsEndpointResponse) ? $flagsEndpointResponse : MockedResponses::DECIDE_REQUEST;
     }
 
     public function sendRequest(string $path, ?string $payload, array $extraHeaders = [], array $requestOptions = []): HttpResponse

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -117,7 +117,7 @@ class PostHogTest extends TestCase
                         "requestOptions" => array(),
                     ),
                     1 => array (
-                        "path" => "/decide/?v=4",
+                        "path" => "/flags/?v=2",
                         "payload" => sprintf('{"api_key":"%s","distinct_id":"john"}', self::FAKE_API_KEY),
                         "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                         "requestOptions" => array("timeout" => 1234, "shouldRetry" => false),
@@ -405,7 +405,7 @@ class PostHogTest extends TestCase
                     "requestOptions" => array(),
                 ),
                 1 => array(
-                    "path" => "/decide/?v=4",
+                    "path" => "/flags/?v=2",
                     "payload" => sprintf('{"api_key":"%s","distinct_id":"some_id","groups":{"company":"id:5","instance":"app.posthog.com"},"person_properties":{"distinct_id":"some_id","x1":"y1"},"group_properties":{"company":{"$group_key":"id:5","x":"y"},"instance":{"$group_key":"app.posthog.com"}}}', self::FAKE_API_KEY),
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),
@@ -427,7 +427,7 @@ class PostHogTest extends TestCase
             $this->http_client->calls,
             array(
                 0 => array(
-                    "path" => "/decide/?v=4",
+                    "path" => "/flags/?v=2",
                     "payload" => sprintf('{"api_key":"%s","distinct_id":"some_id","groups":{"company":"id:5","instance":"app.posthog.com"},"person_properties":{"distinct_id":"override"},"group_properties":{"company":{"$group_key":"group_override"},"instance":{"$group_key":"app.posthog.com"}}}', self::FAKE_API_KEY),
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),
@@ -443,7 +443,7 @@ class PostHogTest extends TestCase
             $this->http_client->calls,
             array(
                 0 => array(
-                    "path" => "/decide/?v=4",
+                    "path" => "/flags/?v=2",
                     "payload" => sprintf('{"api_key":"%s","distinct_id":"some_id","groups":{"company":"id:5"},"person_properties":{"distinct_id":"some_id"},"group_properties":{"company":{"$group_key":"id:5"}}}', self::FAKE_API_KEY),
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),
@@ -459,7 +459,7 @@ class PostHogTest extends TestCase
             $this->http_client->calls,
             array(
                 0 => array(
-                    "path" => "/decide/?v=4",
+                    "path" => "/flags/?v=2",
                     "payload" => sprintf('{"api_key":"%s","distinct_id":"some_id","groups":{"company":"id:5","instance":"app.posthog.com"},"person_properties":{"distinct_id":"some_id","x1":"y1"},"group_properties":{"company":{"$group_key":"id:5","x":"y"},"instance":{"$group_key":"app.posthog.com"}}}', self::FAKE_API_KEY),
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),

--- a/test/assests/MockedResponses.php
+++ b/test/assests/MockedResponses.php
@@ -4,7 +4,7 @@ namespace PostHog\Test\Assets;
 
 class MockedResponses
 {
-    public const DECIDE_REQUEST = [
+    public const FLAGS_REQUEST = [
         'config' => [
             'enable_collect_everything' => true,
         ],
@@ -36,18 +36,7 @@ class MockedResponses
         'sessionRecording' => false,
     ];
 
-    public const DECIDE_V3_RESPONSE = [
-        'config' => [
-            'enable_collect_everything' => true,
-        ],
-        'editorParams' => [
-        ],
-        'isAuthenticated' => false,
-        'supportedCompression' => [
-            0 => 'gzip',
-            1 => 'gzip-js',
-            2 => 'lz64',
-        ],
+    public const FLAGS_RESPONSE = [
         'featureFlags' => [
             'simpleFlag' => true,
             'having_fun' => false,
@@ -79,10 +68,9 @@ class MockedResponses
             'string-payload' => '"A String"',
             'array-payload' => '[1, 2, 3]',
         ],
-        'sessionRecording' => false,
     ];
 
-    public const DECIDE_V4_RESPONSE = [
+    public const FLAGS_V2_RESPONSE = [
         'config' => [
             'enable_collect_everything' => true,
         ],
@@ -1089,7 +1077,7 @@ class MockedResponses
         ],
     ];
 
-    public const FALLBACK_TO_DECIDE_REQUEST = [
+    public const FALLBACK_TO_FLAGS_REQUEST = [
         'count' => 1,
         'next' => null,
         'previous' => null,


### PR DESCRIPTION
update PHP SDK to use the new /flags endpoint instead of the legacy /decide one.