### PR TITLE
feat: add evaluateFlags() API for single-call flag evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
   `FeatureFlagEvaluations` snapshot you can read repeatedly without further `/flags` requests; pass
   it to `capture()` via the new `flags` key to attach `$feature/<key>` and `$active_feature_flags`
   on the captured event without an extra round trip.
+* feat(flags): Deprecate `isFeatureEnabled()`, `getFeatureFlag()`, `getFeatureFlagPayload()`, and
+  the `send_feature_flags` `capture()` option in favor of `evaluateFlags()`. Each emits an
+  `E_USER_DEPRECATED` warning pointing at the new API; existing callers keep working unchanged
+  until the next major version. `getFeatureFlagResult()` and `getAllFlags()` are intentionally
+  *not* deprecated — they expose data the snapshot API doesn't yet cover.
 * fix(flags): `SizeLimitedHash::contains()` and `add()` were storing entries on the outer map and
   comparing values to keys, so the per-distinct_id `$feature_flag_called` dedup never matched after
   the first event. Both helpers now operate on a per-key set as intended.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
   `FeatureFlagEvaluations` snapshot you can read repeatedly without further `/flags` requests; pass
   it to `capture()` via the new `flags` key to attach `$feature/<key>` and `$active_feature_flags`
   on the captured event without an extra round trip.
-* feat(flags): Deprecate `isFeatureEnabled()`, `getFeatureFlag()`, `getFeatureFlagPayload()`, and
-  the `send_feature_flags` `capture()` option in favor of `evaluateFlags()`. Each emits an
-  `E_USER_DEPRECATED` warning pointing at the new API; existing callers keep working unchanged
-  until the next major version. `getFeatureFlagResult()` and `getAllFlags()` are intentionally
-  *not* deprecated — they expose data the snapshot API doesn't yet cover.
+* feat(flags): Deprecate `isFeatureEnabled()`, `getFeatureFlag()`, `getFeatureFlagResult()`,
+  `getFeatureFlagPayload()`, and the `send_feature_flags` `capture()` option in favor of
+  `evaluateFlags()`. Each emits an `E_USER_DEPRECATED` warning pointing at the new API; existing
+  callers keep working unchanged until the next major version. `getAllFlags()` is intentionally
+  *not* deprecated — it returns an arbitrary key list the snapshot API doesn't yet cover.
 * fix(flags): `SizeLimitedHash::contains()` and `add()` were storing entries on the outer map and
   comparing values to keys, so the per-distinct_id `$feature_flag_called` dedup never matched after
   the first event. Both helpers now operate on a per-key set as intended.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Unreleased
+
+* feat(flags): Add `evaluateFlags()` API for single-call flag evaluation. Returns a
+  `FeatureFlagEvaluations` snapshot you can read repeatedly without further `/flags` requests; pass
+  it to `capture()` via the new `flags` key to attach `$feature/<key>` and `$active_feature_flags`
+  on the captured event without an extra round trip.
+* fix(flags): `SizeLimitedHash::contains()` and `add()` were storing entries on the outer map and
+  comparing values to keys, so the per-distinct_id `$feature_flag_called` dedup never matched after
+  the first event. Both helpers now operate on a per-key set as intended.
+
 ## 4.2.2 - 2026-04-21
 
 * [Full Changelog](https://github.com/PostHog/posthog-php/compare/4.2.1...4.2.2)

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -186,6 +186,14 @@ class Client implements FeatureFlagEvaluationsHost
                 $message["properties"]
             );
         } elseif (array_key_exists("send_feature_flags", $message) && $message["send_feature_flags"]) {
+            trigger_error(
+                'capture()\'s `send_feature_flags` option is deprecated and will be removed in a '
+                . 'future major version. Pass a `flags` snapshot from Client::evaluateFlags(...) '
+                . 'instead — it avoids a second /flags request per capture and guarantees the '
+                . 'event carries the exact flag values your code branched on.',
+                E_USER_DEPRECATED
+            );
+
             $extraProperties = [];
             $flags = [];
 
@@ -279,7 +287,9 @@ class Client implements FeatureFlagEvaluationsHost
     }
 
     /**
-     * decide if the feature flag is enabled for this distinct id.
+     * @deprecated Use `evaluateFlags($distinctId, ...)` and call
+     * `$flags->isEnabled($key)` instead. This consolidates flag evaluation into a single
+     * `/flags` request per incoming request.
      *
      * @param string $key
      * @param string $distinctId
@@ -298,7 +308,17 @@ class Client implements FeatureFlagEvaluationsHost
         bool $onlyEvaluateLocally = false,
         bool $sendFeatureFlagEvents = true
     ): null | bool {
-        $result = $this->getFeatureFlag(
+        trigger_error(
+            'Client::isFeatureEnabled() is deprecated and will be removed in a future major '
+            . 'version. Use Client::evaluateFlags($distinctId, ...) and call '
+            . '$flags->isEnabled($key) instead — this consolidates flag evaluation into a '
+            . 'single /flags request per incoming request.',
+            E_USER_DEPRECATED
+        );
+
+        // Bypass the public getFeatureFlag() so the user only sees a single deprecation
+        // warning per call, not two.
+        $result = $this->getFeatureFlagResult(
             $key,
             $distinctId,
             $groups,
@@ -308,15 +328,17 @@ class Client implements FeatureFlagEvaluationsHost
             $sendFeatureFlagEvents
         );
 
-        if (is_null($result)) {
-            return $result;
-        } else {
-            return boolval($result);
+        if ($result === null) {
+            return null;
         }
+
+        return boolval($result->getValue());
     }
 
     /**
-     * get the feature flag value for this distinct id.
+     * @deprecated Use `evaluateFlags($distinctId, ...)` and call
+     * `$flags->getFlag($key)` instead. This consolidates flag evaluation into a single
+     * `/flags` request per incoming request.
      *
      * @param string $key
      * @param string $distinctId
@@ -335,6 +357,14 @@ class Client implements FeatureFlagEvaluationsHost
         bool $onlyEvaluateLocally = false,
         bool $sendFeatureFlagEvents = true
     ): null | bool | string {
+        trigger_error(
+            'Client::getFeatureFlag() is deprecated and will be removed in a future major '
+            . 'version. Use Client::evaluateFlags($distinctId, ...) and call '
+            . '$flags->getFlag($key) instead — this consolidates flag evaluation into a '
+            . 'single /flags request per incoming request.',
+            E_USER_DEPRECATED
+        );
+
         $result = $this->getFeatureFlagResult(
             $key,
             $distinctId,
@@ -507,8 +537,9 @@ class Client implements FeatureFlagEvaluationsHost
     }
 
     /**
-     * @deprecated Use `getFeatureFlagResult()` instead which properly tracks the feature flag call,
-     * and includes both the flag value and payload in a single method.
+     * @deprecated Use `evaluateFlags($distinctId, ...)` and call
+     * `$flags->getFlagPayload($key)` instead. This consolidates flag evaluation into a single
+     * `/flags` request per incoming request.
      *
      * @param string $key
      * @param string $distinctId
@@ -524,6 +555,14 @@ class Client implements FeatureFlagEvaluationsHost
         array $personProperties = array(),
         array $groupProperties = array(),
     ): mixed {
+        trigger_error(
+            'Client::getFeatureFlagPayload() is deprecated and will be removed in a future major '
+            . 'version. Use Client::evaluateFlags($distinctId, ...) and call '
+            . '$flags->getFlagPayload($key) instead — this consolidates flag evaluation into a '
+            . 'single /flags request per incoming request.',
+            E_USER_DEPRECATED
+        );
+
         $result = $this->getFeatureFlagResult(
             $key,
             $distinctId,

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -172,8 +172,15 @@ class Client implements FeatureFlagEvaluationsHost
         }
 
         if ($flagsSnapshot instanceof FeatureFlagEvaluations) {
-            // The snapshot already has every flag value cached. No /flags request, no override of
-            // properties already set on the event.
+            // Precedence: an explicit `flags` snapshot always wins over `send_feature_flags`. The
+            // snapshot guarantees the event carries the same values the developer branched on, with
+            // no additional /flags request.
+            if (!empty($message["send_feature_flags"])) {
+                error_log(
+                    "[PostHog][Client] Both `flags` and `send_feature_flags` were passed to "
+                    . "capture(); using `flags` and ignoring `send_feature_flags`."
+                );
+            }
             $message["properties"] = array_merge(
                 $flagsSnapshot->getEventProperties(),
                 $message["properties"]
@@ -600,7 +607,11 @@ class Client implements FeatureFlagEvaluationsHost
      * @param array<string, mixed> $groups
      * @param array<string, mixed> $personProperties
      * @param array<string, array<string, mixed>> $groupProperties
-     * @param list<string>|null $flagKeys When set, scope the underlying /flags request to these keys.
+     * @param list<string>|null $flagKeys Optional list of flag keys. When provided, only these
+     *     flags are evaluated — the underlying /flags request asks the server for just this
+     *     subset, which makes the response smaller and the request cheaper. Use this when you
+     *     only need a handful of flags out of many. Distinct from FeatureFlagEvaluations::only(),
+     *     which scopes which already-evaluated flags get attached to a captured event.
      */
     public function evaluateFlags(
         string $distinctId,
@@ -630,6 +641,9 @@ class Client implements FeatureFlagEvaluationsHost
         );
 
         $records = [];
+        $requestId = null;
+        $errorsWhileComputing = false;
+        $quotaLimited = false;
 
         // Local pass: try to resolve any flag we can without going to the server.
         foreach ($this->featureFlags as $flag) {
@@ -675,8 +689,6 @@ class Client implements FeatureFlagEvaluationsHost
             );
         }
 
-        $requestId = null;
-
         if (!$onlyEvaluateLocally) {
             try {
                 $response = $this->flags(
@@ -689,6 +701,7 @@ class Client implements FeatureFlagEvaluationsHost
                 );
 
                 $requestId = $response['requestId'] ?? null;
+                $errorsWhileComputing = (bool) ($response['errorsWhileComputingFlags'] ?? false);
                 $remoteFlags = $response['flags'] ?? [];
 
                 foreach ($remoteFlags as $key => $flagDetail) {
@@ -719,6 +732,11 @@ class Client implements FeatureFlagEvaluationsHost
                         locallyEvaluated: false,
                     );
                 }
+            } catch (HttpException $e) {
+                if ($e->getErrorType() === HttpException::QUOTA_LIMITED) {
+                    $quotaLimited = true;
+                }
+                error_log("[PostHog][Client] Unable to evaluate flags: " . $e->getMessage());
             } catch (Exception $e) {
                 error_log("[PostHog][Client] Unable to evaluate flags: " . $e->getMessage());
             }
