### PR TITLE
feat: add evaluateFlags() API for single-call flag evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Unreleased
+
+* feat(flags): Add `evaluateFlags()` API for single-call flag evaluation. Returns a
+  `FeatureFlagEvaluations` snapshot you can read repeatedly without further `/flags` requests; pass
+  it to `capture()` via the new `flags` key to attach `$feature/<key>` and `$active_feature_flags`
+  on the captured event without an extra round trip.
+* fix(flags): `SizeLimitedHash::contains()` and `add()` were storing entries on the outer map and
+  comparing values to keys, so the per-distinct_id `$feature_flag_called` dedup never matched after
+  the first event. Both helpers now operate on a per-key set as intended.
+
 ## 4.0.1 - 2026-02-06
 
 * [Full Changelog](https://github.com/PostHog/posthog-php/compare/4.0.0...4.0.1)

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -11,7 +11,7 @@ use Symfony\Component\Clock\Clock;
 
 const SIZE_LIMIT = 50_000;
 
-class Client
+class Client implements FeatureFlagEvaluationsHost
 {
     private const CONSUMERS = [
         "socket" => Socket::class,
@@ -84,6 +84,11 @@ class Client
     private $debug;
 
     /**
+     * @var bool Whether to surface non-fatal warnings from feature flag helpers.
+     */
+    private $featureFlagsLogWarnings;
+
+    /**
      * Create a new posthog object with your app's API key
      * key
      *
@@ -113,6 +118,7 @@ class Client
             (int) ($options['timeout'] ?? 10000)
         );
         $this->featureFlagsRequestTimeout = (int) ($options['feature_flag_request_timeout_ms'] ?? 3000);
+        $this->featureFlagsLogWarnings = (bool) ($options['feature_flags_log_warnings'] ?? true);
         $this->featureFlags = [];
         $this->groupTypeMapping = [];
         $this->cohorts = [];
@@ -143,6 +149,9 @@ class Client
      */
     public function capture(array $message)
     {
+        $flagsSnapshot = $message["flags"] ?? null;
+        unset($message["flags"]);
+
         $message = $this->message($message);
         $message["type"] = "capture";
 
@@ -150,7 +159,14 @@ class Client
             $message["properties"]['$groups'] = $message['$groups'];
         }
 
-        if (array_key_exists("send_feature_flags", $message) && $message["send_feature_flags"]) {
+        if ($flagsSnapshot instanceof FeatureFlagEvaluations) {
+            // The snapshot already has every flag value cached. No /flags request, no override of
+            // properties already set on the event.
+            $message["properties"] = array_merge(
+                $flagsSnapshot->getEventProperties(),
+                $message["properties"]
+            );
+        } elseif (array_key_exists("send_feature_flags", $message) && $message["send_feature_flags"]) {
             $extraProperties = [];
             $flags = [];
 
@@ -386,7 +402,7 @@ class Client
             }
         }
 
-        if ($sendFeatureFlagEvents && !$this->distinctIdsFeatureFlagsReported->contains($key, $distinctId)) {
+        if ($sendFeatureFlagEvents) {
             $properties = [
                 '$feature_flag' => $key,
                 '$feature_flag_response' => $result,
@@ -410,13 +426,7 @@ class Client
                 $properties['$feature_flag_error'] = $featureFlagError;
             }
 
-            $this->capture([
-                "properties" => $properties,
-                "distinct_id" => $distinctId,
-                "event" => '$feature_flag_called',
-                '$groups' => $groups
-            ]);
-            $this->distinctIdsFeatureFlagsReported->add($key, $distinctId);
+            $this->captureFlagCalledIfNeeded($distinctId, $key, $properties, $groups);
         }
 
         if (is_null($result)) {
@@ -521,6 +531,184 @@ class Client
         }
 
         return $response;
+    }
+
+    /**
+     * Evaluate every feature flag for a distinct id in a single round trip and return a
+     * FeatureFlagEvaluations snapshot. Reads on the snapshot do not trigger additional /flags
+     * requests; access via isEnabled() or getFlag() fires a deduped $feature_flag_called event the
+     * first time each key is touched.
+     *
+     * @param array<string, mixed> $groups
+     * @param array<string, mixed> $personProperties
+     * @param array<string, array<string, mixed>> $groupProperties
+     * @param list<string>|null $flagKeys When set, scope the underlying /flags request to these keys.
+     */
+    public function evaluateFlags(
+        string $distinctId,
+        array $groups = [],
+        array $personProperties = [],
+        array $groupProperties = [],
+        bool $onlyEvaluateLocally = false,
+        bool $disableGeoip = false,
+        ?array $flagKeys = null
+    ): FeatureFlagEvaluations {
+        if ($distinctId === '') {
+            return new FeatureFlagEvaluations(
+                $distinctId,
+                [],
+                $groups,
+                $this,
+                null,
+                $this->featureFlagsLogWarnings,
+            );
+        }
+
+        [$personProperties, $groupProperties] = $this->addLocalPersonAndGroupProperties(
+            $distinctId,
+            $groups,
+            $personProperties,
+            $groupProperties
+        );
+
+        $records = [];
+
+        // Local pass: try to resolve any flag we can without going to the server.
+        foreach ($this->featureFlags as $flag) {
+            $key = $flag['key'] ?? null;
+            if (!is_string($key) || $key === '') {
+                continue;
+            }
+
+            if ($flagKeys !== null && !in_array($key, $flagKeys, true)) {
+                continue;
+            }
+
+            try {
+                $value = $this->computeFlagLocally(
+                    $flag,
+                    $distinctId,
+                    $groups,
+                    $personProperties,
+                    $groupProperties
+                );
+            } catch (RequiresServerEvaluationException $e) {
+                continue;
+            } catch (InconclusiveMatchException $e) {
+                continue;
+            } catch (Exception $e) {
+                error_log("[PostHog][Client] Error while computing variant: " . $e->getMessage());
+                continue;
+            }
+
+            $variant = is_string($value) ? $value : null;
+            $enabled = is_string($value) ? true : (bool) $value;
+            $id = isset($flag['id']) ? (int) $flag['id'] : null;
+
+            $records[$key] = new EvaluatedFlagRecord(
+                key: $key,
+                enabled: $enabled,
+                variant: $variant,
+                payload: null,
+                id: $id,
+                version: null,
+                reason: 'Evaluated locally',
+                locallyEvaluated: true,
+            );
+        }
+
+        $requestId = null;
+
+        if (!$onlyEvaluateLocally) {
+            try {
+                $response = $this->flags(
+                    $distinctId,
+                    $groups,
+                    $personProperties,
+                    $groupProperties,
+                    $disableGeoip,
+                    $flagKeys
+                );
+
+                $requestId = $response['requestId'] ?? null;
+                $remoteFlags = $response['flags'] ?? [];
+
+                foreach ($remoteFlags as $key => $flagDetail) {
+                    if (!is_string($key) || $key === '' || isset($records[$key])) {
+                        continue;
+                    }
+                    if (!is_array($flagDetail) || ($flagDetail['failed'] ?? false)) {
+                        continue;
+                    }
+
+                    $variant = $flagDetail['variant'] ?? null;
+                    $enabled = (bool) ($flagDetail['enabled'] ?? false);
+                    $rawPayload = $flagDetail['metadata']['payload'] ?? null;
+                    $payload = $rawPayload !== null ? json_decode($rawPayload, true) : null;
+
+                    $records[$key] = new EvaluatedFlagRecord(
+                        key: $key,
+                        enabled: $enabled,
+                        variant: is_string($variant) ? $variant : null,
+                        payload: $payload,
+                        id: isset($flagDetail['metadata']['id'])
+                            ? (int) $flagDetail['metadata']['id']
+                            : null,
+                        version: isset($flagDetail['metadata']['version'])
+                            ? (int) $flagDetail['metadata']['version']
+                            : null,
+                        reason: $flagDetail['reason']['description'] ?? null,
+                        locallyEvaluated: false,
+                    );
+                }
+            } catch (Exception $e) {
+                error_log("[PostHog][Client] Unable to evaluate flags: " . $e->getMessage());
+            }
+        }
+
+        return new FeatureFlagEvaluations(
+            $distinctId,
+            $records,
+            $groups,
+            $this,
+            $requestId,
+            $this->featureFlagsLogWarnings,
+        );
+    }
+
+    /**
+     * Fire a $feature_flag_called event the first time a (flag key, distinct id) pair is seen by
+     * this Client, deduped via the per-distinct_id cache shared with every other flag-reading code
+     * path. Properties are built by the caller so each call site can shape the payload to match its
+     * available metadata.
+     *
+     * @param array<string, mixed> $properties
+     * @param array<string, mixed> $groups
+     */
+    public function captureFlagCalledIfNeeded(
+        string $distinctId,
+        string $key,
+        array $properties,
+        array $groups = []
+    ): void {
+        if ($this->distinctIdsFeatureFlagsReported->contains($key, $distinctId)) {
+            return;
+        }
+
+        $this->capture([
+            'properties' => $properties,
+            'distinct_id' => $distinctId,
+            'event' => '$feature_flag_called',
+            '$groups' => $groups,
+        ]);
+        $this->distinctIdsFeatureFlagsReported->add($key, $distinctId);
+    }
+
+    public function logWarning(string $message): void
+    {
+        if ($this->featureFlagsLogWarnings) {
+            error_log("[PostHog][Client] " . $message);
+        }
     }
 
     private function computeFlagLocally(
@@ -757,7 +945,9 @@ class Client
         string $distinctId,
         array $groups = array(),
         array $personProperties = [],
-        array $groupProperties = []
+        array $groupProperties = [],
+        bool $disableGeoip = false,
+        ?array $flagKeys = null
     ): array {
         $payload = array(
             'api_key' => $this->apiKey,
@@ -774,6 +964,14 @@ class Client
 
         if (!empty($groupProperties)) {
             $payload["group_properties"] = $groupProperties;
+        }
+
+        if ($disableGeoip) {
+            $payload["geoip_disable"] = true;
+        }
+
+        if ($flagKeys !== null) {
+            $payload["flag_keys_to_evaluate"] = array_values($flagKeys);
         }
 
         $httpResponse = $this->httpClient->sendRequest(

--- a/lib/EvaluatedFlagRecord.php
+++ b/lib/EvaluatedFlagRecord.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace PostHog;
+
+/**
+ * Immutable per-flag entry stored on a FeatureFlagEvaluations snapshot.
+ */
+final class EvaluatedFlagRecord
+{
+    public function __construct(
+        public readonly string $key,
+        public readonly bool $enabled,
+        public readonly ?string $variant,
+        public readonly mixed $payload,
+        public readonly ?int $id,
+        public readonly ?int $version,
+        public readonly ?string $reason,
+        public readonly bool $locallyEvaluated,
+    ) {
+    }
+
+    /**
+     * The value as $feature_flag_response would render it: variant string when set, otherwise the enabled bool.
+     */
+    public function getValue(): bool|string
+    {
+        return $this->variant ?? $this->enabled;
+    }
+}

--- a/lib/FeatureFlagEvaluations.php
+++ b/lib/FeatureFlagEvaluations.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace PostHog;
+
+/**
+ * Snapshot of feature flag evaluations for a single distinct id.
+ *
+ * Created by Client::evaluateFlags(), this object lets callers read flag values, check enablement,
+ * and pull payloads without paying additional /flags requests. Reads via isEnabled() and getFlag()
+ * record access and trigger a deduped $feature_flag_called event; getFlagPayload() is silent.
+ */
+class FeatureFlagEvaluations
+{
+    /** @var array<string, bool> */
+    private array $accessed;
+
+    /**
+     * @param array<string, EvaluatedFlagRecord> $flags
+     * @param array<string, mixed> $groups
+     */
+    public function __construct(
+        private readonly string $distinctId,
+        private readonly array $flags,
+        private readonly array $groups,
+        private readonly FeatureFlagEvaluationsHost $host,
+        private readonly ?string $requestId = null,
+        private readonly bool $logWarnings = true,
+        ?array $accessed = null,
+    ) {
+        $this->accessed = $accessed ?? [];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getKeys(): array
+    {
+        return array_keys($this->flags);
+    }
+
+    /**
+     * Whether the flag is enabled for the snapshot's distinct id. Returns false for unknown keys.
+     */
+    public function isEnabled(string $key): bool
+    {
+        $record = $this->flags[$key] ?? null;
+        $this->recordAccess($key, $record);
+
+        return $record?->enabled ?? false;
+    }
+
+    /**
+     * Returns the variant (string), enabled state (bool), or null for unknown keys.
+     */
+    public function getFlag(string $key): bool|string|null
+    {
+        $record = $this->flags[$key] ?? null;
+        $this->recordAccess($key, $record);
+
+        if ($record === null) {
+            return null;
+        }
+
+        return $record->getValue();
+    }
+
+    /**
+     * Returns the decoded payload for a flag without recording access or firing a $feature_flag_called event.
+     * Returns null for unknown keys or flags without a payload.
+     */
+    public function getFlagPayload(string $key): mixed
+    {
+        return $this->flags[$key]->payload ?? null;
+    }
+
+    /**
+     * Returns a clone of this snapshot containing only flags that were previously accessed via
+     * isEnabled() or getFlag(). When nothing has been accessed yet, logs a warning and returns a
+     * full clone so callers don't silently emit empty $feature/* property bags.
+     */
+    public function onlyAccessed(): self
+    {
+        if (count($this->accessed) === 0) {
+            $this->emitWarning(
+                'FeatureFlagEvaluations::onlyAccessed() called before any flag was accessed; returning all flags.'
+            );
+
+            return $this->cloneWith($this->flags);
+        }
+
+        $filtered = [];
+        foreach ($this->accessed as $key => $_) {
+            if (isset($this->flags[$key])) {
+                $filtered[$key] = $this->flags[$key];
+            }
+        }
+
+        return $this->cloneWith($filtered);
+    }
+
+    /**
+     * Returns a clone of this snapshot filtered to the given keys. Unknown keys are dropped with a
+     * warning so silent typos don't slip into captured events.
+     *
+     * @param list<string> $keys
+     */
+    public function only(array $keys): self
+    {
+        $filtered = [];
+        foreach ($keys as $key) {
+            if (isset($this->flags[$key])) {
+                $filtered[$key] = $this->flags[$key];
+            } else {
+                $this->emitWarning(
+                    sprintf('FeatureFlagEvaluations::only() dropped unknown flag key "%s".', $key)
+                );
+            }
+        }
+
+        return $this->cloneWith($filtered);
+    }
+
+    /**
+     * Properties to merge onto a captured event when it carries this snapshot. Adds $feature/<key>
+     * for every flag and a sorted $active_feature_flags list for enabled flags.
+     *
+     * @return array<string, mixed>
+     */
+    public function getEventProperties(): array
+    {
+        $properties = [];
+        $active = [];
+        foreach ($this->flags as $key => $record) {
+            $properties['$feature/' . $key] = $record->getValue();
+            if ($record->enabled) {
+                $active[] = $key;
+            }
+        }
+        sort($active);
+        $properties['$active_feature_flags'] = $active;
+
+        return $properties;
+    }
+
+    /**
+     * Records that $key was accessed and fires a deduped $feature_flag_called event when the
+     * snapshot is bound to a real distinct id. Empty distinct ids short-circuit so we never leak
+     * events with an empty actor.
+     */
+    private function recordAccess(string $key, ?EvaluatedFlagRecord $record): void
+    {
+        $this->accessed[$key] = true;
+
+        if ($this->distinctId === '') {
+            return;
+        }
+
+        $properties = [
+            '$feature_flag' => $key,
+            '$feature_flag_response' => $record?->getValue() ?? false,
+        ];
+
+        if ($record === null) {
+            $properties['$feature_flag_error'] = FeatureFlagError::FLAG_MISSING;
+        } else {
+            if ($record->id !== null) {
+                $properties['$feature_flag_id'] = $record->id;
+            }
+            if ($record->version !== null) {
+                $properties['$feature_flag_version'] = $record->version;
+            }
+            if ($record->reason !== null) {
+                $properties['$feature_flag_reason'] = $record->reason;
+            }
+            if ($record->locallyEvaluated) {
+                $properties['locally_evaluated'] = true;
+            }
+        }
+
+        // request_id is per /flags response; locally-evaluated records aren't tied to a remote
+        // call so we omit it for them, matching the existing single-flag local path.
+        if ($this->requestId !== null && !($record?->locallyEvaluated ?? false)) {
+            $properties['$feature_flag_request_id'] = $this->requestId;
+        }
+
+        $this->host->captureFlagCalledIfNeeded(
+            $this->distinctId,
+            $key,
+            $properties,
+            $this->groups
+        );
+    }
+
+    /**
+     * @param array<string, EvaluatedFlagRecord> $flags
+     */
+    private function cloneWith(array $flags): self
+    {
+        // Filtered views start with an empty access set so reads on the child don't propagate back
+        // into the parent's view. PHP's value-copy semantics on arrays already give us isolation.
+        return new self(
+            $this->distinctId,
+            $flags,
+            $this->groups,
+            $this->host,
+            $this->requestId,
+            $this->logWarnings,
+            [],
+        );
+    }
+
+    private function emitWarning(string $message): void
+    {
+        if ($this->logWarnings) {
+            $this->host->logWarning($message);
+        }
+    }
+}

--- a/lib/FeatureFlagEvaluationsHost.php
+++ b/lib/FeatureFlagEvaluationsHost.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace PostHog;
+
+/**
+ * Narrow callback surface that FeatureFlagEvaluations uses to interact with its owning Client.
+ *
+ * Splitting the interface out keeps the snapshot easy to unit-test with a fake host instead of a
+ * full Client.
+ */
+interface FeatureFlagEvaluationsHost
+{
+    /**
+     * Fire a $feature_flag_called event for ($distinctId, $key) unless it has already been recorded
+     * for this distinct id within the dedup window.
+     *
+     * The properties array is built by the caller so this helper does not need to reconstruct the
+     * shape from raw response data.
+     *
+     * @param array<string, mixed> $properties
+     * @param array<string, mixed> $groups
+     */
+    public function captureFlagCalledIfNeeded(
+        string $distinctId,
+        string $key,
+        array $properties,
+        array $groups
+    ): void;
+
+    /**
+     * Emit a non-fatal warning. Implementations may suppress these when feature_flags_log_warnings
+     * is disabled in the client configuration.
+     */
+    public function logWarning(string $message): void;
+}

--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -235,6 +235,38 @@ class PostHog
     }
 
     /**
+     * Evaluate every feature flag for a distinct id in a single round trip and return a snapshot.
+     * Pass the snapshot to capture() via the `flags` key to attach $feature/<key> properties
+     * without making another /flags request.
+     *
+     * @param array $groups
+     * @param array $personProperties
+     * @param array $groupProperties
+     * @param list<string>|null $flagKeys When set, scope the underlying /flags request to these keys.
+     * @throws Exception
+     */
+    public static function evaluateFlags(
+        string $distinctId,
+        array $groups = array(),
+        array $personProperties = array(),
+        array $groupProperties = array(),
+        bool $onlyEvaluateLocally = false,
+        bool $disableGeoip = false,
+        ?array $flagKeys = null
+    ): FeatureFlagEvaluations {
+        self::checkClient();
+        return self::$client->evaluateFlags(
+            $distinctId,
+            $groups,
+            $personProperties,
+            $groupProperties,
+            $onlyEvaluateLocally,
+            $disableGeoip,
+            $flagKeys
+        );
+    }
+
+    /**
      * get all enabled flags for distinct_id
      *
      * @param string $distinctId

--- a/lib/SizeLimitedHash.php
+++ b/lib/SizeLimitedHash.php
@@ -28,19 +28,15 @@ class SizeLimitedHash
         }
 
         if (array_key_exists($key, $this->mapping)) {
-            array_push($this->mapping, $element);
+            $this->mapping[$key][$element] = true;
         } else {
-            $this->mapping[$key] = [$element];
+            $this->mapping[$key] = [$element => true];
         }
     }
 
     public function contains($key, $element)
     {
-        if (array_key_exists($key, $this->mapping) && array_key_exists($element, $this->mapping[$key])) {
-            return true;
-        }
-
-        return false;
+        return isset($this->mapping[$key][$element]);
     }
 
     public function count()

--- a/test/FakeFlagEvaluationsHost.php
+++ b/test/FakeFlagEvaluationsHost.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace PostHog\Test;
+
+use PostHog\FeatureFlagEvaluationsHost;
+
+/**
+ * In-memory FeatureFlagEvaluationsHost implementation used by FeatureFlagEvaluationsTest. Records
+ * each interaction so tests can assert on it without spinning up a real Client.
+ */
+class FakeFlagEvaluationsHost implements FeatureFlagEvaluationsHost
+{
+    /** @var array<int, array<string, mixed>> */
+    public array $captures = [];
+    /** @var list<string> */
+    public array $warnings = [];
+    /** @var array<string, true> */
+    private array $seen = [];
+
+    public function captureFlagCalledIfNeeded(
+        string $distinctId,
+        string $key,
+        array $properties,
+        array $groups
+    ): void {
+        $cacheKey = $distinctId . "\0" . $key;
+        if (isset($this->seen[$cacheKey])) {
+            return;
+        }
+        $this->seen[$cacheKey] = true;
+        $this->captures[] = [
+            'distinct_id' => $distinctId,
+            'key' => $key,
+            'properties' => $properties,
+            'groups' => $groups,
+        ];
+    }
+
+    public function logWarning(string $message): void
+    {
+        $this->warnings[] = $message;
+    }
+}

--- a/test/FeatureFlagEvaluationsTest.php
+++ b/test/FeatureFlagEvaluationsTest.php
@@ -1,0 +1,450 @@
+<?php
+
+namespace PostHog\Test;
+
+// comment out below to print all logs instead of failing tests
+require_once 'test/error_log_mock.php';
+
+use PHPUnit\Framework\TestCase;
+use PostHog\Client;
+use PostHog\EvaluatedFlagRecord;
+use PostHog\FeatureFlagEvaluations;
+use PostHog\PostHog;
+use PostHog\Test\Assets\MockedResponses;
+
+class FeatureFlagEvaluationsTest extends TestCase
+{
+    private const FAKE_API_KEY = 'random_key';
+
+    private MockedHttpClient $http_client;
+    private Client $client;
+
+    public function setUp(): void
+    {
+        date_default_timezone_set('UTC');
+        global $errorMessages;
+        $errorMessages = [];
+    }
+
+    private function makeClient(
+        $flagsEndpointResponse = MockedResponses::FLAGS_V2_RESPONSE,
+        $localEvaluationResponse = [],
+        ?string $personalApiKey = null,
+        array $options = []
+    ): void {
+        $this->http_client = new MockedHttpClient(
+            'app.posthog.com',
+            flagEndpointResponse: $localEvaluationResponse,
+            flagsEndpointResponse: $flagsEndpointResponse
+        );
+        $this->client = new Client(
+            self::FAKE_API_KEY,
+            $options,
+            $this->http_client,
+            $personalApiKey
+        );
+        PostHog::init(null, null, $this->client);
+    }
+
+    private function flagsRequestCount(): int
+    {
+        $count = 0;
+        foreach ($this->http_client->calls ?? [] as $call) {
+            if (str_starts_with($call['path'], '/flags/')) {
+                $count++;
+            }
+        }
+        return $count;
+    }
+
+    private function batchRequests(): array
+    {
+        $batches = [];
+        foreach ($this->http_client->calls ?? [] as $call) {
+            if (str_starts_with($call['path'], '/batch/')) {
+                $batches[] = json_decode($call['payload'], true);
+            }
+        }
+        return $batches;
+    }
+
+    private function makeRecord(
+        string $key,
+        bool $enabled,
+        ?string $variant = null,
+        mixed $payload = null,
+        ?int $id = null,
+        ?int $version = null,
+        ?string $reason = null,
+        bool $locallyEvaluated = false
+    ): EvaluatedFlagRecord {
+        return new EvaluatedFlagRecord(
+            key: $key,
+            enabled: $enabled,
+            variant: $variant,
+            payload: $payload,
+            id: $id,
+            version: $version,
+            reason: $reason,
+            locallyEvaluated: $locallyEvaluated,
+        );
+    }
+
+    public function testEvaluateFlagsReturnsSnapshotAndMakesOneFlagsRequest(): void
+    {
+        $this->makeClient();
+        $snapshot = PostHog::evaluateFlags('user-1');
+
+        $this->assertInstanceOf(FeatureFlagEvaluations::class, $snapshot);
+        $this->assertSame(1, $this->flagsRequestCount());
+        $this->assertContains('simple-test', $snapshot->getKeys());
+        $this->assertContains('multivariate-test', $snapshot->getKeys());
+    }
+
+    public function testNoFeatureFlagCalledEventsUntilAccess(): void
+    {
+        $this->makeClient();
+        PostHog::evaluateFlags('user-1');
+        PostHog::flush();
+
+        $this->assertSame([], $this->batchRequests());
+    }
+
+    public function testIsEnabledFiresEventWithFullMetadata(): void
+    {
+        $this->makeClient();
+        $snapshot = PostHog::evaluateFlags('user-1');
+
+        $this->assertTrue($snapshot->isEnabled('simple-test'));
+        PostHog::flush();
+
+        $batches = $this->batchRequests();
+        $this->assertCount(1, $batches);
+        $event = $batches[0]['batch'][0];
+
+        $this->assertSame('$feature_flag_called', $event['event']);
+        $this->assertSame('user-1', $event['distinct_id']);
+        $properties = $event['properties'];
+        $this->assertSame('simple-test', $properties['$feature_flag']);
+        $this->assertTrue($properties['$feature_flag_response']);
+        $this->assertSame(6, $properties['$feature_flag_id']);
+        $this->assertSame(1, $properties['$feature_flag_version']);
+        $this->assertSame('Matched condition set 1', $properties['$feature_flag_reason']);
+        $this->assertSame('98487c8a-287a-4451-a085-299cd76228dd', $properties['$feature_flag_request_id']);
+        $this->assertArrayNotHasKey('locally_evaluated', $properties);
+    }
+
+    public function testGetFlagFiresEventOnFirstAccessDedupedOnSecond(): void
+    {
+        $this->makeClient();
+        $snapshot = PostHog::evaluateFlags('user-1');
+
+        $snapshot->getFlag('multivariate-test');
+        $snapshot->getFlag('multivariate-test');
+        PostHog::flush();
+
+        $batches = $this->batchRequests();
+        $this->assertCount(1, $batches);
+        $this->assertCount(1, $batches[0]['batch']);
+        $this->assertSame('multivariate-test', $batches[0]['batch'][0]['properties']['$feature_flag']);
+        $this->assertSame('variant-value', $batches[0]['batch'][0]['properties']['$feature_flag_response']);
+    }
+
+    public function testGetFlagPayloadDoesNotFireEvent(): void
+    {
+        $this->makeClient();
+        $snapshot = PostHog::evaluateFlags('user-1');
+
+        $payload = $snapshot->getFlagPayload('json-payload');
+        PostHog::flush();
+
+        $this->assertSame(['key' => 'value'], $payload);
+        $this->assertSame([], $this->batchRequests());
+    }
+
+    public function testUnknownKeyAccessRecordsFlagMissingError(): void
+    {
+        $this->makeClient();
+        $snapshot = PostHog::evaluateFlags('user-1');
+
+        $this->assertNull($snapshot->getFlag('does-not-exist'));
+        $this->assertFalse($snapshot->isEnabled('does-not-exist'));
+        PostHog::flush();
+
+        $batches = $this->batchRequests();
+        $this->assertCount(1, $batches);
+        $properties = $batches[0]['batch'][0]['properties'];
+        $this->assertSame('flag_missing', $properties['$feature_flag_error']);
+    }
+
+    public function testOnlyWarnsOnUnknownKeys(): void
+    {
+        $host = new FakeFlagEvaluationsHost();
+        $snapshot = new FeatureFlagEvaluations(
+            'user-1',
+            ['flag-a' => $this->makeRecord('flag-a', true)],
+            [],
+            $host,
+        );
+
+        $filtered = $snapshot->only(['flag-a', 'unknown-flag']);
+
+        $this->assertSame(['flag-a'], $filtered->getKeys());
+        $this->assertCount(1, $host->warnings);
+        $this->assertStringContainsString('unknown-flag', $host->warnings[0]);
+    }
+
+    public function testOnlyAccessedFallsBackAndWarnsWhenEmpty(): void
+    {
+        $host = new FakeFlagEvaluationsHost();
+        $snapshot = new FeatureFlagEvaluations(
+            'user-1',
+            [
+                'flag-a' => $this->makeRecord('flag-a', true),
+                'flag-b' => $this->makeRecord('flag-b', false),
+            ],
+            [],
+            $host,
+        );
+
+        $filtered = $snapshot->onlyAccessed();
+
+        $this->assertEqualsCanonicalizing(['flag-a', 'flag-b'], $filtered->getKeys());
+        $this->assertCount(1, $host->warnings);
+    }
+
+    public function testOnlyAccessedReturnsSubsetWhenAccessed(): void
+    {
+        $host = new FakeFlagEvaluationsHost();
+        $snapshot = new FeatureFlagEvaluations(
+            'user-1',
+            [
+                'flag-a' => $this->makeRecord('flag-a', true),
+                'flag-b' => $this->makeRecord('flag-b', false),
+            ],
+            [],
+            $host,
+        );
+
+        $snapshot->isEnabled('flag-a');
+        $filtered = $snapshot->onlyAccessed();
+
+        $this->assertSame(['flag-a'], $filtered->getKeys());
+    }
+
+    public function testFilteredSnapshotsDoNotBackPropagateAccess(): void
+    {
+        $host = new FakeFlagEvaluationsHost();
+        $snapshot = new FeatureFlagEvaluations(
+            'user-1',
+            [
+                'flag-a' => $this->makeRecord('flag-a', true),
+                'flag-b' => $this->makeRecord('flag-b', true),
+            ],
+            [],
+            $host,
+        );
+
+        $snapshot->isEnabled('flag-a');
+        $filtered = $snapshot->onlyAccessed();
+
+        // Touch flag-b on the child; the parent's accessed set should still be {flag-a}.
+        $filtered->isEnabled('flag-b');
+
+        $parentAccessed = $snapshot->onlyAccessed();
+        $this->assertSame(['flag-a'], $parentAccessed->getKeys());
+    }
+
+    public function testCaptureFlagsAttachesFeaturePropertiesWithoutHttpRequest(): void
+    {
+        $this->makeClient();
+        $snapshot = PostHog::evaluateFlags('user-1');
+
+        $callsBefore = count($this->http_client->calls ?? []);
+
+        PostHog::capture([
+            'distinctId' => 'user-1',
+            'event' => 'page_view',
+            'flags' => $snapshot,
+        ]);
+        PostHog::flush();
+
+        $batches = $this->batchRequests();
+        $this->assertCount(1, $batches);
+        $event = $batches[0]['batch'][0];
+        $this->assertSame('page_view', $event['event']);
+        $this->assertTrue($event['properties']['$feature/simple-test']);
+        $this->assertSame('variant-value', $event['properties']['$feature/multivariate-test']);
+        $this->assertContains('simple-test', $event['properties']['$active_feature_flags']);
+        $this->assertNotContains('having_fun', $event['properties']['$active_feature_flags']);
+
+        // Capture only added one /batch/ call; no extra /flags/ request.
+        $newCalls = array_slice($this->http_client->calls, $callsBefore);
+        foreach ($newCalls as $call) {
+            $this->assertStringStartsNotWith('/flags/', $call['path']);
+        }
+    }
+
+    public function testFlagKeysIsForwardedInRequestBody(): void
+    {
+        $this->makeClient();
+        PostHog::evaluateFlags('user-1', flagKeys: ['simple-test', 'multivariate-test']);
+
+        $flagsCall = null;
+        foreach ($this->http_client->calls as $call) {
+            if (str_starts_with($call['path'], '/flags/')) {
+                $flagsCall = $call;
+                break;
+            }
+        }
+
+        $this->assertNotNull($flagsCall);
+        $payload = json_decode($flagsCall['payload'], true);
+        $this->assertSame(['simple-test', 'multivariate-test'], $payload['flag_keys_to_evaluate']);
+    }
+
+    public function testDisableGeoipIsForwardedInRequestBody(): void
+    {
+        $this->makeClient();
+        PostHog::evaluateFlags('user-1', disableGeoip: true);
+
+        $payload = null;
+        foreach ($this->http_client->calls as $call) {
+            if (str_starts_with($call['path'], '/flags/')) {
+                $payload = json_decode($call['payload'], true);
+                break;
+            }
+        }
+
+        $this->assertNotNull($payload);
+        $this->assertTrue($payload['geoip_disable']);
+    }
+
+    public function testEmptyDistinctIdSnapshotDoesNotFireEvents(): void
+    {
+        $this->makeClient();
+        $snapshot = PostHog::evaluateFlags('');
+
+        $this->assertSame([], $snapshot->getKeys());
+        $this->assertSame(0, $this->flagsRequestCount());
+
+        $snapshot->isEnabled('simple-test');
+        $snapshot->getFlag('multivariate-test');
+        PostHog::flush();
+
+        $this->assertSame([], $this->batchRequests());
+    }
+
+    public function testLocallyEvaluatedFlagTagsLocallyEvaluatedAndReason(): void
+    {
+        $this->makeClient(
+            personalApiKey: 'test-personal-key',
+            localEvaluationResponse: MockedResponses::LOCAL_EVALUATION_REQUEST,
+        );
+        $snapshot = PostHog::evaluateFlags(
+            'user-1',
+            personProperties: ['region' => 'USA']
+        );
+
+        $this->assertTrue($snapshot->isEnabled('person-flag'));
+        PostHog::flush();
+
+        $batches = $this->batchRequests();
+        $this->assertCount(1, $batches);
+        $properties = $batches[0]['batch'][0]['properties'];
+        $this->assertSame('person-flag', $properties['$feature_flag']);
+        $this->assertTrue($properties['$feature_flag_response']);
+        $this->assertSame('Evaluated locally', $properties['$feature_flag_reason']);
+        $this->assertTrue($properties['locally_evaluated']);
+        $this->assertSame(1, $properties['$feature_flag_id']);
+        $this->assertArrayNotHasKey('$feature_flag_version', $properties);
+        $this->assertArrayNotHasKey('$feature_flag_request_id', $properties);
+    }
+
+    public function testCaptureFlagsTakesPrecedenceOverSendFeatureFlags(): void
+    {
+        $this->makeClient();
+        $host = new FakeFlagEvaluationsHost();
+        $snapshot = new FeatureFlagEvaluations(
+            'user-1',
+            ['flag-a' => $this->makeRecord('flag-a', true)],
+            [],
+            $host,
+        );
+
+        PostHog::capture([
+            'distinctId' => 'user-1',
+            'event' => 'page_view',
+            'flags' => $snapshot,
+            'send_feature_flags' => true,
+        ]);
+        PostHog::flush();
+
+        $batches = $this->batchRequests();
+        $this->assertCount(1, $batches);
+        $properties = $batches[0]['batch'][0]['properties'];
+
+        // Only the snapshot's single flag is attached; send_feature_flags would have produced more.
+        $this->assertTrue($properties['$feature/flag-a']);
+        $this->assertSame(['flag-a'], $properties['$active_feature_flags']);
+        $this->assertSame(0, $this->flagsRequestCount());
+    }
+
+    public function testFlagsArgumentNotSerializedIntoEventPayload(): void
+    {
+        $this->makeClient();
+        $host = new FakeFlagEvaluationsHost();
+        $snapshot = new FeatureFlagEvaluations(
+            'user-1',
+            ['flag-a' => $this->makeRecord('flag-a', true)],
+            [],
+            $host,
+        );
+
+        PostHog::capture([
+            'distinctId' => 'user-1',
+            'event' => 'page_view',
+            'flags' => $snapshot,
+        ]);
+        PostHog::flush();
+
+        $rawPayload = $this->http_client->calls[0]['payload'];
+        $this->assertStringNotContainsString('FeatureFlagEvaluations', $rawPayload);
+        $batches = $this->batchRequests();
+        $this->assertArrayNotHasKey('flags', $batches[0]['batch'][0]);
+    }
+
+    public function testFeatureFlagsLogWarningsFalseSilencesFilterWarnings(): void
+    {
+        $host = new FakeFlagEvaluationsHost();
+        $snapshot = new FeatureFlagEvaluations(
+            'user-1',
+            ['flag-a' => $this->makeRecord('flag-a', true)],
+            [],
+            $host,
+            null,
+            false,
+        );
+
+        $snapshot->only(['unknown']);
+        $snapshot->onlyAccessed();
+
+        $this->assertSame([], $host->warnings);
+    }
+
+    public function testSnapshotDedupesAcrossClientPaths(): void
+    {
+        $this->makeClient();
+        $snapshot = PostHog::evaluateFlags('user-1');
+        $snapshot->isEnabled('simple-test');
+
+        // The single-flag path should be deduped against the snapshot's earlier event because
+        // both share the Client's distinctIdsFeatureFlagsReported cache.
+        PostHog::isFeatureEnabled('simple-test', 'user-1');
+        PostHog::flush();
+
+        $batches = $this->batchRequests();
+        $this->assertCount(1, $batches);
+        $this->assertCount(1, $batches[0]['batch']);
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 of the [Server SDK Feature Flag Evaluations RFC](https://github.com/PostHog/posthog-js/pull/3476) ported to posthog-php. Mirrors the Node ([posthog-js#3476](https://github.com/PostHog/posthog-js/pull/3476)) and Python ([posthog-python#539](https://github.com/PostHog/posthog-python/pull/539)) implementations.

Adds a single-call flag evaluation API:

- `Client::evaluateFlags(distinctId, …)` returns a `FeatureFlagEvaluations` snapshot. Reads on the snapshot do not trigger additional `/flags` requests.
- `isEnabled($key)` / `getFlag($key)` record access and fire a deduped `\$feature_flag_called` event the first time each key is touched, with the rich metadata (`\$feature_flag_id`, `\$feature_flag_version`, `\$feature_flag_reason`, `\$feature_flag_request_id`).
- `getFlagPayload($key)` is silent — no event, no access tracking.
- `only([...])` and `onlyAccessed()` return filtered clones with their own access set, so child reads don't back-propagate. `onlyAccessed()` warns and falls back to the full snapshot when no flags have been accessed.
- `capture(['flags' => \$snapshot, …])` attaches `\$feature/<key>` and `\$active_feature_flags` from the snapshot — no extra `/flags` request. Takes precedence over the existing `send_feature_flags` path; `send_feature_flags` is **not** deprecated in this PR.

The single-flag dedup block in `getFeatureFlagResult()` is now extracted to `Client::captureFlagCalledIfNeeded()` and shared by both code paths against the existing per-distinct_id `SizeLimitedHash` cache.

### Pre-flight answers

1. **Existing single-flag dedup helper?** Inline block in `getFeatureFlagResult()` — extracted in this PR to `Client::captureFlagCalledIfNeeded()`. Cache: `Client::\$distinctIdsFeatureFlagsReported` (cap 50,000).
2. **Rich `/flags` response handler?** `Client::flags()` already returns the v4 shape (`flags[\$key]['metadata']['{id,version,payload}']`, `flags[\$key]['reason']['description']`, top-level `requestId`, `evaluatedAt`). No new lower-level call needed.
3. **Local evaluation poller?** Yes — `Client::loadFlags()` polls `/api/feature_flag/local_evaluation` with ETag/304 support. There is **no** `flag_definitions_loaded_at` timestamp in posthog-php today, so locally-evaluated records leave it null. Adding it is left for a follow-up.
4. **Capture options convention?** `Client::capture(array \$message)` takes a single associative array; the new `flags` parameter slots in as a top-level key.
5. **Snapshot module path?** New file `lib/FeatureFlagEvaluations.php` (PSR-4 → `PostHog\\FeatureFlagEvaluations`), with companions `lib/EvaluatedFlagRecord.php` and `lib/FeatureFlagEvaluationsHost.php`.

### Pre-existing dedup bug fix

`SizeLimitedHash::contains/add` used `array_key_exists` to compare values to keys, so the per-distinct_id `\$feature_flag_called` dedup never actually matched after the first event. Existing tests only ever made a single call per (flag, distinct_id), so the bug was invisible. The new snapshot path requires real dedup; this PR fixes both helpers to operate on a per-key set as intended.

### Phase 2 — follow-up

Phase 2 (a separate minor) will deprecate the legacy methods now superseded by `evaluateFlags()`:

- `Client::getFeatureFlag()` / `PostHog::getFeatureFlag()`
- `Client::isFeatureEnabled()` / `PostHog::isFeatureEnabled()`
- `Client::getFeatureFlagResult()` / `PostHog::getFeatureFlagResult()`
- `Client::getAllFlags()` / `PostHog::getAllFlags()`
- The `send_feature_flags` capture parameter

`Client::getFeatureFlagPayload()` (already deprecated) and the rich-result-for-one-flag method (`getFeatureFlagResult()`) are intentionally **not** removed in either phase — there is no public equivalent on the new API for fetching a single flag's full result.

## Test plan

- [x] `vendor/bin/phpunit --filter FeatureFlagEvaluationsTest` — 19 new tests, 65 assertions, all passing
- [x] `vendor/bin/phpunit` — full suite passes (1 pre-existing unrelated failure in \`testLoadFeatureFlagsWrongKey\` reproduces on the upstream branch this is based on)
- [x] \`vendor/bin/phpcs\` — no new errors on touched files
- [ ] Smoke-test against a real PostHog project: one \`/flags\` request, \`\$feature_flag_called\` fires once per accessed flag with rich metadata, captured \`page_view\` event has the expected \`\$feature/*\` properties

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*