### PR TITLE
docs: Update changelog - drop unreleased header for 4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 * [Full Changelog](https://github.com/PostHog/posthog-php/compare/4.2.4...4.3.0)
 
-## Unreleased
-
 * feat(flags): Add `evaluateFlags()` API for single-call flag evaluation. Returns a
   `FeatureFlagEvaluations` snapshot you can read repeatedly without further `/flags` requests; pass
   it to `capture()` via the new `flags` key to attach `$feature/<key>` and `$active_feature_flags`


### PR DESCRIPTION
Add new API for single-call flag evaluation in flags.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Added the `release` label to the PR
- [ ] Added exactly one version bump label: `bump-patch`, `bump-minor`, or `bump-major`

<!-- For more details check RELEASING.md -->
