### PR TITLE
fix(flags): fallback to API for multi-condition flags with static cohorts

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -256,6 +256,8 @@ class Client
                         $personProperties,
                         $groupProperties
                     );
+                } catch (RequiresServerEvaluationException $e) {
+                    $result = null;
                 } catch (InconclusiveMatchException $e) {
                     $result = null;
                 } catch (Exception $e) {
@@ -387,6 +389,8 @@ class Client
                         $personProperties,
                         $groupProperties
                     );
+                } catch (RequiresServerEvaluationException $e) {
+                    $fallbackToFlags = true;
                 } catch (InconclusiveMatchException $e) {
                     $fallbackToFlags = true;
                 } catch (Exception $e) {

--- a/lib/RequiresServerEvaluationException.php
+++ b/lib/RequiresServerEvaluationException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace PostHog;
+
+use Exception;
+
+class RequiresServerEvaluationException extends Exception
+{
+    public function errorMessage()
+    {
+        $errorMsg = 'Error on line ' . $this->getLine() . ' in ' . $this->getFile() . ': <b> Requires Server Evaluation:' . $this->getMessage() . '</b>'; //phpcs:ignore
+        return $errorMsg;
+    }
+}

--- a/test/assests/MockedResponses.php
+++ b/test/assests/MockedResponses.php
@@ -1429,4 +1429,100 @@ class MockedResponses
             ],
         ]
     ];
+
+    public const LOCAL_EVALUATION_WITH_STATIC_COHORT = [
+        'flags' => [
+            [
+                'id' => 1,
+                'key' => 'multi-condition-flag',
+                'filters' => [
+                    'groups' => [
+                        [
+                            'properties' => [
+                                [
+                                    'key' => 'id',
+                                    'value' => 999,
+                                    'type' => 'cohort'
+                                ]
+                            ],
+                            'rollout_percentage' => 100,
+                            'variant' => 'set-1'
+                        ],
+                        [
+                            'properties' => [
+                                [
+                                    'key' => '$geoip_country_code',
+                                    'operator' => 'exact',
+                                    'value' => ['DE'],
+                                    'type' => 'person'
+                                ]
+                            ],
+                            'rollout_percentage' => 100,
+                            'variant' => 'set-8'
+                        ]
+                    ],
+                    'multivariate' => [
+                        'variants' => [
+                            ['key' => 'set-1', 'rollout_percentage' => 50],
+                            ['key' => 'set-8', 'rollout_percentage' => 50]
+                        ]
+                    ],
+                    'payloads' => [
+                        'set-1' => '{"message": "local-payload-1"}',
+                        'set-8' => '{"message": "local-payload-8"}'
+                    ]
+                ],
+                'active' => true,
+                'is_simple_flag' => false
+            ]
+        ],
+        'cohorts' => []
+    ];
+
+    public const FLAGS_WITH_STATIC_COHORT_RESPONSE = [
+        'featureFlags' => [
+            'multi-condition-flag' => 'set-1'
+        ],
+        'featureFlagPayloads' => [
+            'multi-condition-flag' => '{"message": "from-api"}'
+        ]
+    ];
+
+    public const LOCAL_EVALUATION_WITH_STATIC_COHORT_FOR_PAYLOAD = [
+        'flags' => [
+            [
+                'id' => 2,
+                'key' => 'flag-with-payload',
+                'filters' => [
+                    'groups' => [
+                        [
+                            'properties' => [
+                                [
+                                    'key' => 'id',
+                                    'value' => 999,
+                                    'type' => 'cohort'
+                                ]
+                            ],
+                            'rollout_percentage' => 100
+                        ]
+                    ],
+                    'payloads' => [
+                        'true' => '{"message": "local-payload"}'
+                    ]
+                ],
+                'active' => true,
+                'is_simple_flag' => false
+            ]
+        ],
+        'cohorts' => []
+    ];
+
+    public const FLAGS_WITH_STATIC_COHORT_PAYLOAD_RESPONSE = [
+        'featureFlags' => [
+            'flag-with-payload' => true
+        ],
+        'featureFlagPayloads' => [
+            'flag-with-payload' => '{"message": "from-api"}'
+        ]
+    ];
 }


### PR DESCRIPTION
When a feature flag has multiple conditions and one contains a static cohort, the SDK should fallback to API for the entire flag evaluation instead of skipping the static cohort condition and evaluating subsequent conditions locally. This prevents returning incorrect variants when later conditions match locally but the user is actually in the static cohort.

Changes:
- Introduce RequiresServerEvaluationException class to distinguish missing server-side data (static cohorts, experience continuity) from evaluation errors (bad regex, invalid dates, missing properties)
- Update matchCohort() to throw RequiresServerEvaluationException when cohort not found in local cohorts
- Propagate RequiresServerEvaluationException immediately in matchPropertyGroup() and matchFeatureFlagProperties()
- Catch RequiresServerEvaluationException in getFeatureFlag(), getAllFlags(), and getFeatureFlagPayload() to trigger API fallback
- Add test cases validating multi-condition flags with static cohorts fall back to API and return correct variants and payloads

Follows same pattern as Ruby SDK fix: PostHog/posthog-ruby#80