### PR TITLE
fix: return booleans from immediate batch flushes

### DIFF
--- a/lib/Consumer/LibCurl.php
+++ b/lib/Consumer/LibCurl.php
@@ -69,7 +69,8 @@ class LibCurl extends QueueConsumer
             $payload = gzencode($payload);
         }
 
-        return $this->httpClient->sendRequest(
+        $shouldVerify = $this->options['verify_batch_events_request'] ?? true;
+        $response = $this->httpClient->sendRequest(
             '/batch/',
             $payload,
             [
@@ -77,8 +78,15 @@ class LibCurl extends QueueConsumer
                 "User-Agent: {$messages[0]['library']}/{$messages[0]['library_version']}",
             ],
             [
-                'shouldVerify' => $this->options['verify_batch_events_request'] ?? true,
+                'shouldVerify' => $shouldVerify,
             ]
-        )->getResponse();
+        );
+
+        if (!$shouldVerify) {
+            return $response->getResponse() !== false;
+        }
+
+        // Keep batch success semantics aligned with HttpClient retry handling and the Socket consumer.
+        return $response->getResponseCode() === 200;
     }
 }

--- a/lib/Consumer/Socket.php
+++ b/lib/Consumer/Socket.php
@@ -42,7 +42,7 @@ class Socket extends QueueConsumer
         $socket = $this->createSocket();
 
         if (!$socket) {
-            return;
+            return false;
         }
 
         $payload = $this->payload($batch);
@@ -166,7 +166,7 @@ class Socket extends QueueConsumer
             $socket = $this->createSocket();
         }
 
-        return true;
+        return false;
     }
 
     /**

--- a/test/ConsumerSocketTest.php
+++ b/test/ConsumerSocketTest.php
@@ -86,6 +86,29 @@ class ConsumerSocketTest extends TestCase
         $client->__destruct();
     }
 
+    public function testBatchSizeOneConnectionErrorReturnsFalse(): void
+    {
+        $client = new Client(
+            "x",
+            array(
+                "batch_size" => 1,
+                "consumer" => "socket",
+                "host" => "invalid.invalid",
+                "ssl" => false,
+                "timeout" => 0.01,
+            )
+        );
+
+        self::assertFalse(
+            $client->capture(
+                array(
+                    "distinctId" => "some-user",
+                    "event" => "Socket PHP Event",
+                )
+            )
+        );
+    }
+
     public function testProductionProblems(): void
     {
         $client = new Client(

--- a/test/MockedHttpClient.php
+++ b/test/MockedHttpClient.php
@@ -114,6 +114,10 @@ class MockedHttpClient extends \PostHog\HttpClient
             );
         }
 
+        if ($path === "/batch/") {
+            return new HttpResponse('{"status":1}', 200);
+        }
+
         return parent::sendRequest($path, $payload, $extraHeaders, $requestOptions);
     }
 }

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -444,6 +444,30 @@ class PostHogTest extends TestCase
         );
     }
 
+    public function testAliasReturnsBooleanWhenBatchFlushesImmediately(): void
+    {
+        $httpClient = new MockedHttpClient("app.posthog.com");
+        $client = new Client(
+            self::FAKE_API_KEY,
+            [
+                "debug" => true,
+                "batch_size" => 1,
+            ],
+            $httpClient
+        );
+        PostHog::init(null, null, $client);
+
+        $result = PostHog::alias(
+            array(
+                "alias" => "previous-id",
+                "distinctId" => "user-id",
+            )
+        );
+
+        $this->assertIsBool($result);
+        $this->assertTrue($result);
+    }
+
     public function testTimestamps(): void
     {
         self::assertTrue(


### PR DESCRIPTION
## :bulb: Motivation and Context
Fixes #57.

When `batch_size` is `1`, queued calls flush immediately. `LibCurl::flushBatch()` returned the raw batch endpoint response body instead of a boolean, so `PostHog::alias()` could return a JSON string for immediate flushes but `true` when the event was only queued. The socket consumer also had related non-boolean/failure return paths during immediate flushes.

## :green_heart: How did you test it?

- `./vendor/bin/phpunit --no-coverage --colors=never`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Added the `release` label to the PR
- [x] Added exactly one version bump label: `bump-patch`, `bump-minor`, or `bump-major`

<!-- For more details check RELEASING.md -->
