### PR TITLE
feat: Cut a new GH release when deploying new version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ release:
 	@node -e "var fs = require('fs'), pkg = require('./composer'); pkg.version = '${VERSION}'; fs.writeFileSync('./composer.json', JSON.stringify(pkg, null, '\t'));"
 	@git changelog -t ${VERSION}
 	@git release ${VERSION}
+	@gh release create ${VERSION} --generate-notes 
 
 clean:
 	rm -rf \

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,9 +1,14 @@
-Releasing
-=========
+# Releasing
 
- 1. Make sure you have `make`, `git`, and [`git-extras`](https://github.com/tj/git-extras) installed.
- 1. Run `VERSION=X.Y.Z make release` (where X.Y.Z is the new version).
+1.  Make sure you have `make`, `git`, [`git-extras`](https://github.com/tj/git-extras), and [`gh`](https://cli.github.com/) (GitHub CLI) installed.
+2.  Make sure you're authenticated with GitHub CLI: `gh auth login`
+3.  Run `VERSION=X.Y.Z make release` (where X.Y.Z is the new version).
 
- That's it! Composer will pick up the new tag and you can see the latest version at https://packagist.org/packages/posthog/posthog-php.
+That's it! The release process will:
 
- An entry will also be made to `History.md` with a list of commits since last release.
+- Update the version in `lib/PostHog.php` and `composer.json`
+- Create a changelog entry in `History.md` with a list of commits since last release
+- Create and push a git tag
+- Create a GitHub release with the changelog notes
+
+Composer will pick up the new tag and you can see the latest version at https://packagist.org/packages/posthog/posthog-php.


### PR DESCRIPTION
I wanna standardize how the SDK doctor finds releases, so let's make sure we're publishing a GH release here