### PR TITLE
feat: add captureException() for error tracking

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -79,6 +79,11 @@ class Client
     private $flagsEtag;
 
     /**
+     * @var int
+     */
+    private $exceptionSourceContextLines;
+
+    /**
      * @var bool
      */
     private $debug;
@@ -113,6 +118,7 @@ class Client
             (int) ($options['timeout'] ?? 10000)
         );
         $this->featureFlagsRequestTimeout = (int) ($options['feature_flag_request_timeout_ms'] ?? 3000);
+        $this->exceptionSourceContextLines = (int) ($options['exception_source_context_lines'] ?? 5);
         $this->featureFlags = [];
         $this->groupTypeMapping = [];
         $this->cohorts = [];
@@ -176,6 +182,62 @@ class Client
 
 
         return $this->consumer->capture($message);
+    }
+
+    /**
+     * Captures an exception as a PostHog error tracking event.
+     *
+     * @param \Throwable $exception The exception to capture
+     * @param string|null $distinctId User distinct ID. If null, generates a UUID and disables person processing.
+     * @param array $properties Additional properties to include with the event
+     * @param bool $handled Whether the exception was handled by the application
+     * @return bool whether the capture call succeeded
+     */
+    public function captureException(
+        \Throwable $exception,
+        ?string $distinctId = null,
+        array $properties = [],
+        bool $handled = true
+    ): bool {
+        $exceptionList = ExceptionUtils::buildExceptionList($exception, $this->exceptionSourceContextLines);
+
+        // Set handled flag on the outermost exception (first entry)
+        if (!empty($exceptionList)) {
+            $exceptionList[0]['mechanism']['handled'] = $handled;
+        }
+
+        $properties = array_merge($properties, [
+            '$exception_list' => $exceptionList,
+        ]);
+
+        $captureMessage = [
+            'event' => '$exception',
+            'properties' => $properties,
+        ];
+
+        if ($distinctId !== null) {
+            $captureMessage['distinct_id'] = $distinctId;
+        } else {
+            // Generate anonymous distinct ID and disable person processing
+            $captureMessage['distinct_id'] = self::generateUuidV4();
+            $captureMessage['properties']['$process_person_profile'] = false;
+        }
+
+        return $this->capture($captureMessage);
+    }
+
+    /**
+     * Generate a UUID v4 string.
+     *
+     * @return string
+     */
+    private static function generateUuidV4(): string
+    {
+        $data = random_bytes(16);
+        $data[6] = chr(ord($data[6]) & 0x0f | 0x40); // Version 4
+        $data[8] = chr(ord($data[8]) & 0x3f | 0x80); // Variant 1
+
+        return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($data), 4));
     }
 
     /**

--- a/lib/ExceptionUtils.php
+++ b/lib/ExceptionUtils.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace PostHog;
+
+class ExceptionUtils
+{
+    /**
+     * Build the $exception_list payload from a Throwable.
+     *
+     * Walks the getPrevious() chain to produce a flat list
+     * (outermost first, root cause last).
+     *
+     * @param \Throwable $exception
+     * @param int $sourceContextLines Number of source lines to include around each frame (0 to disable)
+     * @return array
+     */
+    public static function buildExceptionList(\Throwable $exception, int $sourceContextLines = 5): array
+    {
+        // Collect all exceptions in the chain (outermost first)
+        $exceptions = [];
+        $current = $exception;
+        while ($current !== null) {
+            $exceptions[] = $current;
+            $current = $current->getPrevious();
+        }
+
+        $isChained = count($exceptions) > 1;
+        $result = [];
+
+        foreach ($exceptions as $index => $exc) {
+            $entry = [
+                'type' => get_class($exc),
+                'value' => $exc->getMessage(),
+                'mechanism' => [
+                    'type' => $isChained && $index > 0 ? 'chained' : 'generic',
+                    'handled' => true,
+                ],
+                'stacktrace' => [
+                    'type' => 'raw',
+                    'frames' => self::buildFrames($exc, $sourceContextLines),
+                ],
+            ];
+
+            if ($isChained) {
+                $entry['mechanism']['exception_id'] = $index;
+                if ($index > 0) {
+                    $entry['mechanism']['parent_id'] = $index - 1;
+                    $entry['mechanism']['source'] = 'getPrevious()';
+                }
+            }
+
+            $result[] = $entry;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Build frames from a Throwable's trace.
+     *
+     * Returns frames in oldest-first order. Appends the throw location
+     * as the final frame since PHP's getTrace() omits it.
+     *
+     * @param \Throwable $exception
+     * @param int $sourceContextLines
+     * @return array
+     */
+    public static function buildFrames(\Throwable $exception, int $sourceContextLines): array
+    {
+        $trace = $exception->getTrace();
+        $frames = [];
+
+        // getTrace() returns newest-first; reverse to get oldest-first
+        foreach (array_reverse($trace) as $traceEntry) {
+            $frames[] = self::buildFrame($traceEntry, $sourceContextLines);
+        }
+
+        // Append the throw location as the final frame
+        if ($exception->getFile()) {
+            $frames[] = self::buildFrame([
+                'file' => $exception->getFile(),
+                'line' => $exception->getLine(),
+            ], $sourceContextLines);
+        }
+
+        return $frames;
+    }
+
+    /**
+     * Build a single frame from a trace entry.
+     *
+     * @param array $frame A single trace entry from getTrace() or a synthetic entry
+     * @param int $sourceContextLines
+     * @return array
+     */
+    public static function buildFrame(array $frame, int $sourceContextLines): array
+    {
+        $filename = $frame['file'] ?? '[internal]';
+        $lineno = $frame['line'] ?? 0;
+
+        // Build function name, prefixing with class if present
+        $function = $frame['function'] ?? null;
+        if (!empty($frame['class'])) {
+            $type = $frame['type'] ?? '->'; // -> for instance, :: for static
+            $function = $frame['class'] . $type . $function;
+        }
+
+        $result = [
+            'filename' => $filename,
+            'lineno' => $lineno,
+            'platform' => 'php',
+            'in_app' => self::isInApp($filename),
+        ];
+
+        if ($function !== null) {
+            $result['function'] = $function;
+        }
+
+        // Add source context if enabled and file is readable
+        if ($sourceContextLines > 0 && $filename !== '[internal]' && $lineno > 0) {
+            $lines = @file($filename);
+            if ($lines !== false) {
+                $lineIndex = $lineno - 1; // Convert to 0-indexed
+
+                if (isset($lines[$lineIndex])) {
+                    $result['context_line'] = rtrim($lines[$lineIndex], "\r\n");
+                }
+
+                // pre_context
+                $preStart = max(0, $lineIndex - $sourceContextLines);
+                $preContext = [];
+                for ($i = $preStart; $i < $lineIndex; $i++) {
+                    if (isset($lines[$i])) {
+                        $preContext[] = rtrim($lines[$i], "\r\n");
+                    }
+                }
+                $result['pre_context'] = $preContext;
+
+                // post_context
+                $postEnd = min(count($lines), $lineIndex + 1 + $sourceContextLines);
+                $postContext = [];
+                for ($i = $lineIndex + 1; $i < $postEnd; $i++) {
+                    if (isset($lines[$i])) {
+                        $postContext[] = rtrim($lines[$i], "\r\n");
+                    }
+                }
+                $result['post_context'] = $postContext;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Determine if a frame is "in app" code.
+     *
+     * Returns false for [internal] and paths containing /vendor/.
+     *
+     * @param string $filename
+     * @return bool
+     */
+    public static function isInApp(string $filename): bool
+    {
+        if ($filename === '[internal]') {
+            return false;
+        }
+
+        if (str_contains($filename, '/vendor/')) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -62,6 +62,27 @@ class PostHog
     }
 
     /**
+     * Captures an exception as a PostHog error tracking event.
+     *
+     * @param \Throwable $exception The exception to capture
+     * @param string|null $distinctId User distinct ID. If null, generates a UUID and disables person processing.
+     * @param array $properties Additional properties to include with the event
+     * @param bool $handled Whether the exception was handled by the application
+     * @return bool whether the capture call succeeded
+     * @throws Exception
+     */
+    public static function captureException(
+        \Throwable $exception,
+        ?string $distinctId = null,
+        array $properties = [],
+        bool $handled = true
+    ): bool {
+        self::checkClient();
+
+        return self::$client->captureException($exception, $distinctId, $properties, $handled);
+    }
+
+    /**
      * Tags properties about the user.
      *
      * @param array $message

--- a/test/ExceptionTest.php
+++ b/test/ExceptionTest.php
@@ -1,0 +1,448 @@
+<?php
+
+namespace PostHog\Test;
+
+require_once 'test/error_log_mock.php';
+
+use Error;
+use Exception;
+use PHPUnit\Framework\TestCase;
+use PostHog\Client;
+use PostHog\ExceptionUtils;
+use PostHog\PostHog;
+
+class ExceptionTest extends TestCase
+{
+    use ClockMockTrait;
+
+    const FAKE_API_KEY = "random_key";
+
+    private MockedHttpClient $http_client;
+    private Client $client;
+
+    public function setUp(): void
+    {
+        date_default_timezone_set("UTC");
+        $this->http_client = new MockedHttpClient("app.posthog.com");
+        // Don't pass personalAPIKey to avoid loadFlags() call in constructor
+        $this->client = new Client(
+            self::FAKE_API_KEY,
+            [
+                "debug" => true,
+            ],
+            $this->http_client,
+        );
+        PostHog::init(null, null, $this->client);
+
+        global $errorMessages;
+        $errorMessages = [];
+    }
+
+    /**
+     * Helper to get the batch payload from the last HTTP call.
+     */
+    private function getLastBatchPayload(): array
+    {
+        $lastCall = end($this->http_client->calls);
+        return json_decode($lastCall["payload"], true);
+    }
+
+    public function testBasicCaptureException(): void
+    {
+        $this->executeAtFrozenDateTime(new \DateTime('2024-01-01'), function () {
+            $exception = new Exception("Something went wrong");
+
+            $result = $this->client->captureException($exception, "user-123");
+            $this->assertTrue($result);
+
+            $this->client->flush();
+
+            $payload = $this->getLastBatchPayload();
+            $batch = $payload["batch"];
+            $this->assertCount(1, $batch);
+
+            $event = $batch[0];
+            $this->assertEquals('$exception', $event["event"]);
+            $this->assertEquals('user-123', $event["distinct_id"]);
+
+            $exceptionList = $event["properties"]['$exception_list'];
+            $this->assertCount(1, $exceptionList);
+
+            $entry = $exceptionList[0];
+            $this->assertEquals('Exception', $entry["type"]);
+            $this->assertEquals("Something went wrong", $entry["value"]);
+            $this->assertEquals('generic', $entry["mechanism"]["type"]);
+            $this->assertTrue($entry["mechanism"]["handled"]);
+            $this->assertArrayHasKey('frames', $entry["stacktrace"]);
+            $this->assertEquals('raw', $entry["stacktrace"]["type"]);
+        });
+    }
+
+    public function testChainedExceptions(): void
+    {
+        $this->executeAtFrozenDateTime(new \DateTime('2024-01-01'), function () {
+            $root = new Exception("Root cause");
+            $outer = new Exception("Outer error", 0, $root);
+
+            $this->client->captureException($outer, "user-123");
+            $this->client->flush();
+
+            $payload = $this->getLastBatchPayload();
+            $exceptionList = $payload["batch"][0]["properties"]['$exception_list'];
+
+            // Should have 2 entries: outermost first, root cause last
+            $this->assertCount(2, $exceptionList);
+
+            // Outermost exception (index 0)
+            $this->assertEquals("Outer error", $exceptionList[0]["value"]);
+            $this->assertEquals('generic', $exceptionList[0]["mechanism"]["type"]);
+            $this->assertEquals(0, $exceptionList[0]["mechanism"]["exception_id"]);
+            $this->assertArrayNotHasKey('parent_id', $exceptionList[0]["mechanism"]);
+
+            // Root cause (index 1)
+            $this->assertEquals("Root cause", $exceptionList[1]["value"]);
+            $this->assertEquals('chained', $exceptionList[1]["mechanism"]["type"]);
+            $this->assertEquals(1, $exceptionList[1]["mechanism"]["exception_id"]);
+            $this->assertEquals(0, $exceptionList[1]["mechanism"]["parent_id"]);
+            $this->assertEquals('getPrevious()', $exceptionList[1]["mechanism"]["source"]);
+        });
+    }
+
+    public function testAnonymousDistinctId(): void
+    {
+        $this->executeAtFrozenDateTime(new \DateTime('2024-01-01'), function () {
+            $exception = new Exception("Anonymous error");
+
+            $this->client->captureException($exception);
+            $this->client->flush();
+
+            $payload = $this->getLastBatchPayload();
+            $event = $payload["batch"][0];
+
+            // Should have a non-empty distinct_id (UUID)
+            $this->assertNotEmpty($event["distinct_id"]);
+            // Should match UUID v4 format
+            $this->assertMatchesRegularExpression(
+                '/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
+                $event["distinct_id"]
+            );
+            // Should disable person processing
+            $this->assertFalse($event["properties"]['$process_person_profile']);
+        });
+    }
+
+    public function testHandledFalse(): void
+    {
+        $this->executeAtFrozenDateTime(new \DateTime('2024-01-01'), function () {
+            $exception = new Exception("Unhandled error");
+
+            $this->client->captureException($exception, "user-123", [], false);
+            $this->client->flush();
+
+            $payload = $this->getLastBatchPayload();
+            $exceptionList = $payload["batch"][0]["properties"]['$exception_list'];
+
+            $this->assertFalse($exceptionList[0]["mechanism"]["handled"]);
+        });
+    }
+
+    public function testFrameOrderingOldestFirst(): void
+    {
+        // Create an exception with a real stack trace
+        $exception = $this->createNestedExceptionForTest();
+
+        $exceptionList = ExceptionUtils::buildExceptionList($exception);
+        $frames = $exceptionList[0]["stacktrace"]["frames"];
+
+        $this->assertNotEmpty($frames);
+
+        // The last frame should be the throw location (this test file)
+        $lastFrame = end($frames);
+        $this->assertStringContainsString('ExceptionTest.php', $lastFrame["filename"]);
+    }
+
+    public function testInAppDetection(): void
+    {
+        // App path should be in_app
+        $this->assertTrue(ExceptionUtils::isInApp('/app/src/MyClass.php'));
+
+        // Vendor path should NOT be in_app
+        $this->assertFalse(ExceptionUtils::isInApp('/app/vendor/some/package/File.php'));
+
+        // Internal should NOT be in_app
+        $this->assertFalse(ExceptionUtils::isInApp('[internal]'));
+    }
+
+    public function testSourceContextDisabled(): void
+    {
+        $exception = new Exception("No context");
+
+        $exceptionList = ExceptionUtils::buildExceptionList($exception, 0);
+        $frames = $exceptionList[0]["stacktrace"]["frames"];
+
+        foreach ($frames as $frame) {
+            $this->assertArrayNotHasKey('context_line', $frame);
+            $this->assertArrayNotHasKey('pre_context', $frame);
+            $this->assertArrayNotHasKey('post_context', $frame);
+        }
+    }
+
+    public function testSourceContextPresent(): void
+    {
+        // Create exception that references this file (which is readable)
+        $exception = new Exception("Context test");
+
+        $exceptionList = ExceptionUtils::buildExceptionList($exception, 3);
+        $frames = $exceptionList[0]["stacktrace"]["frames"];
+
+        // Find the frame for this file (the throw location, should be last)
+        $thisFileFrame = null;
+        foreach ($frames as $frame) {
+            if (str_contains($frame['filename'], 'ExceptionTest.php')) {
+                $thisFileFrame = $frame;
+                break;
+            }
+        }
+
+        $this->assertNotNull($thisFileFrame, 'Should find a frame from this test file');
+        $this->assertArrayHasKey('context_line', $thisFileFrame);
+        $this->assertArrayHasKey('pre_context', $thisFileFrame);
+        $this->assertArrayHasKey('post_context', $thisFileFrame);
+        $this->assertNotEmpty($thisFileFrame['context_line']);
+        $this->assertIsArray($thisFileFrame['pre_context']);
+        $this->assertIsArray($thisFileFrame['post_context']);
+    }
+
+    public function testSourceContextLinesOption(): void
+    {
+        $this->executeAtFrozenDateTime(new \DateTime('2024-01-01'), function () {
+            $httpClient = new MockedHttpClient("app.posthog.com");
+            $client = new Client(
+                self::FAKE_API_KEY,
+                [
+                    "debug" => true,
+                    "exception_source_context_lines" => 0,
+                ],
+                $httpClient,
+            );
+
+            $exception = new Exception("No context from option");
+            $client->captureException($exception, "user-123");
+            $client->flush();
+
+            $lastCall = end($httpClient->calls);
+            $payload = json_decode($lastCall["payload"], true);
+            $frames = $payload["batch"][0]["properties"]['$exception_list'][0]["stacktrace"]["frames"];
+
+            foreach ($frames as $frame) {
+                $this->assertArrayNotHasKey('context_line', $frame);
+                $this->assertArrayNotHasKey('pre_context', $frame);
+                $this->assertArrayNotHasKey('post_context', $frame);
+            }
+        });
+    }
+
+    public function testPhpError(): void
+    {
+        $this->executeAtFrozenDateTime(new \DateTime('2024-01-01'), function () {
+            // PHP \Error is also a Throwable
+            $error = new Error("Type error occurred");
+
+            $result = $this->client->captureException($error, "user-123");
+            $this->assertTrue($result);
+
+            $this->client->flush();
+
+            $payload = $this->getLastBatchPayload();
+            $exceptionList = $payload["batch"][0]["properties"]['$exception_list'];
+
+            $this->assertCount(1, $exceptionList);
+            $this->assertEquals('Error', $exceptionList[0]["type"]);
+            $this->assertEquals("Type error occurred", $exceptionList[0]["value"]);
+        });
+    }
+
+    public function testStaticFacade(): void
+    {
+        $this->executeAtFrozenDateTime(new \DateTime('2024-01-01'), function () {
+            $exception = new Exception("Facade test");
+
+            $result = PostHog::captureException($exception, "user-456");
+            $this->assertTrue($result);
+
+            PostHog::flush();
+
+            $payload = $this->getLastBatchPayload();
+            $event = $payload["batch"][0];
+
+            $this->assertEquals('$exception', $event["event"]);
+            $this->assertEquals('user-456', $event["distinct_id"]);
+            $this->assertEquals('Exception', $event["properties"]['$exception_list'][0]["type"]);
+        });
+    }
+
+    public function testAdditionalProperties(): void
+    {
+        $this->executeAtFrozenDateTime(new \DateTime('2024-01-01'), function () {
+            $exception = new Exception("With props");
+
+            $this->client->captureException($exception, "user-123", [
+                'environment' => 'production',
+                'release' => 'v1.2.3',
+            ]);
+            $this->client->flush();
+
+            $payload = $this->getLastBatchPayload();
+            $props = $payload["batch"][0]["properties"];
+
+            $this->assertEquals('production', $props['environment']);
+            $this->assertEquals('v1.2.3', $props['release']);
+            $this->assertArrayHasKey('$exception_list', $props);
+        });
+    }
+
+    public function testFrameFunction(): void
+    {
+        // Test building a frame with class and instance method
+        $frame = ExceptionUtils::buildFrame([
+            'file' => '/app/src/MyClass.php',
+            'line' => 42,
+            'class' => 'App\\MyClass',
+            'type' => '->',
+            'function' => 'doSomething',
+        ], 0);
+
+        $this->assertEquals('App\\MyClass->doSomething', $frame['function']);
+        $this->assertEquals('/app/src/MyClass.php', $frame['filename']);
+        $this->assertEquals(42, $frame['lineno']);
+        $this->assertEquals('php', $frame['platform']);
+        $this->assertTrue($frame['in_app']);
+    }
+
+    public function testFrameStaticMethod(): void
+    {
+        $frame = ExceptionUtils::buildFrame([
+            'file' => '/app/src/MyClass.php',
+            'line' => 10,
+            'class' => 'App\\MyClass',
+            'type' => '::',
+            'function' => 'staticMethod',
+        ], 0);
+
+        $this->assertEquals('App\\MyClass::staticMethod', $frame['function']);
+    }
+
+    public function testFrameInternalFunction(): void
+    {
+        // Internal PHP functions have no file/line
+        $frame = ExceptionUtils::buildFrame([
+            'function' => 'array_map',
+        ], 0);
+
+        $this->assertEquals('[internal]', $frame['filename']);
+        $this->assertEquals(0, $frame['lineno']);
+        $this->assertEquals('array_map', $frame['function']);
+        $this->assertFalse($frame['in_app']);
+    }
+
+    public function testFrameVendorPath(): void
+    {
+        $frame = ExceptionUtils::buildFrame([
+            'file' => '/app/vendor/guzzle/guzzle/src/Client.php',
+            'line' => 100,
+            'class' => 'GuzzleHttp\\Client',
+            'type' => '->',
+            'function' => 'send',
+        ], 0);
+
+        $this->assertFalse($frame['in_app']);
+    }
+
+    public function testThreeDeepChain(): void
+    {
+        $root = new Exception("Database error");
+        $middle = new Exception("Repository failed", 0, $root);
+        $outer = new Exception("Controller error", 0, $middle);
+
+        $exceptionList = ExceptionUtils::buildExceptionList($outer);
+
+        $this->assertCount(3, $exceptionList);
+
+        // Outermost first
+        $this->assertEquals("Controller error", $exceptionList[0]["value"]);
+        $this->assertEquals(0, $exceptionList[0]["mechanism"]["exception_id"]);
+        $this->assertArrayNotHasKey('parent_id', $exceptionList[0]["mechanism"]);
+
+        // Middle
+        $this->assertEquals("Repository failed", $exceptionList[1]["value"]);
+        $this->assertEquals(1, $exceptionList[1]["mechanism"]["exception_id"]);
+        $this->assertEquals(0, $exceptionList[1]["mechanism"]["parent_id"]);
+
+        // Root cause last
+        $this->assertEquals("Database error", $exceptionList[2]["value"]);
+        $this->assertEquals(2, $exceptionList[2]["mechanism"]["exception_id"]);
+        $this->assertEquals(1, $exceptionList[2]["mechanism"]["parent_id"]);
+    }
+
+    public function testLibraryProperties(): void
+    {
+        $this->executeAtFrozenDateTime(new \DateTime('2024-01-01'), function () {
+            $exception = new Exception("Test");
+            $this->client->captureException($exception, "user-123");
+            $this->client->flush();
+
+            $payload = $this->getLastBatchPayload();
+            $event = $payload["batch"][0];
+
+            // Standard PostHog library properties should be present
+            $this->assertEquals('posthog-php', $event["properties"]['$lib']);
+            $this->assertArrayHasKey('$lib_version', $event["properties"]);
+        });
+    }
+
+    public function testHandledTrueByDefault(): void
+    {
+        $exception = new Exception("Handled by default");
+        $exceptionList = ExceptionUtils::buildExceptionList($exception);
+
+        // Default mechanism.handled should be true
+        $this->assertTrue($exceptionList[0]["mechanism"]["handled"]);
+    }
+
+    public function testChainedHandledFlagOnOutermost(): void
+    {
+        $this->executeAtFrozenDateTime(new \DateTime('2024-01-01'), function () {
+            $root = new Exception("Root");
+            $outer = new Exception("Outer", 0, $root);
+
+            $this->client->captureException($outer, "user-123", [], false);
+            $this->client->flush();
+
+            $payload = $this->getLastBatchPayload();
+            $exceptionList = $payload["batch"][0]["properties"]['$exception_list'];
+
+            // handled=false should only be on the outermost exception
+            $this->assertFalse($exceptionList[0]["mechanism"]["handled"]);
+            // Inner exceptions keep default handled=true
+            $this->assertTrue($exceptionList[1]["mechanism"]["handled"]);
+        });
+    }
+
+    /**
+     * Helper to create an exception with a deeper call stack for frame ordering tests.
+     */
+    private function createNestedExceptionForTest(): Exception
+    {
+        return $this->helperLevel1();
+    }
+
+    private function helperLevel1(): Exception
+    {
+        return $this->helperLevel2();
+    }
+
+    private function helperLevel2(): Exception
+    {
+        return new Exception("Nested test");
+    }
+}


### PR DESCRIPTION
## Summary

Adds `captureException()` to the PHP SDK, enabling PHP applications to send exceptions to PostHog's error tracking — matching the existing Python and Node SDK implementations.

- **New `ExceptionUtils` class** — converts `\Throwable` to `$exception_list` payload with stack frames, source context, and chained exception support
- **`Client::captureException()`** — captures exceptions as `$exception` events with configurable source context lines
- **`PostHog::captureException()`** — static facade for the same functionality
- **Anonymous capture** — when no `distinctId` is provided, generates a UUID v4 and sets `$process_person_profile: false`

### Key design decisions

- **No fingerprint generation** — PostHog backend handles grouping (matches Python/Node)
- **No autocapture** (`set_exception_handler`) — keeping initial PR scoped to manual capture; autocapture can follow in a separate PR
- **No `args` in frames** — PHP trace includes function args but they can contain sensitive data and blow batch size limits
- **`platform: "php"`** — matches Python's `"python"` and Node's `"node:javascript"` convention
- **Source context default 5 lines** — matches Python SDK; configurable via `exception_source_context_lines` option (0 to disable)
- **Outermost-first ordering** — chained exceptions are listed with outermost first, root cause last

### Usage

```php
// With distinct ID
PostHog::captureException($exception, 'user-123');

// Anonymous (generates UUID, disables person processing)
PostHog::captureException($exception);

// With additional properties
PostHog::captureException($exception, 'user-123', [
    'environment' => 'production',
    'release' => 'v1.2.3',
]);

// Unhandled exception
PostHog::captureException($exception, 'user-123', [], false);

// Disable source context
PostHog::init('your-api-key', [
    'exception_source_context_lines' => 0,
]);
```

## Test plan

- [x] 20 new tests covering: basic capture, chained exceptions, anonymous IDs, handled/unhandled, frame ordering, in_app detection, source context on/off, PHP `\Error` support, static facade, additional properties, 3-deep chains
- [x] All 175 existing tests pass (zero regressions)

Closes https://github.com/PostHog/posthog/issues/31076

🤖 Generated with [Claude Code](https://claude.com/claude-code)