### PR TITLE
chore: use engineering@posthog.com in package metadata

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 	"license": "MIT",
 	"authors": [
 		{
-			"name": "PostHog <hey@posthog.com>",
+			"name": "PostHog <engineering@posthog.com>",
 			"homepage": "https://posthog.com/"
 		}
 	],


### PR DESCRIPTION
## :bulb: Motivation and Context

Composer metadata still uses `hey@posthog.com` as the package author contact. This updates the published package metadata to use the shared `engineering@posthog.com` address instead.

## :green_heart: How did you test it?

- Verified `composer.json` now uses `engineering@posthog.com`
- Confirmed there are no other non-`engineering@posthog.com` `@posthog.com` addresses in package metadata files in this repo

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Added the `release` label to the PR
- [ ] Added exactly one version bump label: `bump-patch`, `bump-minor`, or `bump-major`
