### PR TITLE
fix: infer CLI SSL from host protocol

### DIFF
--- a/bin/posthog
+++ b/bin/posthog
@@ -34,13 +34,21 @@ if (empty($options['apiKey'])) {
     error('apiKey flag required');
 }
 
+$initOptions = array(
+    'debug' => array_key_exists('debug', $options),
+);
+
+if (array_key_exists('host', $options)) {
+    $initOptions['host'] = $options['host'];
+}
+
+if (array_key_exists('no-ssl', $options)) {
+    $initOptions['ssl'] = false;
+}
+
 PostHog::init(
     $options['apiKey'],
-    array(
-        'host' => $options['host'],
-        'debug' => array_key_exists('debug', $options),
-        'ssl' => !array_key_exists('no-ssl', $options)
-    )
+    $initOptions
 );
 
 switch ($options['type']) {


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes https://github.com/PostHog/posthog-php/issues/25 for the `bin/posthog` CLI.

The CLI always passed an explicit `ssl` option, defaulting to `true` unless `--no-ssl` was provided. That prevented `PostHog::init()` from inferring `ssl=false` from `http://` hosts, so local HTTP hosts still required `--no-ssl`.

## :green_heart: How did you test it?

- `php -l bin/posthog`
- `vendor/bin/phpcs bin/posthog`
- `vendor/bin/phpunit --do-not-fail-on-warning --do-not-fail-on-deprecation --do-not-fail-on-phpunit-warning --do-not-fail-on-phpunit-deprecation --filter 'testInitWithHttpHostSetsSslFalse|testInitWithWhitespacePaddedHttpHostSetsSslFalse|testInitWithHttpsHostSetsSslTrue|testInitWithEnvHttpHostSetsSslFalse' test/PostHogTest.php`
- Verified manually against a local HTTP server that `php bin/posthog --type capture --apiKey key --distinctId id --event ev --properties '{}' --host http://127.0.0.1:<port> --debug` sends `POST /batch/` without `--no-ssl`.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Added the `release` label to the PR
- [x] Added exactly one version bump label: `bump-patch`, `bump-minor`, or `bump-major`

<!-- For more details check RELEASING.md -->