@@ -731,6 +749,9 @@ class Client implements FeatureFlagEvaluationsHost
             $this,
             $requestId,
             $this->featureFlagsLogWarnings,
+            null,
+            $errorsWhileComputing,
+            $quotaLimited,
         );
     }
 

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -11,7 +11,7 @@ use Symfony\Component\Clock\Clock;
 
 const SIZE_LIMIT = 50_000;
 
-class Client
+class Client implements FeatureFlagEvaluationsHost
 {
     private const CONSUMERS = [
         "socket" => Socket::class,
@@ -89,6 +89,11 @@ class Client
     private $options;
 
     /**
+     * @var bool Whether to surface non-fatal warnings from feature flag helpers.
+     */
+    private $featureFlagsLogWarnings;
+
+    /**
      * Create a new posthog object with your app's API key
      * key
      *
@@ -123,6 +128,7 @@ class Client
             (int) ($options['timeout'] ?? 10000)
         );
         $this->featureFlagsRequestTimeout = (int) ($options['feature_flag_request_timeout_ms'] ?? 3000);
+        $this->featureFlagsLogWarnings = (bool) ($options['feature_flags_log_warnings'] ?? true);
         $this->featureFlags = [];
         $this->groupTypeMapping = [];
         $this->cohorts = [];
@@ -155,6 +161,9 @@ class Client
      */
     public function capture(array $message)
     {
+        $flagsSnapshot = $message["flags"] ?? null;
+        unset($message["flags"]);
+
         $message = $this->message($message);
         $message["type"] = "capture";
 
@@ -162,7 +171,14 @@ class Client
             $message["properties"]['$groups'] = $message['$groups'];
         }
 
-        if (array_key_exists("send_feature_flags", $message) && $message["send_feature_flags"]) {
+        if ($flagsSnapshot instanceof FeatureFlagEvaluations) {
+            // The snapshot already has every flag value cached. No /flags request, no override of
+            // properties already set on the event.
+            $message["properties"] = array_merge(
+                $flagsSnapshot->getEventProperties(),
+                $message["properties"]
+            );
+        } elseif (array_key_exists("send_feature_flags", $message) && $message["send_feature_flags"]) {
             $extraProperties = [];
             $flags = [];
 
@@ -444,7 +460,7 @@ class Client
             }
         }
 
-        if ($sendFeatureFlagEvents && !$this->distinctIdsFeatureFlagsReported->contains($key, $distinctId)) {
+        if ($sendFeatureFlagEvents) {
             $properties = [
                 '$feature_flag' => $key,
                 '$feature_flag_response' => $result,
@@ -468,13 +484,7 @@ class Client
                 $properties['$feature_flag_error'] = $featureFlagError;
             }
 
-            $this->capture([
-                "properties" => $properties,
-                "distinct_id" => $distinctId,
-                "event" => '$feature_flag_called',
-                '$groups' => $groups
-            ]);
-            $this->distinctIdsFeatureFlagsReported->add($key, $distinctId);
+            $this->captureFlagCalledIfNeeded($distinctId, $key, $properties, $groups);
         }
 
         if (is_null($result)) {
@@ -579,6 +589,184 @@ class Client
         }
 
         return $response;
+    }
+
+    /**
+     * Evaluate every feature flag for a distinct id in a single round trip and return a
+     * FeatureFlagEvaluations snapshot. Reads on the snapshot do not trigger additional /flags
+     * requests; access via isEnabled() or getFlag() fires a deduped $feature_flag_called event the
+     * first time each key is touched.
+     *
+     * @param array<string, mixed> $groups
+     * @param array<string, mixed> $personProperties
+     * @param array<string, array<string, mixed>> $groupProperties
+     * @param list<string>|null $flagKeys When set, scope the underlying /flags request to these keys.
+     */
+    public function evaluateFlags(
+        string $distinctId,
+        array $groups = [],
+        array $personProperties = [],
+        array $groupProperties = [],
+        bool $onlyEvaluateLocally = false,
+        bool $disableGeoip = false,
+        ?array $flagKeys = null
+    ): FeatureFlagEvaluations {
+        if ($distinctId === '') {
+            return new FeatureFlagEvaluations(
+                $distinctId,
+                [],
+                $groups,
+                $this,
+                null,
+                $this->featureFlagsLogWarnings,
+            );
+        }
+
+        [$personProperties, $groupProperties] = $this->addLocalPersonAndGroupProperties(
+            $distinctId,
+            $groups,
+            $personProperties,
+            $groupProperties
+        );
+
+        $records = [];
+
+        // Local pass: try to resolve any flag we can without going to the server.
+        foreach ($this->featureFlags as $flag) {
+            $key = $flag['key'] ?? null;
+            if (!is_string($key) || $key === '') {
+                continue;
+            }
+
+            if ($flagKeys !== null && !in_array($key, $flagKeys, true)) {
+                continue;
+            }
+
+            try {
+                $value = $this->computeFlagLocally(
+                    $flag,
+                    $distinctId,
+                    $groups,
+                    $personProperties,
+                    $groupProperties
+                );
+            } catch (RequiresServerEvaluationException $e) {
+                continue;
+            } catch (InconclusiveMatchException $e) {
+                continue;
+            } catch (Exception $e) {
+                error_log("[PostHog][Client] Error while computing variant: " . $e->getMessage());
+                continue;
+            }
+
+            $variant = is_string($value) ? $value : null;
+            $enabled = is_string($value) ? true : (bool) $value;
+            $id = isset($flag['id']) ? (int) $flag['id'] : null;
+
+            $records[$key] = new EvaluatedFlagRecord(
+                key: $key,
+                enabled: $enabled,
+                variant: $variant,
+                payload: null,
+                id: $id,
+                version: null,
+                reason: 'Evaluated locally',
+                locallyEvaluated: true,
+            );
+        }
+
+        $requestId = null;
+
+        if (!$onlyEvaluateLocally) {
+            try {
+                $response = $this->flags(
+                    $distinctId,
+                    $groups,
+                    $personProperties,
+                    $groupProperties,
+                    $disableGeoip,
+                    $flagKeys
+                );
+
+                $requestId = $response['requestId'] ?? null;
+                $remoteFlags = $response['flags'] ?? [];
+
+                foreach ($remoteFlags as $key => $flagDetail) {
+                    if (!is_string($key) || $key === '' || isset($records[$key])) {
+                        continue;
+                    }
+                    if (!is_array($flagDetail) || ($flagDetail['failed'] ?? false)) {
+                        continue;
+                    }
+
+                    $variant = $flagDetail['variant'] ?? null;
+                    $enabled = (bool) ($flagDetail['enabled'] ?? false);
+                    $rawPayload = $flagDetail['metadata']['payload'] ?? null;
+                    $payload = $rawPayload !== null ? json_decode($rawPayload, true) : null;
+
+                    $records[$key] = new EvaluatedFlagRecord(
+                        key: $key,
+                        enabled: $enabled,
+                        variant: is_string($variant) ? $variant : null,
+                        payload: $payload,
+                        id: isset($flagDetail['metadata']['id'])
+                            ? (int) $flagDetail['metadata']['id']
+                            : null,
+                        version: isset($flagDetail['metadata']['version'])
+                            ? (int) $flagDetail['metadata']['version']
+                            : null,
+                        reason: $flagDetail['reason']['description'] ?? null,
+                        locallyEvaluated: false,
+                    );
+                }
+            } catch (Exception $e) {
+                error_log("[PostHog][Client] Unable to evaluate flags: " . $e->getMessage());
+            }
+        }
+
+        return new FeatureFlagEvaluations(
+            $distinctId,
+            $records,
+            $groups,
+            $this,
+            $requestId,
+            $this->featureFlagsLogWarnings,
+        );
+    }
+
+    /**
+     * Fire a $feature_flag_called event the first time a (flag key, distinct id) pair is seen by
+     * this Client, deduped via the per-distinct_id cache shared with every other flag-reading code
+     * path. Properties are built by the caller so each call site can shape the payload to match its
+     * available metadata.
+     *
+     * @param array<string, mixed> $properties
+     * @param array<string, mixed> $groups
+     */
+    public function captureFlagCalledIfNeeded(
+        string $distinctId,
+        string $key,
+        array $properties,
+        array $groups = []
+    ): void {
+        if ($this->distinctIdsFeatureFlagsReported->contains($key, $distinctId)) {
+            return;
+        }
+
+        $this->capture([
+            'properties' => $properties,
+            'distinct_id' => $distinctId,
+            'event' => '$feature_flag_called',
+            '$groups' => $groups,
+        ]);
+        $this->distinctIdsFeatureFlagsReported->add($key, $distinctId);
+    }
+
+    public function logWarning(string $message): void
+    {
+        if ($this->featureFlagsLogWarnings) {
+            error_log("[PostHog][Client] " . $message);
+        }
     }
 
     private function computeFlagLocally(
@@ -821,7 +1009,9 @@ class Client
         string $distinctId,
         array $groups = array(),
         array $personProperties = [],
-        array $groupProperties = []
+        array $groupProperties = [],
+        bool $disableGeoip = false,
+        ?array $flagKeys = null
     ): array {
         $payload = array(
             'api_key' => $this->apiKey,
@@ -838,6 +1028,14 @@ class Client
 
         if (!empty($groupProperties)) {
             $payload["group_properties"] = $groupProperties;
+        }
+
+        if ($disableGeoip) {
+            $payload["geoip_disable"] = true;
+        }
+
+        if ($flagKeys !== null) {
+            $payload["flag_keys_to_evaluate"] = array_values($flagKeys);
         }
 
         $httpResponse = $this->httpClient->sendRequest(

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -89,11 +89,6 @@ class Client implements FeatureFlagEvaluationsHost
     private $options;
 
     /**
-     * @var bool Whether to surface non-fatal warnings from feature flag helpers.
-     */
-    private $featureFlagsLogWarnings;
-
-    /**
      * Create a new posthog object with your app's API key
      * key
      *
@@ -128,7 +123,6 @@ class Client implements FeatureFlagEvaluationsHost
             (int) ($options['timeout'] ?? 10000)
         );
         $this->featureFlagsRequestTimeout = (int) ($options['feature_flag_request_timeout_ms'] ?? 3000);
-        $this->featureFlagsLogWarnings = (bool) ($options['feature_flags_log_warnings'] ?? true);
         $this->featureFlags = [];
         $this->groupTypeMapping = [];
         $this->cohorts = [];
@@ -316,9 +310,9 @@ class Client implements FeatureFlagEvaluationsHost
             E_USER_DEPRECATED
         );
 
-        // Bypass the public getFeatureFlag() so the user only sees a single deprecation
-        // warning per call, not two.
-        $result = $this->getFeatureFlagResult(
+        // Route through the private helper so the user sees exactly one deprecation warning
+        // per call, not two (or three).
+        $result = $this->doGetFeatureFlagResult(
             $key,
             $distinctId,
             $groups,
@@ -365,7 +359,8 @@ class Client implements FeatureFlagEvaluationsHost
             E_USER_DEPRECATED
         );
 
-        $result = $this->getFeatureFlagResult(
+        // Route through the private helper so the user sees exactly one deprecation warning.
+        $result = $this->doGetFeatureFlagResult(
             $key,
             $distinctId,
             $groups,
@@ -379,10 +374,9 @@ class Client implements FeatureFlagEvaluationsHost
     }
 
     /**
-     * Get the feature flag result including value and payload.
-     *
-     * This is the recommended method for getting feature flag data as it returns
-     * both the flag value and payload in a single call, while properly tracking analytics.
+     * @deprecated Use `evaluateFlags($distinctId, ...)` and call `$flags->getFlag($key)` and
+     * `$flags->getFlagPayload($key)` instead. This consolidates flag evaluation into a single
+     * `/flags` request per incoming request.
      *
      * @param string $key
      * @param string $distinctId
@@ -400,6 +394,45 @@ class Client implements FeatureFlagEvaluationsHost
         array $groups = array(),
         array $personProperties = array(),
         array $groupProperties = array(),
+        bool $onlyEvaluateLocally = false,
+        bool $sendFeatureFlagEvents = true
+    ): ?FeatureFlagResult {
+        trigger_error(
+            'Client::getFeatureFlagResult() is deprecated and will be removed in a future major '
+            . 'version. Use Client::evaluateFlags($distinctId, ...) and call $flags->getFlag($key) '
+            . '(and $flags->getFlagPayload($key) if you need the payload) instead — this '
+            . 'consolidates flag evaluation into a single /flags request per incoming request.',
+            E_USER_DEPRECATED
+        );
+
+        return $this->doGetFeatureFlagResult(
+            $key,
+            $distinctId,
+            $groups,
+            $personProperties,
+            $groupProperties,
+            $onlyEvaluateLocally,
+            $sendFeatureFlagEvents
+        );
+    }
+
+    /**
+     * Internal entry point for the rich single-flag fetch. Public callers should go through
+     * the deprecated `getFeatureFlagResult()`; the deprecated `isFeatureEnabled()` /
+     * `getFeatureFlag()` paths route directly here so a single user-level call surfaces exactly
+     * one deprecation warning, not two.
+     *
+     * @param array<string, mixed> $groups
+     * @param array<string, mixed> $personProperties
+     * @param array<string, array<string, mixed>> $groupProperties
+     * @throws Exception
+     */
+    private function doGetFeatureFlagResult(
+        string $key,
+        string $distinctId,
+        array $groups = [],
+        array $personProperties = [],
+        array $groupProperties = [],
         bool $onlyEvaluateLocally = false,
         bool $sendFeatureFlagEvents = true
     ): ?FeatureFlagResult {
@@ -563,7 +596,8 @@ class Client implements FeatureFlagEvaluationsHost
             E_USER_DEPRECATED
         );
 
-        $result = $this->getFeatureFlagResult(
+        // Route through the private helper so the user sees exactly one deprecation warning.
+        $result = $this->doGetFeatureFlagResult(
             $key,
             $distinctId,
             $groups,
@@ -667,8 +701,6 @@ class Client implements FeatureFlagEvaluationsHost
                 [],
                 $groups,
                 $this,
-                null,
-                $this->featureFlagsLogWarnings,
             );
         }
 
@@ -681,54 +713,82 @@ class Client implements FeatureFlagEvaluationsHost
 
         $records = [];
         $requestId = null;
+        $evaluatedAt = null;
         $errorsWhileComputing = false;
         $quotaLimited = false;
+        $fallbackToRemote = false;
 
-        // Local pass: try to resolve any flag we can without going to the server.
-        foreach ($this->featureFlags as $flag) {
-            $key = $flag['key'] ?? null;
-            if (!is_string($key) || $key === '') {
-                continue;
-            }
+        // Local pass: try to resolve any flag we can without going to the server. Track whether
+        // any flag was inconclusive (which forces a remote round trip) so we can skip /flags
+        // entirely when local evaluation covered everything we know about.
+        $hasLocalDefinitions = count($this->featureFlags) > 0;
+        if ($hasLocalDefinitions) {
+            $localKeys = [];
+            foreach ($this->featureFlags as $flag) {
+                $key = $flag['key'] ?? null;
+                if (!is_string($key) || $key === '') {
+                    continue;
+                }
+                $localKeys[$key] = true;
 
-            if ($flagKeys !== null && !in_array($key, $flagKeys, true)) {
-                continue;
-            }
+                if ($flagKeys !== null && !in_array($key, $flagKeys, true)) {
+                    continue;
+                }
 
-            try {
-                $value = $this->computeFlagLocally(
-                    $flag,
-                    $distinctId,
-                    $groups,
-                    $personProperties,
-                    $groupProperties
+                try {
+                    $value = $this->computeFlagLocally(
+                        $flag,
+                        $distinctId,
+                        $groups,
+                        $personProperties,
+                        $groupProperties
+                    );
+                } catch (RequiresServerEvaluationException $e) {
+                    $fallbackToRemote = true;
+                    continue;
+                } catch (InconclusiveMatchException $e) {
+                    $fallbackToRemote = true;
+                    continue;
+                } catch (Exception $e) {
+                    $fallbackToRemote = true;
+                    error_log("[PostHog][Client] Error while computing variant: " . $e->getMessage());
+                    continue;
+                }
+
+                $variant = is_string($value) ? $value : null;
+                $enabled = is_string($value) ? true : (bool) $value;
+                $id = isset($flag['id']) ? (int) $flag['id'] : null;
+
+                $records[$key] = new EvaluatedFlagRecord(
+                    key: $key,
+                    enabled: $enabled,
+                    variant: $variant,
+                    payload: null,
+                    id: $id,
+                    version: null,
+                    reason: 'Evaluated locally',
+                    locallyEvaluated: true,
                 );
-            } catch (RequiresServerEvaluationException $e) {
-                continue;
-            } catch (InconclusiveMatchException $e) {
-                continue;
-            } catch (Exception $e) {
-                error_log("[PostHog][Client] Error while computing variant: " . $e->getMessage());
-                continue;
             }
 
-            $variant = is_string($value) ? $value : null;
-            $enabled = is_string($value) ? true : (bool) $value;
-            $id = isset($flag['id']) ? (int) $flag['id'] : null;
-
-            $records[$key] = new EvaluatedFlagRecord(
-                key: $key,
-                enabled: $enabled,
-                variant: $variant,
-                payload: null,
-                id: $id,
-                version: null,
-                reason: 'Evaluated locally',
-                locallyEvaluated: true,
-            );
+            // If the caller asked for keys we don't have local definitions for, hit /flags so
+            // we can resolve them.
+            if ($flagKeys !== null) {
+                foreach ($flagKeys as $requestedKey) {
+                    if (!isset($localKeys[$requestedKey])) {
+                        $fallbackToRemote = true;
+                        break;
+                    }
+                }
+            }
+        } else {
+            // No local definitions loaded — every flag has to come from the server.
+            $fallbackToRemote = true;
         }
 
-        if (!$onlyEvaluateLocally) {
+        $shouldHitRemote = !$onlyEvaluateLocally && $fallbackToRemote;
+
+        if ($shouldHitRemote) {
             try {
                 $response = $this->flags(
                     $distinctId,
@@ -740,6 +800,9 @@ class Client implements FeatureFlagEvaluationsHost
                 );
 
                 $requestId = $response['requestId'] ?? null;
+                $evaluatedAt = isset($response['evaluatedAt']) && is_int($response['evaluatedAt'])
+                    ? $response['evaluatedAt']
+                    : null;
                 $errorsWhileComputing = (bool) ($response['errorsWhileComputingFlags'] ?? false);
                 $remoteFlags = $response['flags'] ?? [];
 
@@ -753,8 +816,16 @@ class Client implements FeatureFlagEvaluationsHost
 
                     $variant = $flagDetail['variant'] ?? null;
                     $enabled = (bool) ($flagDetail['enabled'] ?? false);
+                    // Payloads come down as JSON strings, but defensively handle pre-decoded
+                    // values too (some clients/middleware may deserialize transparently).
                     $rawPayload = $flagDetail['metadata']['payload'] ?? null;
-                    $payload = $rawPayload !== null ? json_decode($rawPayload, true) : null;
+                    if ($rawPayload === null) {
+                        $payload = null;
+                    } elseif (is_string($rawPayload)) {
+                        $payload = json_decode($rawPayload, true);
+                    } else {
+                        $payload = $rawPayload;
+                    }
 
                     $records[$key] = new EvaluatedFlagRecord(
                         key: $key,
@@ -787,7 +858,7 @@ class Client implements FeatureFlagEvaluationsHost
             $groups,
             $this,
             $requestId,
-            $this->featureFlagsLogWarnings,
+            $evaluatedAt,
             null,
             $errorsWhileComputing,
             $quotaLimited,
@@ -824,9 +895,7 @@ class Client implements FeatureFlagEvaluationsHost
 
     public function logWarning(string $message): void
     {
-        if ($this->featureFlagsLogWarnings) {
-            error_log("[PostHog][Client] " . $message);
-        }
+        error_log("[PostHog][Client] " . $message);
     }
 
     private function computeFlagLocally(

--- a/lib/EvaluatedFlagRecord.php
+++ b/lib/EvaluatedFlagRecord.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace PostHog;
+
+/**
+ * Immutable per-flag entry stored on a FeatureFlagEvaluations snapshot.
+ */
+final class EvaluatedFlagRecord
+{
+    public function __construct(
+        public readonly string $key,
+        public readonly bool $enabled,
+        public readonly ?string $variant,
+        public readonly mixed $payload,
+        public readonly ?int $id,
+        public readonly ?int $version,
+        public readonly ?string $reason,
+        public readonly bool $locallyEvaluated,
+    ) {
+    }
+
+    /**
+     * The value as $feature_flag_response would render it: variant string when set, otherwise the enabled bool.
+     */
+    public function getValue(): bool|string
+    {
+        return $this->variant ?? $this->enabled;
+    }
+}

--- a/lib/FeatureFlagEvaluations.php
+++ b/lib/FeatureFlagEvaluations.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace PostHog;
+
+/**
+ * Snapshot of feature flag evaluations for a single distinct id.
+ *
+ * Created by Client::evaluateFlags(), this object lets callers read flag values, check enablement,
+ * and pull payloads without paying additional /flags requests. Reads via isEnabled() and getFlag()
+ * record access and trigger a deduped $feature_flag_called event; getFlagPayload() is silent.
+ */
+class FeatureFlagEvaluations
+{
+    /** @var array<string, bool> */
+    private array $accessed;
+
+    /**
+     * @param array<string, EvaluatedFlagRecord> $flags
+     * @param array<string, mixed> $groups
+     */
+    public function __construct(
+        private readonly string $distinctId,
+        private readonly array $flags,
+        private readonly array $groups,
+        private readonly FeatureFlagEvaluationsHost $host,
+        private readonly ?string $requestId = null,
+        private readonly bool $logWarnings = true,
+        ?array $accessed = null,
+    ) {
+        $this->accessed = $accessed ?? [];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getKeys(): array
+    {
+        return array_keys($this->flags);
+    }
+
+    /**
+     * Whether the flag is enabled for the snapshot's distinct id. Returns false for unknown keys.
+     */
+    public function isEnabled(string $key): bool
+    {
+        $record = $this->flags[$key] ?? null;
+        $this->recordAccess($key, $record);
+
+        return $record?->enabled ?? false;
+    }
+
+    /**
+     * Returns the variant (string), enabled state (bool), or null for unknown keys.
+     */
+    public function getFlag(string $key): bool|string|null
+    {
+        $record = $this->flags[$key] ?? null;
+        $this->recordAccess($key, $record);
+
+        if ($record === null) {
+            return null;
+        }
+
+        return $record->getValue();
+    }
+
+    /**
+     * Returns the decoded payload for a flag without recording access or firing a $feature_flag_called event.
+     * Returns null for unknown keys or flags without a payload.
+     */
+    public function getFlagPayload(string $key): mixed
+    {
+        return $this->flags[$key]->payload ?? null;
+    }
+
+    /**
+     * Returns a clone of this snapshot containing only flags that were previously accessed via
+     * isEnabled() or getFlag(). When nothing has been accessed yet, logs a warning and returns a
+     * full clone so callers don't silently emit empty $feature/* property bags.
+     */
+    public function onlyAccessed(): self
+    {
+        if (count($this->accessed) === 0) {
+            $this->emitWarning(
+                'FeatureFlagEvaluations::onlyAccessed() called before any flag was accessed; returning all flags.'
+            );
+
+            return $this->cloneWith($this->flags);
+        }
+
+        $filtered = [];
+        foreach ($this->accessed as $key => $_) {
+            if (isset($this->flags[$key])) {
+                $filtered[$key] = $this->flags[$key];
+            }
+        }
+
+        return $this->cloneWith($filtered);
+    }
+
+    /**
+     * Returns a clone of this snapshot filtered to the given keys. Unknown keys are dropped with a
+     * warning so silent typos don't slip into captured events.
+     *
+     * @param list<string> $keys
+     */
+    public function only(array $keys): self
+    {
+        $filtered = [];
+        foreach ($keys as $key) {
+            if (isset($this->flags[$key])) {
+                $filtered[$key] = $this->flags[$key];
+            } else {
+                $this->emitWarning(
+                    sprintf('FeatureFlagEvaluations::only() dropped unknown flag key "%s".', $key)
+                );
+            }
+        }
+
+        return $this->cloneWith($filtered);
+    }
+
+    /**
+     * Properties to merge onto a captured event when it carries this snapshot. Adds $feature/<key>
+     * for every flag and a sorted $active_feature_flags list for enabled flags.
+     *
+     * @return array<string, mixed>
+     */
+    public function getEventProperties(): array
+    {
+        $properties = [];
+        $active = [];
+        foreach ($this->flags as $key => $record) {
+            $properties['$feature/' . $key] = $record->getValue();
+            if ($record->enabled) {
+                $active[] = $key;
+            }
+        }
+        sort($active);
+        $properties['$active_feature_flags'] = $active;
+
+        return $properties;
+    }
+
+    /**
+     * Records that $key was accessed and fires a deduped $feature_flag_called event when the
+     * snapshot is bound to a real distinct id. Empty distinct ids short-circuit so we never leak
+     * events with an empty actor.
+     */
+    private function recordAccess(string $key, ?EvaluatedFlagRecord $record): void
+    {
+        $this->accessed[$key] = true;
+
+        if ($this->distinctId === '') {
+            return;
+        }
+
+        $properties = [
+            '$feature_flag' => $key,
+            '$feature_flag_response' => $record?->getValue() ?? false,
+        ];
+
+        if ($record === null) {
+            $properties['$feature_flag_error'] = FeatureFlagError::FLAG_MISSING;
+        } else {
+            if ($record->id !== null) {
+                $properties['$feature_flag_id'] = $record->id;
+            }
+            if ($record->version !== null) {
+                $properties['$feature_flag_version'] = $record->version;
+            }
+            if ($record->reason !== null) {
+                $properties['$feature_flag_reason'] = $record->reason;
+            }
+            if ($record->locallyEvaluated) {
+                $properties['locally_evaluated'] = true;
+            }
+        }
+
+        // request_id is per /flags response; locally-evaluated records aren't tied to a remote
+        // call so we omit it for them, matching the existing single-flag local path.
+        if ($this->requestId !== null && !($record?->locallyEvaluated ?? false)) {
+            $properties['$feature_flag_request_id'] = $this->requestId;
+        }
+
+        $this->host->captureFlagCalledIfNeeded(
+            $this->distinctId,
+            $key,
+            $properties,
+            $this->groups
+        );
+    }
+
+    /**
+     * @param array<string, EvaluatedFlagRecord> $flags
+     */
+    private function cloneWith(array $flags): self
+    {
+        // Filtered views start with an empty access set so reads on the child don't propagate back
+        // into the parent's view. PHP's value-copy semantics on arrays already give us isolation.
+        return new self(
+            $this->distinctId,
+            $flags,
+            $this->groups,
+            $this->host,
+            $this->requestId,
+            $this->logWarnings,
+            [],
+        );
+    }
+
+    private function emitWarning(string $message): void
+    {
+        if ($this->logWarnings) {
+            $this->host->logWarning($message);
+        }
+    }
+}

--- a/lib/FeatureFlagEvaluations.php
+++ b/lib/FeatureFlagEvaluations.php
@@ -24,7 +24,7 @@ class FeatureFlagEvaluations
         private readonly array $groups,
         private readonly FeatureFlagEvaluationsHost $host,
         private readonly ?string $requestId = null,
-        private readonly bool $logWarnings = true,
+        private readonly ?int $evaluatedAt = null,
         ?array $accessed = null,
         private readonly bool $errorsWhileComputing = false,
         private readonly bool $quotaLimited = false,
@@ -105,7 +105,7 @@ class FeatureFlagEvaluations
             if (isset($this->flags[$key])) {
                 $filtered[$key] = $this->flags[$key];
             } else {
-                $this->emitWarning(
+                $this->host->logWarning(
                     sprintf('FeatureFlagEvaluations::only() dropped unknown flag key "%s".', $key)
                 );
             }
@@ -151,7 +151,11 @@ class FeatureFlagEvaluations
 
         $properties = [
             '$feature_flag' => $key,
-            '$feature_flag_response' => $record?->getValue() ?? false,
+            // Missing flags get a null response (not false), matching the legacy single-flag path
+            // so consumers can distinguish "flag exists and is disabled" from "flag not found".
+            '$feature_flag_response' => $record?->getValue(),
+            // Always set explicitly so consumers don't have to infer "missing key means remote".
+            'locally_evaluated' => $record?->locallyEvaluated ?? false,
         ];
 
         if ($record !== null) {
@@ -164,15 +168,16 @@ class FeatureFlagEvaluations
             if ($record->reason !== null) {
                 $properties['$feature_flag_reason'] = $record->reason;
             }
-            if ($record->locallyEvaluated) {
-                $properties['locally_evaluated'] = true;
-            }
         }
 
-        // request_id is per /flags response; locally-evaluated records aren't tied to a remote
-        // call so we omit it for them, matching the existing single-flag local path.
-        if ($this->requestId !== null && !($record?->locallyEvaluated ?? false)) {
+        // request_id and evaluated_at are per /flags response; locally-evaluated records aren't
+        // tied to a remote call so we omit them for those, matching the legacy single-flag path.
+        $isLocal = $record?->locallyEvaluated ?? false;
+        if ($this->requestId !== null && !$isLocal) {
             $properties['$feature_flag_request_id'] = $this->requestId;
+        }
+        if ($this->evaluatedAt !== null && !$isLocal) {
+            $properties['$feature_flag_evaluated_at'] = $this->evaluatedAt;
         }
 
         // Build a comma-joined $feature_flag_error matching the single-flag path's granularity:
@@ -212,17 +217,10 @@ class FeatureFlagEvaluations
             $this->groups,
             $this->host,
             $this->requestId,
-            $this->logWarnings,
+            $this->evaluatedAt,
             [],
             $this->errorsWhileComputing,
             $this->quotaLimited,
         );
-    }
-
-    private function emitWarning(string $message): void
-    {
-        if ($this->logWarnings) {
-            $this->host->logWarning($message);
-        }
     }
 }

--- a/lib/FeatureFlagEvaluations.php
+++ b/lib/FeatureFlagEvaluations.php
@@ -26,6 +26,8 @@ class FeatureFlagEvaluations
         private readonly ?string $requestId = null,
         private readonly bool $logWarnings = true,
         ?array $accessed = null,
+        private readonly bool $errorsWhileComputing = false,
+        private readonly bool $quotaLimited = false,
     ) {
         $this->accessed = $accessed ?? [];
     }
@@ -75,19 +77,11 @@ class FeatureFlagEvaluations
 
     /**
      * Returns a clone of this snapshot containing only flags that were previously accessed via
-     * isEnabled() or getFlag(). When nothing has been accessed yet, logs a warning and returns a
-     * full clone so callers don't silently emit empty $feature/* property bags.
+     * isEnabled() or getFlag(). Order-dependent: if nothing has been accessed yet, the returned
+     * snapshot is empty. The method honors its name — pre-access if you want a populated result.
      */
     public function onlyAccessed(): self
     {
-        if (count($this->accessed) === 0) {
-            $this->emitWarning(
-                'FeatureFlagEvaluations::onlyAccessed() called before any flag was accessed; returning all flags.'
-            );
-
-            return $this->cloneWith($this->flags);
-        }
-
         $filtered = [];
         foreach ($this->accessed as $key => $_) {
             if (isset($this->flags[$key])) {
@@ -160,9 +154,7 @@ class FeatureFlagEvaluations
             '$feature_flag_response' => $record?->getValue() ?? false,
         ];
 
-        if ($record === null) {
-            $properties['$feature_flag_error'] = FeatureFlagError::FLAG_MISSING;
-        } else {
+        if ($record !== null) {
             if ($record->id !== null) {
                 $properties['$feature_flag_id'] = $record->id;
             }
@@ -181,6 +173,22 @@ class FeatureFlagEvaluations
         // call so we omit it for them, matching the existing single-flag local path.
         if ($this->requestId !== null && !($record?->locallyEvaluated ?? false)) {
             $properties['$feature_flag_request_id'] = $this->requestId;
+        }
+
+        // Build a comma-joined $feature_flag_error matching the single-flag path's granularity:
+        // response-level errors combine with per-flag errors so consumers can filter by type.
+        $errors = [];
+        if ($this->errorsWhileComputing) {
+            $errors[] = FeatureFlagError::ERRORS_WHILE_COMPUTING_FLAGS;
+        }
+        if ($this->quotaLimited) {
+            $errors[] = FeatureFlagError::QUOTA_LIMITED;
+        }
+        if ($record === null) {
+            $errors[] = FeatureFlagError::FLAG_MISSING;
+        }
+        if (!empty($errors)) {
+            $properties['$feature_flag_error'] = implode(',', $errors);
         }
 
         $this->host->captureFlagCalledIfNeeded(
@@ -206,6 +214,8 @@ class FeatureFlagEvaluations
             $this->requestId,
             $this->logWarnings,
             [],
+            $this->errorsWhileComputing,
+            $this->quotaLimited,
         );
     }
 

--- a/lib/FeatureFlagEvaluationsHost.php
+++ b/lib/FeatureFlagEvaluationsHost.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace PostHog;
+
+/**
+ * Narrow callback surface that FeatureFlagEvaluations uses to interact with its owning Client.
+ *
+ * Splitting the interface out keeps the snapshot easy to unit-test with a fake host instead of a
+ * full Client.
+ */
+interface FeatureFlagEvaluationsHost
+{
+    /**
+     * Fire a $feature_flag_called event for ($distinctId, $key) unless it has already been recorded
+     * for this distinct id within the dedup window.
+     *
+     * The properties array is built by the caller so this helper does not need to reconstruct the
+     * shape from raw response data.
+     *
+     * @param array<string, mixed> $properties
+     * @param array<string, mixed> $groups
+     */
+    public function captureFlagCalledIfNeeded(
+        string $distinctId,
+        string $key,
+        array $properties,
+        array $groups
+    ): void;
+
+    /**
+     * Emit a non-fatal warning. Implementations may suppress these when feature_flags_log_warnings
+     * is disabled in the client configuration.
+     */
+    public function logWarning(string $message): void;
+}

--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -206,10 +206,9 @@ class PostHog
     }
 
     /**
-     * Get the feature flag result including value and payload.
-     *
-     * This is the recommended method for getting feature flag data as it returns
-     * both the flag value and payload in a single call, while properly tracking analytics.
+     * @deprecated Use `evaluateFlags($distinctId, ...)` and call `$flags->getFlag($key)` and
+     * `$flags->getFlagPayload($key)` instead. This consolidates flag evaluation into a single
+     * `/flags` request per incoming request.
      *
      * @param string $key
      * @param string $distinctId

--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -266,6 +266,38 @@ class PostHog
     }
 
     /**
+     * Evaluate every feature flag for a distinct id in a single round trip and return a snapshot.
+     * Pass the snapshot to capture() via the `flags` key to attach $feature/<key> properties
+     * without making another /flags request.
+     *
+     * @param array $groups
+     * @param array $personProperties
+     * @param array $groupProperties
+     * @param list<string>|null $flagKeys When set, scope the underlying /flags request to these keys.
+     * @throws Exception
+     */
+    public static function evaluateFlags(
+        string $distinctId,
+        array $groups = array(),
+        array $personProperties = array(),
+        array $groupProperties = array(),
+        bool $onlyEvaluateLocally = false,
+        bool $disableGeoip = false,
+        ?array $flagKeys = null
+    ): FeatureFlagEvaluations {
+        self::checkClient();
+        return self::$client->evaluateFlags(
+            $distinctId,
+            $groups,
+            $personProperties,
+            $groupProperties,
+            $onlyEvaluateLocally,
+            $disableGeoip,
+            $flagKeys
+        );
+    }
+
+    /**
      * get all enabled flags for distinct_id
      *
      * @param string $distinctId

--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -138,7 +138,9 @@ class PostHog
     }
 
     /**
-     * decide if the feature flag is enabled for this distinct id.
+     * @deprecated Use `evaluateFlags($distinctId, ...)` and call
+     * `$flags->isEnabled($key)` instead. This consolidates flag evaluation into a single
+     * `/flags` request per incoming request.
      *
      * @param string $key
      * @param string $distinctId
@@ -170,7 +172,9 @@ class PostHog
     }
 
     /**
-     * get the feature flag value for this distinct id.
+     * @deprecated Use `evaluateFlags($distinctId, ...)` and call
+     * `$flags->getFlag($key)` instead. This consolidates flag evaluation into a single
+     * `/flags` request per incoming request.
      *
      * @param string $key
      * @param string $distinctId
@@ -239,8 +243,9 @@ class PostHog
     }
 
     /**
-     * @deprecated Use getFeatureFlagResult() instead. This method does not send
-     * the $feature_flag_called event, leading to missing analytics.
+     * @deprecated Use `evaluateFlags($distinctId, ...)` and call
+     * `$flags->getFlagPayload($key)` instead. This consolidates flag evaluation into a single
+     * `/flags` request per incoming request.
      *
      * @param string $key
      * @param string $distinctId

--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -273,7 +273,11 @@ class PostHog
      * @param array $groups
      * @param array $personProperties
      * @param array $groupProperties
-     * @param list<string>|null $flagKeys When set, scope the underlying /flags request to these keys.
+     * @param list<string>|null $flagKeys Optional list of flag keys. When provided, only these
+     *     flags are evaluated — the underlying /flags request asks the server for just this
+     *     subset, which makes the response smaller and the request cheaper. Use this when you
+     *     only need a handful of flags out of many. Distinct from FeatureFlagEvaluations::only(),
+     *     which scopes which already-evaluated flags get attached to a captured event.
      * @throws Exception
      */
     public static function evaluateFlags(

--- a/lib/SizeLimitedHash.php
+++ b/lib/SizeLimitedHash.php
@@ -28,19 +28,15 @@ class SizeLimitedHash
         }
 
         if (array_key_exists($key, $this->mapping)) {
-            array_push($this->mapping, $element);
+            $this->mapping[$key][$element] = true;
         } else {
-            $this->mapping[$key] = [$element];
+            $this->mapping[$key] = [$element => true];
         }
     }
 
     public function contains($key, $element)
     {
-        if (array_key_exists($key, $this->mapping) && array_key_exists($element, $this->mapping[$key])) {
-            return true;
-        }
-
-        return false;
+        return isset($this->mapping[$key][$element]);
     }
 
     public function count()

--- a/test/FakeFlagEvaluationsHost.php
+++ b/test/FakeFlagEvaluationsHost.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace PostHog\Test;
+
+use PostHog\FeatureFlagEvaluationsHost;
+
+/**
+ * In-memory FeatureFlagEvaluationsHost implementation used by FeatureFlagEvaluationsTest. Records
+ * each interaction so tests can assert on it without spinning up a real Client.
+ */
+class FakeFlagEvaluationsHost implements FeatureFlagEvaluationsHost
+{
+    /** @var array<int, array<string, mixed>> */
+    public array $captures = [];
+    /** @var list<string> */
+    public array $warnings = [];
+    /** @var array<string, true> */
+    private array $seen = [];
+
+    public function captureFlagCalledIfNeeded(
+        string $distinctId,
+        string $key,
+        array $properties,
+        array $groups
+    ): void {
+        $cacheKey = $distinctId . "\0" . $key;
+        if (isset($this->seen[$cacheKey])) {
+            return;
+        }
+        $this->seen[$cacheKey] = true;
+        $this->captures[] = [
+            'distinct_id' => $distinctId,
+            'key' => $key,
+            'properties' => $properties,
+            'groups' => $groups,
+        ];
+    }
+
+    public function logWarning(string $message): void
+    {
+        $this->warnings[] = $message;
+    }
+}

--- a/test/FeatureFlagEvaluationsTest.php
+++ b/test/FeatureFlagEvaluationsTest.php
@@ -49,9 +49,11 @@ class FeatureFlagEvaluationsTest extends TestCase
 
     private function flagsRequestCount(): int
     {
+        // Counts the runtime /flags endpoint only; the /flags/definitions local-evaluation
+        // poller hits a different path and shouldn't be conflated with per-request evaluation.
         $count = 0;
         foreach ($this->http_client->calls ?? [] as $call) {
-            if (str_starts_with($call['path'], '/flags/')) {
+            if (str_starts_with($call['path'], '/flags/?')) {
                 $count++;
             }
         }
@@ -132,7 +134,7 @@ class FeatureFlagEvaluationsTest extends TestCase
         $this->assertSame(1, $properties['$feature_flag_version']);
         $this->assertSame('Matched condition set 1', $properties['$feature_flag_reason']);
         $this->assertSame('98487c8a-287a-4451-a085-299cd76228dd', $properties['$feature_flag_request_id']);
-        $this->assertArrayNotHasKey('locally_evaluated', $properties);
+        $this->assertFalse($properties['locally_evaluated']);
     }
 
     public function testGetFlagFiresEventOnFirstAccessDedupedOnSecond(): void
@@ -360,6 +362,64 @@ class FeatureFlagEvaluationsTest extends TestCase
         $this->assertSame(1, $properties['$feature_flag_id']);
         $this->assertArrayNotHasKey('$feature_flag_version', $properties);
         $this->assertArrayNotHasKey('$feature_flag_request_id', $properties);
+        $this->assertArrayNotHasKey('$feature_flag_evaluated_at', $properties);
+    }
+
+    public function testLocalEvaluationSkipsRemoteFlagsRequestWhenAllResolved(): void
+    {
+        // When local definitions cover every flag and they all evaluate without inconclusive
+        // results, evaluateFlags() should skip the /flags request entirely.
+        $this->makeClient(
+            personalApiKey: 'test-personal-key',
+            localEvaluationResponse: MockedResponses::LOCAL_EVALUATION_REQUEST,
+        );
+        PostHog::evaluateFlags('user-1', personProperties: ['region' => 'USA']);
+
+        $this->assertSame(0, $this->flagsRequestCount());
+    }
+
+    public function testRemoteEvaluatedAtPropagatesToEvent(): void
+    {
+        $response = MockedResponses::FLAGS_V2_RESPONSE;
+        $response['evaluatedAt'] = 1714435200;
+        $this->makeClient(flagsEndpointResponse: $response);
+
+        $snapshot = PostHog::evaluateFlags('user-1');
+        $snapshot->isEnabled('simple-test');
+        PostHog::flush();
+
+        $batches = $this->batchRequests();
+        $this->assertCount(1, $batches);
+        $this->assertSame(
+            1714435200,
+            $batches[0]['batch'][0]['properties']['$feature_flag_evaluated_at']
+        );
+    }
+
+    public function testMissingFlagResponseIsNullNotFalse(): void
+    {
+        $this->makeClient();
+        $snapshot = PostHog::evaluateFlags('user-1');
+        $snapshot->isEnabled('does-not-exist');
+        PostHog::flush();
+
+        $batches = $this->batchRequests();
+        $this->assertCount(1, $batches);
+        $properties = $batches[0]['batch'][0]['properties'];
+        $this->assertNull($properties['$feature_flag_response']);
+        $this->assertFalse($properties['locally_evaluated']);
+    }
+
+    public function testRemotePayloadHandlesPreDecodedValue(): void
+    {
+        // Some middleware may transparently decode JSON payloads before they reach the SDK; the
+        // snapshot should accept the value as-is rather than json_decode-ing a non-string.
+        $response = MockedResponses::FLAGS_V2_RESPONSE;
+        $response['flags']['json-payload']['metadata']['payload'] = ['already' => 'decoded'];
+        $this->makeClient(flagsEndpointResponse: $response);
+
+        $snapshot = PostHog::evaluateFlags('user-1');
+        $this->assertSame(['already' => 'decoded'], $snapshot->getFlagPayload('json-payload'));
     }
 
     public function testCaptureFlagsTakesPrecedenceOverSendFeatureFlags(): void
@@ -413,24 +473,6 @@ class FeatureFlagEvaluationsTest extends TestCase
         $this->assertStringNotContainsString('FeatureFlagEvaluations', $rawPayload);
         $batches = $this->batchRequests();
         $this->assertArrayNotHasKey('flags', $batches[0]['batch'][0]);
-    }
-
-    public function testFeatureFlagsLogWarningsFalseSilencesFilterWarnings(): void
-    {
-        $host = new FakeFlagEvaluationsHost();
-        $snapshot = new FeatureFlagEvaluations(
-            'user-1',
-            ['flag-a' => $this->makeRecord('flag-a', true)],
-            [],
-            $host,
-            null,
-            false,
-        );
-
-        $snapshot->only(['unknown']);
-        $snapshot->onlyAccessed();
-
-        $this->assertSame([], $host->warnings);
     }
 
     public function testCaptureWarnsWhenBothFlagsAndSendFeatureFlagsSet(): void

--- a/test/FeatureFlagEvaluationsTest.php
+++ b/test/FeatureFlagEvaluationsTest.php
@@ -195,7 +195,7 @@ class FeatureFlagEvaluationsTest extends TestCase
         $this->assertStringContainsString('unknown-flag', $host->warnings[0]);
     }
 
-    public function testOnlyAccessedFallsBackAndWarnsWhenEmpty(): void
+    public function testOnlyAccessedReturnsEmptyWhenNoFlagsAccessed(): void
     {
         $host = new FakeFlagEvaluationsHost();
         $snapshot = new FeatureFlagEvaluations(
@@ -210,8 +210,8 @@ class FeatureFlagEvaluationsTest extends TestCase
 
         $filtered = $snapshot->onlyAccessed();
 
-        $this->assertEqualsCanonicalizing(['flag-a', 'flag-b'], $filtered->getKeys());
-        $this->assertCount(1, $host->warnings);
+        $this->assertSame([], $filtered->getKeys());
+        $this->assertSame([], $host->warnings);
     }
 
     public function testOnlyAccessedReturnsSubsetWhenAccessed(): void
@@ -431,6 +431,77 @@ class FeatureFlagEvaluationsTest extends TestCase
         $snapshot->onlyAccessed();
 
         $this->assertSame([], $host->warnings);
+    }
+
+    public function testCaptureWarnsWhenBothFlagsAndSendFeatureFlagsSet(): void
+    {
+        global $errorMessages;
+        $errorMessages = [];
+
+        $this->makeClient();
+        $host = new FakeFlagEvaluationsHost();
+        $snapshot = new FeatureFlagEvaluations(
+            'user-1',
+            ['flag-a' => $this->makeRecord('flag-a', true)],
+            [],
+            $host,
+        );
+
+        PostHog::capture([
+            'distinctId' => 'user-1',
+            'event' => 'page_view',
+            'flags' => $snapshot,
+            'send_feature_flags' => true,
+        ]);
+        PostHog::flush();
+
+        $warned = false;
+        foreach ($errorMessages as $message) {
+            if (str_contains($message, 'Both `flags` and `send_feature_flags`')) {
+                $warned = true;
+                break;
+            }
+        }
+        $this->assertTrue($warned, 'Expected warning when both `flags` and `send_feature_flags` are set');
+
+        // No extra /flags request.
+        $this->assertSame(0, $this->flagsRequestCount());
+    }
+
+    public function testErrorsWhileComputingFlagsPropagatesToEvent(): void
+    {
+        $errorResponse = MockedResponses::FLAGS_V2_RESPONSE;
+        $errorResponse['errorsWhileComputingFlags'] = true;
+        $this->makeClient(flagsEndpointResponse: $errorResponse);
+
+        $snapshot = PostHog::evaluateFlags('user-1');
+        $snapshot->isEnabled('simple-test');
+        PostHog::flush();
+
+        $batches = $this->batchRequests();
+        $this->assertCount(1, $batches);
+        $this->assertSame(
+            'errors_while_computing_flags',
+            $batches[0]['batch'][0]['properties']['$feature_flag_error']
+        );
+    }
+
+    public function testErrorsWhileComputingFlagsCombinesWithFlagMissing(): void
+    {
+        $errorResponse = MockedResponses::FLAGS_V2_RESPONSE;
+        $errorResponse['errorsWhileComputingFlags'] = true;
+        $this->makeClient(flagsEndpointResponse: $errorResponse);
+
+        $snapshot = PostHog::evaluateFlags('user-1');
+        $snapshot->isEnabled('does-not-exist');
+        PostHog::flush();
+
+        $batches = $this->batchRequests();
+        $this->assertCount(1, $batches);
+        $this->assertSame(
+            'errors_while_computing_flags,flag_missing',
+            $batches[0]['batch'][0]['properties']['$feature_flag_error']
+        );
     }
 
     public function testSnapshotDedupesAcrossClientPaths(): void

--- a/test/FeatureFlagEvaluationsTest.php
+++ b/test/FeatureFlagEvaluationsTest.php
@@ -511,12 +511,106 @@ class FeatureFlagEvaluationsTest extends TestCase
         $snapshot->isEnabled('simple-test');
 
         // The single-flag path should be deduped against the snapshot's earlier event because
-        // both share the Client's distinctIdsFeatureFlagsReported cache.
-        PostHog::isFeatureEnabled('simple-test', 'user-1');
+        // both share the Client's distinctIdsFeatureFlagsReported cache. The legacy single-flag
+        // method also emits a deprecation; we suppress it here so the test focuses on dedup.
+        $this->captureDeprecations(fn() => PostHog::isFeatureEnabled('simple-test', 'user-1'));
         PostHog::flush();
 
         $batches = $this->batchRequests();
         $this->assertCount(1, $batches);
         $this->assertCount(1, $batches[0]['batch']);
+    }
+
+    /**
+     * @return list<string> the deprecation messages emitted while running $callable
+     */
+    private function captureDeprecations(callable $callable): array
+    {
+        $messages = [];
+        $previous = set_error_handler(
+            function (int $errno, string $errstr) use (&$messages, &$previous) {
+                if ($errno === E_USER_DEPRECATED) {
+                    $messages[] = $errstr;
+                    return true;
+                }
+                if ($previous !== null) {
+                    return ($previous)($errno, $errstr);
+                }
+                return false;
+            },
+            E_USER_DEPRECATED
+        );
+
+        try {
+            $callable();
+        } finally {
+            restore_error_handler();
+        }
+
+        return $messages;
+    }
+
+    public function testIsFeatureEnabledEmitsDeprecationWarning(): void
+    {
+        $this->makeClient();
+        $messages = $this->captureDeprecations(
+            fn() => $this->client->isFeatureEnabled('simple-test', 'user-1')
+        );
+
+        $this->assertCount(1, $messages, 'Expected exactly one deprecation warning');
+        $this->assertStringContainsString('isFeatureEnabled', $messages[0]);
+        $this->assertStringContainsString('evaluateFlags', $messages[0]);
+    }
+
+    public function testGetFeatureFlagEmitsDeprecationWarning(): void
+    {
+        $this->makeClient();
+        $messages = $this->captureDeprecations(
+            fn() => $this->client->getFeatureFlag('simple-test', 'user-1')
+        );
+
+        $this->assertCount(1, $messages);
+        $this->assertStringContainsString('getFeatureFlag', $messages[0]);
+        $this->assertStringContainsString('evaluateFlags', $messages[0]);
+    }
+
+    public function testGetFeatureFlagPayloadEmitsDeprecationWarning(): void
+    {
+        $this->makeClient();
+        $messages = $this->captureDeprecations(
+            fn() => $this->client->getFeatureFlagPayload('json-payload', 'user-1')
+        );
+
+        $this->assertCount(1, $messages);
+        $this->assertStringContainsString('getFeatureFlagPayload', $messages[0]);
+        $this->assertStringContainsString('evaluateFlags', $messages[0]);
+    }
+
+    public function testCaptureSendFeatureFlagsEmitsDeprecationWarning(): void
+    {
+        $this->makeClient();
+        $messages = $this->captureDeprecations(
+            fn() => $this->client->capture([
+                'distinct_id' => 'user-1',
+                'event' => 'page_view',
+                'send_feature_flags' => true,
+            ])
+        );
+
+        $this->assertCount(1, $messages);
+        $this->assertStringContainsString('send_feature_flags', $messages[0]);
+        $this->assertStringContainsString('evaluateFlags', $messages[0]);
+    }
+
+    public function testIsFeatureEnabledDoesNotCascadeDeprecationWarnings(): void
+    {
+        // isFeatureEnabled bypasses the public getFeatureFlag() so users see only one
+        // warning per call, not two (or three if getFeatureFlagResult were also deprecated).
+        $this->makeClient();
+        $messages = $this->captureDeprecations(
+            fn() => $this->client->isFeatureEnabled('simple-test', 'user-1')
+        );
+
+        $this->assertCount(1, $messages);
     }
 }

--- a/test/FeatureFlagEvaluationsTest.php
+++ b/test/FeatureFlagEvaluationsTest.php
@@ -1,5 +1,6 @@
 <?php
 
+// phpcs:disable PSR1.Files.SideEffects
 namespace PostHog\Test;
 
 // comment out below to print all logs instead of failing tests

--- a/test/FeatureFlagEvaluationsTest.php
+++ b/test/FeatureFlagEvaluationsTest.php
@@ -1,0 +1,450 @@
+<?php
+
+namespace PostHog\Test;
+
+// comment out below to print all logs instead of failing tests
+require_once 'test/error_log_mock.php';
+
+use PHPUnit\Framework\TestCase;
+use PostHog\Client;
+use PostHog\EvaluatedFlagRecord;
+use PostHog\FeatureFlagEvaluations;
+use PostHog\PostHog;
+use PostHog\Test\Assets\MockedResponses;
+
+class FeatureFlagEvaluationsTest extends TestCase
+{
+    private const FAKE_API_KEY = 'random_key';
+
+    private MockedHttpClient $http_client;
+    private Client $client;
+
+    public function setUp(): void
+    {
+        date_default_timezone_set('UTC');
+        global $errorMessages;
+        $errorMessages = [];
+    }
+
+    private function makeClient(
+        $flagsEndpointResponse = MockedResponses::FLAGS_V2_RESPONSE,
+        $localEvaluationResponse = [],
+        ?string $personalApiKey = null,
+        array $options = []
+    ): void {
+        $this->http_client = new MockedHttpClient(
+            'app.posthog.com',
+            flagEndpointResponse: $localEvaluationResponse,
+            flagsEndpointResponse: $flagsEndpointResponse
+        );
+        $this->client = new Client(
+            self::FAKE_API_KEY,
+            $options,
+            $this->http_client,
+            $personalApiKey
+        );
+        PostHog::init(null, null, $this->client);
+    }
+
+    private function flagsRequestCount(): int
+    {
+        $count = 0;
+        foreach ($this->http_client->calls ?? [] as $call) {
+            if (str_starts_with($call['path'], '/flags/')) {
+                $count++;
+            }
+        }
+        return $count;
+    }
+
+    private function batchRequests(): array
+    {
+        $batches = [];
+        foreach ($this->http_client->calls ?? [] as $call) {
+            if (str_starts_with($call['path'], '/batch/')) {
+                $batches[] = json_decode($call['payload'], true);
+            }
+        }
+        return $batches;
+    }
+
+    private function makeRecord(
+        string $key,
+        bool $enabled,
+        ?string $variant = null,
+        mixed $payload = null,
+        ?int $id = null,
+        ?int $version = null,
+        ?string $reason = null,
+        bool $locallyEvaluated = false
+    ): EvaluatedFlagRecord {
+        return new EvaluatedFlagRecord(
+            key: $key,
+            enabled: $enabled,
+            variant: $variant,
+            payload: $payload,
+            id: $id,
+            version: $version,
+            reason: $reason,
+            locallyEvaluated: $locallyEvaluated,
+        );
+    }
+
+    public function testEvaluateFlagsReturnsSnapshotAndMakesOneFlagsRequest(): void
+    {
+        $this->makeClient();
+        $snapshot = PostHog::evaluateFlags('user-1');
+
+        $this->assertInstanceOf(FeatureFlagEvaluations::class, $snapshot);
+        $this->assertSame(1, $this->flagsRequestCount());
+        $this->assertContains('simple-test', $snapshot->getKeys());
+        $this->assertContains('multivariate-test', $snapshot->getKeys());
+    }
+
+    public function testNoFeatureFlagCalledEventsUntilAccess(): void
+    {
+        $this->makeClient();
+        PostHog::evaluateFlags('user-1');
+        PostHog::flush();
+
+        $this->assertSame([], $this->batchRequests());
+    }
+
+    public function testIsEnabledFiresEventWithFullMetadata(): void
+    {
+        $this->makeClient();
+        $snapshot = PostHog::evaluateFlags('user-1');
+
+        $this->assertTrue($snapshot->isEnabled('simple-test'));
+        PostHog::flush();
+
+        $batches = $this->batchRequests();
+        $this->assertCount(1, $batches);
+        $event = $batches[0]['batch'][0];
+
+        $this->assertSame('$feature_flag_called', $event['event']);
+        $this->assertSame('user-1', $event['distinct_id']);
+        $properties = $event['properties'];
+        $this->assertSame('simple-test', $properties['$feature_flag']);
+        $this->assertTrue($properties['$feature_flag_response']);
+        $this->assertSame(6, $properties['$feature_flag_id']);
+        $this->assertSame(1, $properties['$feature_flag_version']);
+        $this->assertSame('Matched condition set 1', $properties['$feature_flag_reason']);
+        $this->assertSame('98487c8a-287a-4451-a085-299cd76228dd', $properties['$feature_flag_request_id']);
+        $this->assertArrayNotHasKey('locally_evaluated', $properties);
+    }
+
+    public function testGetFlagFiresEventOnFirstAccessDedupedOnSecond(): void
+    {
+        $this->makeClient();
+        $snapshot = PostHog::evaluateFlags('user-1');
+
+        $snapshot->getFlag('multivariate-test');
+        $snapshot->getFlag('multivariate-test');
+        PostHog::flush();
+
+        $batches = $this->batchRequests();
+        $this->assertCount(1, $batches);
+        $this->assertCount(1, $batches[0]['batch']);
+        $this->assertSame('multivariate-test', $batches[0]['batch'][0]['properties']['$feature_flag']);
+        $this->assertSame('variant-value', $batches[0]['batch'][0]['properties']['$feature_flag_response']);
+    }
+
+    public function testGetFlagPayloadDoesNotFireEvent(): void
+    {
+        $this->makeClient();
+        $snapshot = PostHog::evaluateFlags('user-1');
+
+        $payload = $snapshot->getFlagPayload('json-payload');
+        PostHog::flush();
+
+        $this->assertSame(['key' => 'value'], $payload);
+        $this->assertSame([], $this->batchRequests());
+    }
+
+    public function testUnknownKeyAccessRecordsFlagMissingError(): void
+    {
+        $this->makeClient();
+        $snapshot = PostHog::evaluateFlags('user-1');
+
+        $this->assertNull($snapshot->getFlag('does-not-exist'));
+        $this->assertFalse($snapshot->isEnabled('does-not-exist'));
+        PostHog::flush();
+
+        $batches = $this->batchRequests();
+        $this->assertCount(1, $batches);
+        $properties = $batches[0]['batch'][0]['properties'];
+        $this->assertSame('flag_missing', $properties['$feature_flag_error']);
+    }
+
+    public function testOnlyWarnsOnUnknownKeys(): void
+    {
+        $host = new FakeFlagEvaluationsHost();
+        $snapshot = new FeatureFlagEvaluations(
+            'user-1',
+            ['flag-a' => $this->makeRecord('flag-a', true)],
+            [],
+            $host,
+        );
+
+        $filtered = $snapshot->only(['flag-a', 'unknown-flag']);
+
+        $this->assertSame(['flag-a'], $filtered->getKeys());
+        $this->assertCount(1, $host->warnings);
+        $this->assertStringContainsString('unknown-flag', $host->warnings[0]);
+    }
+
+    public function testOnlyAccessedFallsBackAndWarnsWhenEmpty(): void
+    {
+        $host = new FakeFlagEvaluationsHost();
+        $snapshot = new FeatureFlagEvaluations(
+            'user-1',
+            [
+                'flag-a' => $this->makeRecord('flag-a', true),
+                'flag-b' => $this->makeRecord('flag-b', false),
+            ],
+            [],
+            $host,
+        );
+
+        $filtered = $snapshot->onlyAccessed();
+
+        $this->assertEqualsCanonicalizing(['flag-a', 'flag-b'], $filtered->getKeys());
+        $this->assertCount(1, $host->warnings);
+    }
+
+    public function testOnlyAccessedReturnsSubsetWhenAccessed(): void
+    {
+        $host = new FakeFlagEvaluationsHost();
+        $snapshot = new FeatureFlagEvaluations(
+            'user-1',
+            [
+                'flag-a' => $this->makeRecord('flag-a', true),
+                'flag-b' => $this->makeRecord('flag-b', false),
+            ],
+            [],
+            $host,
+        );
+
+        $snapshot->isEnabled('flag-a');
+        $filtered = $snapshot->onlyAccessed();
+
+        $this->assertSame(['flag-a'], $filtered->getKeys());
+    }
+
+    public function testFilteredSnapshotsDoNotBackPropagateAccess(): void
+    {
+        $host = new FakeFlagEvaluationsHost();
+        $snapshot = new FeatureFlagEvaluations(
+            'user-1',
+            [
+                'flag-a' => $this->makeRecord('flag-a', true),
+                'flag-b' => $this->makeRecord('flag-b', true),
+            ],
+            [],
+            $host,
+        );
+
+        $snapshot->isEnabled('flag-a');
+        $filtered = $snapshot->onlyAccessed();
+
+        // Touch flag-b on the child; the parent's accessed set should still be {flag-a}.
+        $filtered->isEnabled('flag-b');
+
+        $parentAccessed = $snapshot->onlyAccessed();
+        $this->assertSame(['flag-a'], $parentAccessed->getKeys());
+    }
+
+    public function testCaptureFlagsAttachesFeaturePropertiesWithoutHttpRequest(): void
+    {
+        $this->makeClient();
+        $snapshot = PostHog::evaluateFlags('user-1');
+
+        $callsBefore = count($this->http_client->calls ?? []);
+
+        PostHog::capture([
+            'distinctId' => 'user-1',
+            'event' => 'page_view',
+            'flags' => $snapshot,
+        ]);
+        PostHog::flush();
+
+        $batches = $this->batchRequests();
+        $this->assertCount(1, $batches);
+        $event = $batches[0]['batch'][0];
+        $this->assertSame('page_view', $event['event']);
+        $this->assertTrue($event['properties']['$feature/simple-test']);
+        $this->assertSame('variant-value', $event['properties']['$feature/multivariate-test']);
+        $this->assertContains('simple-test', $event['properties']['$active_feature_flags']);
+        $this->assertNotContains('having_fun', $event['properties']['$active_feature_flags']);
+
+        // Capture only added one /batch/ call; no extra /flags/ request.
+        $newCalls = array_slice($this->http_client->calls, $callsBefore);
+        foreach ($newCalls as $call) {
+            $this->assertStringStartsNotWith('/flags/', $call['path']);
+        }
+    }
+
+    public function testFlagKeysIsForwardedInRequestBody(): void
+    {
+        $this->makeClient();
+        PostHog::evaluateFlags('user-1', flagKeys: ['simple-test', 'multivariate-test']);
+
+        $flagsCall = null;
+        foreach ($this->http_client->calls as $call) {
+            if (str_starts_with($call['path'], '/flags/')) {
+                $flagsCall = $call;
+                break;
+            }
+        }
+
+        $this->assertNotNull($flagsCall);
+        $payload = json_decode($flagsCall['payload'], true);
+        $this->assertSame(['simple-test', 'multivariate-test'], $payload['flag_keys_to_evaluate']);
+    }
+
+    public function testDisableGeoipIsForwardedInRequestBody(): void
+    {
+        $this->makeClient();
+        PostHog::evaluateFlags('user-1', disableGeoip: true);
+
+        $payload = null;
+        foreach ($this->http_client->calls as $call) {
+            if (str_starts_with($call['path'], '/flags/')) {
+                $payload = json_decode($call['payload'], true);
+                break;
+            }
+        }
+
+        $this->assertNotNull($payload);
+        $this->assertTrue($payload['geoip_disable']);
+    }
+
+    public function testEmptyDistinctIdSnapshotDoesNotFireEvents(): void
+    {
+        $this->makeClient();
+        $snapshot = PostHog::evaluateFlags('');
+
+        $this->assertSame([], $snapshot->getKeys());
+        $this->assertSame(0, $this->flagsRequestCount());
+
+        $snapshot->isEnabled('simple-test');
+        $snapshot->getFlag('multivariate-test');
+        PostHog::flush();
+
+        $this->assertSame([], $this->batchRequests());
+    }
+
+    public function testLocallyEvaluatedFlagTagsLocallyEvaluatedAndReason(): void
+    {
+        $this->makeClient(
+            personalApiKey: 'test-personal-key',
+            localEvaluationResponse: MockedResponses::LOCAL_EVALUATION_REQUEST,
+        );
+        $snapshot = PostHog::evaluateFlags(
+            'user-1',
+            personProperties: ['region' => 'USA']
+        );
+
+        $this->assertTrue($snapshot->isEnabled('person-flag'));
+        PostHog::flush();
+
+        $batches = $this->batchRequests();
+        $this->assertCount(1, $batches);
+        $properties = $batches[0]['batch'][0]['properties'];
+        $this->assertSame('person-flag', $properties['$feature_flag']);
+        $this->assertTrue($properties['$feature_flag_response']);
+        $this->assertSame('Evaluated locally', $properties['$feature_flag_reason']);
+        $this->assertTrue($properties['locally_evaluated']);
+        $this->assertSame(1, $properties['$feature_flag_id']);
+        $this->assertArrayNotHasKey('$feature_flag_version', $properties);
+        $this->assertArrayNotHasKey('$feature_flag_request_id', $properties);
+    }
+
+    public function testCaptureFlagsTakesPrecedenceOverSendFeatureFlags(): void
+    {
+        $this->makeClient();
+        $host = new FakeFlagEvaluationsHost();
+        $snapshot = new FeatureFlagEvaluations(
+            'user-1',
+            ['flag-a' => $this->makeRecord('flag-a', true)],
+            [],
+            $host,
+        );
+
+        PostHog::capture([
+            'distinctId' => 'user-1',
+            'event' => 'page_view',
+            'flags' => $snapshot,
+            'send_feature_flags' => true,
+        ]);
+        PostHog::flush();
+
+        $batches = $this->batchRequests();
+        $this->assertCount(1, $batches);
+        $properties = $batches[0]['batch'][0]['properties'];
+
+        // Only the snapshot's single flag is attached; send_feature_flags would have produced more.
+        $this->assertTrue($properties['$feature/flag-a']);
+        $this->assertSame(['flag-a'], $properties['$active_feature_flags']);
+        $this->assertSame(0, $this->flagsRequestCount());
+    }
+
+    public function testFlagsArgumentNotSerializedIntoEventPayload(): void
+    {
+        $this->makeClient();
+        $host = new FakeFlagEvaluationsHost();
+        $snapshot = new FeatureFlagEvaluations(
+            'user-1',
+            ['flag-a' => $this->makeRecord('flag-a', true)],
+            [],
+            $host,
+        );
+
+        PostHog::capture([
+            'distinctId' => 'user-1',
+            'event' => 'page_view',
+            'flags' => $snapshot,
+        ]);
+        PostHog::flush();
+
+        $rawPayload = $this->http_client->calls[0]['payload'];
+        $this->assertStringNotContainsString('FeatureFlagEvaluations', $rawPayload);
+        $batches = $this->batchRequests();
+        $this->assertArrayNotHasKey('flags', $batches[0]['batch'][0]);
+    }
+
+    public function testFeatureFlagsLogWarningsFalseSilencesFilterWarnings(): void
+    {
+        $host = new FakeFlagEvaluationsHost();
+        $snapshot = new FeatureFlagEvaluations(
+            'user-1',
+            ['flag-a' => $this->makeRecord('flag-a', true)],
+            [],
+            $host,
+            null,
+            false,
+        );
+
+        $snapshot->only(['unknown']);
+        $snapshot->onlyAccessed();
+
+        $this->assertSame([], $host->warnings);
+    }
+
+    public function testSnapshotDedupesAcrossClientPaths(): void
+    {
+        $this->makeClient();
+        $snapshot = PostHog::evaluateFlags('user-1');
+        $snapshot->isEnabled('simple-test');
+
+        // The single-flag path should be deduped against the snapshot's earlier event because
+        // both share the Client's distinctIdsFeatureFlagsReported cache.
+        PostHog::isFeatureEnabled('simple-test', 'user-1');
+        PostHog::flush();
+
+        $batches = $this->batchRequests();
+        $this->assertCount(1, $batches);
+        $this->assertCount(1, $batches[0]['batch']);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `evaluateFlags()`, a single-call flag evaluation API that returns a `FeatureFlagEvaluations` snapshot for one distinct id, and deprecates the legacy single-flag entry points in favor of it:

- One `/flags` request per call, and only when local evaluation can't cover everything; reads on the snapshot make zero further requests.
- `isEnabled($key)` / `getFlag($key)` fire a deduped `$feature_flag_called` event with full metadata (id, version, reason, request_id, evaluated_at, locally_evaluated, plus combined response-level errors) on first access. `getFlagPayload($key)` is silent.
- `only([...])` / `onlyAccessed()` return filtered clones for scoping which flags attach to a captured event.
- `capture(['flags' => $snapshot, …])` attaches `$feature/<key>` and `$active_feature_flags` without a fresh `/flags` round trip; warns when both `flags` and `send_feature_flags` are passed.
- `isFeatureEnabled()`, `getFeatureFlag()`, `getFeatureFlagResult()`, `getFeatureFlagPayload()`, and the `send_feature_flags` capture option emit `E_USER_DEPRECATED` pointing at `evaluateFlags()`. Existing callers keep working unchanged until the next major.

[RFC](https://github.com/PostHog/requests-for-comments-internal/pull/1020) · reference SDK PRs: [posthog-python#539](https://github.com/PostHog/posthog-python/pull/539), [posthog-js#3476](https://github.com/PostHog/posthog-js/pull/3476).

## Design decisions

- Snapshot takes a tiny `FeatureFlagEvaluationsHost` interface (`captureFlagCalledIfNeeded`, `logWarning`) instead of a full `Client`, so unit tests can use a fake without spinning up the SDK.
- Filtered clones get a fresh access set; reads on the child never back-propagate to the parent.
- `onlyAccessed()` returns an empty snapshot when nothing has been accessed (no warning, no fallback). The earlier "warn + return all flags" fallback was contradictory with the method's name and surprised callers doing `capture(flags: $snapshot->onlyAccessed())` early in a request.
- Empty-distinct_id snapshots short-circuit event emission inside `recordAccess` rather than at every call site, so `isEnabled` / `getFlag` still return sane values without leaking events with empty actors.
- Local pass tracks whether any flag was inconclusive (or any `flagKeys` aren't covered locally); when local evaluation answered everything, we skip the `/flags` request entirely.
- Locally-evaluated records omit `$feature_flag_request_id` and `$feature_flag_evaluated_at` (both are per-`/flags`-response) but always emit `locally_evaluated=true|false` and reason `"Evaluated locally"` for local records, matching the legacy single-flag path.
- Missing flags emit `$feature_flag_response: null` (not `false`), so consumers can distinguish "flag exists and is disabled" from "flag not found".
- Response-level errors (`errorsWhileComputingFlags`, `quota_limited`) are tracked at snapshot construction and combined with per-flag `flag_missing` in `$feature_flag_error` (e.g. `errors_while_computing_flags,flag_missing`).
- `flags=` on `capture()` takes precedence over `send_feature_flags`; passing both logs a warning so the conflict isn't silent.
- Deprecation cascade avoidance: `getFeatureFlagResult()` is now deprecated, but `isFeatureEnabled()` / `getFeatureFlag()` / `getFeatureFlagPayload()` route through a private `doGetFeatureFlagResult()` helper so a single user call surfaces exactly one warning, not two or three.
- `getAllFlags()` is intentionally **not** deprecated — it returns a value-only key list the snapshot API doesn't yet cover.
- Drive-by fix: `SizeLimitedHash::contains/add` were comparing values to keys and pushing onto the outer map, so the per-distinct_id `$feature_flag_called` dedup never matched after the first event. The new snapshot path requires real dedup, so it's fixed here.

## Out of scope (explicit non-goals)

- Removing the deprecated methods — that's the next major.
- Plumbing `flag_definitions_loaded_at` through the snapshot. posthog-php doesn't track that timestamp on the local poller today; left for a follow-up.

> Note: this supersedes #130 (stale base, blocked from rebase by a signature rule on a pre-existing unsigned ancestor).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
