### PR TITLE
test: make testLoadFeatureFlagsWrongKey deterministic

### DIFF
--- a/test/FeatureFlagLocalEvaluationTest.php
+++ b/test/FeatureFlagLocalEvaluationTest.php
@@ -1326,12 +1326,16 @@ class FeatureFlagLocalEvaluationTest extends TestCase
     public function testLoadFeatureFlagsWrongKey()
     {
         self::expectException(Exception::class);
+        $this->http_client = new MockedHttpClient(
+            host: "app.posthog.com",
+            flagEndpointResponse: ["detail" => "Invalid personal API key."]
+        );
         $this->client = new Client(
             self::FAKE_API_KEY,
             [
                 "debug" => true,
             ],
-            null,
+            $this->http_client,
             self::FAKE_API_KEY
         );
         PostHog::init(null, null, $this->client);


### PR DESCRIPTION
Previously relied on a live HTTPS request with a fake personal API key and expected the real server to return a response that triggered an exception. That is flaky: network reachability and server behavior vary across CI runs. Mock the local_evaluation endpoint to return a payload with a "detail" key so loadFlags() always throws.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Added the `release` label to the PR
- [ ] Added exactly one version bump label: `bump-patch`, `bump-minor`, or `bump-major`

<!-- For more details check RELEASING.md -->
