### PR TITLE
docs: add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributing
+
+Thanks for your interest in improving the PostHog PHP SDK.
+
+## Development setup
+
+1. Install [PHP](https://www.php.net/manual/en/install.php) and [Composer](https://getcomposer.org/download/).
+2. Install dependencies:
+
+   ```bash
+   php composer.phar update
+   ```
+
+3. Run the test suite:
+
+   ```bash
+   bin/test
+   ```
+
+   This script runs `./vendor/bin/phpunit --verbose test`.
+
+## Pull requests
+
+Please follow the existing project conventions and include tests when you change behavior.

--- a/README.md
+++ b/README.md
@@ -63,9 +63,7 @@ Auto error tracking is off by default. When enabled, the SDK chains existing exc
 
 ## Contributing
 
-1. [Download PHP](https://www.php.net/manual/en/install.php) and [Composer](https://getcomposer.org/download/)
-2. `php composer.phar update` to install dependencies
-3. `bin/test` to run tests (this script calls `./vendor/bin/phpunit --verbose test`)
+See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup and test instructions.
 
 ## Releasing
 


### PR DESCRIPTION
## :bulb: Motivation and Context

The local development instructions in this repo lived in the main README.

This PR moves them into a dedicated `CONTRIBUTING.md` so contributors have a consistent place to find setup and test commands.

## :green_heart: How did you test it?

- Not run (docs-only changes)
- Checked the updated markdown links and file locations

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Added the `release` label to the PR
- [ ] Added exactly one version bump label: `bump-patch`, `bump-minor`, or `bump-major`
