### PR TITLE
Run PHP CI on main pushes

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -8,6 +8,15 @@ on:
       - "phpcs.xml"
       - "phpunit.xml"
       - ".github/workflows/php.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "**.php"
+      - "bin/posthog"
+      - "phpcs.xml"
+      - "phpunit.xml"
+      - ".github/workflows/php.yml"
 
 jobs:
   phpunit:


### PR DESCRIPTION
## :bulb: Motivation and Context
Ensure the PHP SDK's CI workflow also runs after relevant changes land on `main`, so regressions introduced by merges are caught on the default branch.

## :green_heart: How did you test it?
Validated the workflow YAML parses and now includes `push` for the `main` branch with the same path filters as pull requests.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
