### PR TITLE
chore: update branch references to main

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: 'CodeQL Advanced'
 
 on:
   push:
-    branches: ['master']
+    branches: ['main']
   pull_request:
-    branches: ['master']
+    branches: ['main']
   schedule:
     - cron: '32 13 * * 1'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: "Release"
 on:
   pull_request:
     types: [closed]
-    branches: [master]
+    branches: [main]
 
 permissions:
   contents: read
@@ -18,7 +18,7 @@ jobs:
   check-release-label:
     name: Check for release label
     runs-on: ubuntu-latest
-    # Run when PR with 'release' label is merged to master, or when manually triggered
+    # Run when PR with 'release' label is merged to main, or when manually triggered
     if: |
       github.event.pull_request.merged == true
        && contains(github.event.pull_request.labels.*.name, 'release')
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          ref: master
+          ref: main
           fetch-depth: 0
 
       - name: Check release conditions
@@ -93,7 +93,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          ref: master
+          ref: main
           fetch-depth: 0
           token: ${{ steps.releaser.outputs.token }}
 
@@ -140,7 +140,7 @@ jobs:
         with:
           commit_message: "chore: bump version to ${{ steps.bump-version.outputs.new_version }} [version bump]"
           repo: ${{ github.repository }}
-          branch: master
+          branch: main
           file_pattern: "lib/PostHog.php composer.json CHANGELOG.md"
         env:
           GITHUB_TOKEN: ${{ steps.releaser.outputs.token }}
@@ -153,7 +153,7 @@ jobs:
         run: |
           LAST_CHANGELOG_ENTRY=$(awk -v defText="see CHANGELOG.md" '/^## /{if (flag) exit; flag=1} flag && /^##$/{exit} flag; END{if (!flag) print defText}' CHANGELOG.md)
           gh release create "$NEW_VERSION" \
-            --target master \
+            --target main \
             --title "$NEW_VERSION" \
             --notes "$LAST_CHANGELOG_ENTRY"
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing
 
-Releases are semi-automated via GitHub Actions. When a PR with the `release` and a version bump label is merged to `master`, the release workflow is triggered.
+Releases are semi-automated via GitHub Actions. When a PR with the `release` and a version bump label is merged to `main`, the release workflow is triggered.
 
 You'll need an approval from a PostHog engineer. If you're an employee, you can see the request in the [#approvals-client-libraries](https://app.slack.com/client/TSS5W8YQZ/C0A3UEVDDNF) channel.
 
@@ -9,7 +9,7 @@ You'll need an approval from a PostHog engineer. If you're an employee, you can 
 1. **Create your PR** with the changes you want to release
 2. **Add the `release` label** to the PR
 3. **Add a version bump label** that should be either `bump-patch`, `bump-minor` or `bump-major`
-4. **Merge the PR** to `master`
+4. **Merge the PR** to `main`
 
 Once merged, the following happens automatically:
 
@@ -17,7 +17,7 @@ Once merged, the following happens automatically:
 2. A maintainer approves the release in the GitHub `Release` environment
 3. The version is bumped in `lib/PostHog.php` and `composer.json` based on the version label (`patch`, `minor`, or `major`, extracted from the label)
 4. The `CHANGELOG.md` is updated with a link to the full changelog
-5. Changes are committed and pushed to `master`
+5. Changes are committed and pushed to `main`
 6. A git tag is created (e.g., `v1.8.0`)
 7. A GitHub release is created with the changelog content
 8. Slack is notified of the successful release


### PR DESCRIPTION
## :bulb: Motivation and Context
This repo was still using `master` as the default branch. This updates the workflow and release references that still pointed at `master` so the repository can use `main` consistently.

## :green_heart: How did you test it?
- Ran `git diff --check`
- Searched the repo for remaining branch-name references with `rg '\bmaster\b'`

## :pencil: Checklist
- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Added the `release` label to the PR
- [ ] Added exactly one version bump label: `bump-patch`, `bump-minor`, or `bump-major`