### PR TITLE
Wrong code to capture an event an assign it to a group

### DIFF
--- a/example.php
+++ b/example.php
@@ -146,7 +146,7 @@ function identifyAndCaptureExamples()
             'property1' => 'value',
             'property2' => 'value',
         ],
-        'groups' => ['company' => 'id:5']
+        '$groups' => ['company' => 'id:5']
     ]);
 
     // Add properties to the person


### PR DESCRIPTION
The `$` is missing in this code example. 

In addition the assignment of 'id:5' is misleading. First I thought this `id:` is mandatory, but in fact, you have to add here the identifier of your group, which could be a string or integer.