### PR TITLE
feat: Allow groupIdentify distinct ID override

### DIFF
--- a/.changeset/green-groups-identify.md
+++ b/.changeset/green-groups-identify.md
@@ -1,0 +1,5 @@
+---
+"posthog-php": minor
+---
+
+Add an optional `distinctId`/`distinct_id` override for `groupIdentify()` events.

--- a/bin/posthog
+++ b/bin/posthog
@@ -81,13 +81,15 @@ switch ($options['type']) {
         break;
 
     case 'groupIdentify':
-        PostHog::groupIdentify(
-            array(
-                'groupType' => $options['groupType'],
-                'groupKey' => $options['groupKey'],
-                'properties' => parse_json($options['properties'])
-            )
+        $message = array(
+            'groupType' => $options['groupType'],
+            'groupKey' => $options['groupKey'],
+            'properties' => parse_json($options['properties'])
         );
+        if (!empty($options['distinctId'])) {
+            $message['distinctId'] = $options['distinctId'];
+        }
+        PostHog::groupIdentify($message);
         break;
 
     case 'getFeatureFlag':
@@ -121,7 +123,7 @@ function usage(): string
         "\n    posthog --type capture --distinctId \"id\" --event \"event name\" --properties '{ \"json\": \"object\" }'" .
         "\n    posthog --type identify --distinctId \"id\" --properties '{ \"json\": \"object\" }'" .
         "\n    posthog --type alias --distinctId \"id\" --alias \"alias\"" .
-        "\n    posthog --type groupIdentify --groupType \"organization\" --groupKey \"id:5\" --properties '{ \"json\": \"object\" }'" .
+        "\n    posthog --type groupIdentify --groupType \"organization\" --groupKey \"id:5\" --distinctId \"user-id\" --properties '{ \"json\": \"object\" }'" .
         "\n    posthog --type getFeatureFlag --flag some-flag --apiKey phc_... --host localhost:8010 --no-ssl" .
         "\n    posthog --type getFeatureFlag --flag some-flag --apiKey phc_... --host localhost:8010 --no-ssl" .
         "\n\n\n";

--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -110,7 +110,8 @@ class PostHog
     /**
      * Adds properties to a group.
      *
-     * @param array $message Must contain keys `groupType`, `groupKey`, `properties`
+     * @param array $message Must contain keys `groupType`, `groupKey`; accepts optional `properties`
+     *                       and `distinctId`/`distinct_id` to override the default synthetic ID.
      * @return boolean whether the groupIdentify call succeeded
      * @throws Exception
      */
@@ -123,9 +124,24 @@ class PostHog
             $message["properties"] = array();
         }
 
+        $distinctId = "\${$message['groupType']}_{$message['groupKey']}";
+        if (
+            array_key_exists("distinctId", $message)
+            && is_scalar($message["distinctId"])
+            && (string) $message["distinctId"] !== ""
+        ) {
+            $distinctId = (string) $message["distinctId"];
+        } elseif (
+            array_key_exists("distinct_id", $message)
+            && is_scalar($message["distinct_id"])
+            && (string) $message["distinct_id"] !== ""
+        ) {
+            $distinctId = (string) $message["distinct_id"];
+        }
+
         $msg = array(
             "event" => "\$groupidentify",
-            "distinctId" => "\${$message['groupType']}_{$message['groupKey']}",
+            "distinctId" => $distinctId,
             "properties" => array(
                 "\$group_type" => $message["groupType"],
                 "\$group_key" => $message["groupKey"],

--- a/test/RequestContextTest.php
+++ b/test/RequestContextTest.php
@@ -438,6 +438,38 @@ class RequestContextTest extends TestCase
         $this->assertArrayNotHasKey('$session_id', $event['properties']);
     }
 
+    public function testGroupIdentifyAllowsDistinctIdOverride(): void
+    {
+        PostHog::groupIdentify([
+            'groupType' => 'organization',
+            'groupKey' => 'acme',
+            'distinctId' => 'user-123',
+            'properties' => ['name' => 'Acme Inc.'],
+        ]);
+
+        $event = $this->flushAndGetEvents()[0];
+
+        $this->assertSame('user-123', $event['distinct_id']);
+        $this->assertSame('$groupidentify', $event['event']);
+        $this->assertSame('organization', $event['properties']['$group_type']);
+        $this->assertSame('acme', $event['properties']['$group_key']);
+        $this->assertSame(['name' => 'Acme Inc.'], $event['properties']['$group_set']);
+    }
+
+    public function testGroupIdentifyAllowsSnakeCaseDistinctIdOverride(): void
+    {
+        PostHog::groupIdentify([
+            'groupType' => 'organization',
+            'groupKey' => 'acme',
+            'distinct_id' => 'snake-user-123',
+            'properties' => ['name' => 'Acme Inc.'],
+        ]);
+
+        $event = $this->flushAndGetEvents()[0];
+
+        $this->assertSame('snake-user-123', $event['distinct_id']);
+    }
+
     public function testEvaluateFlagsUsesContextDistinctIdWhenOmitted(): void
     {
         PostHog::withContext(['distinctId' => 'context-user'], function (): void {


### PR DESCRIPTION
## :bulb: Motivation and Context

`groupIdentify()` currently always uses a synthetic distinct ID like `$team_team_x2`, which can create one dummy person per group. Other server-side SDKs allow callers to override the distinct ID used for the `$groupidentify` event.

This adds a backwards-compatible optional `distinctId` / `distinct_id` override while preserving the current synthetic ID default when omitted.

## :green_heart: How did you test it?

- `./vendor/bin/phpcs --standard=phpcs.xml lib/PostHog.php test/RequestContextTest.php bin/posthog`
- `./vendor/bin/phpunit --no-coverage --filter 'RequestContextTest'`
- `./vendor/bin/phpunit --no-coverage` (passes with existing warnings/deprecations)

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
