### PR TITLE
chore: restore pending release changesets

### DIFF
--- a/.changeset/brave-turkeys-serve.md
+++ b/.changeset/brave-turkeys-serve.md
@@ -1,0 +1,5 @@
+---
+"posthog-php": minor
+---
+
+Add request context helpers for propagating request metadata and optional PostHog tracing headers.

--- a/.changeset/green-groups-identify.md
+++ b/.changeset/green-groups-identify.md
@@ -1,0 +1,5 @@
+---
+"posthog-php": minor
+---
+
+Add an optional `distinctId`/`distinct_id` override for `groupIdentify()` events.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,3 @@
-## 4.3.0
-
-### Minor Changes
-
-- 7ab9080: Add request context helpers for propagating request metadata and optional PostHog tracing headers.
-- 10e985b: Add an optional `distinctId`/`distinct_id` override for `groupIdentify()` events.
-
 ## 4.3.0 - 2026-05-01
 
 - [Full Changelog](https://github.com/PostHog/posthog-php/compare/4.2.4...4.3.0)


### PR DESCRIPTION
## :bulb: Motivation and Context

The release workflow for `posthog-php@4.3.0` partially succeeded: it committed the version bump, but failed creating the GitHub release because the immutable `4.3.0` release/tag already exists.

This restores the two pending changesets and removes the generated duplicate `4.3.0` changelog section while leaving package/composer/library versions at `4.3.0`. With those changesets restored, the next release should resolve to `4.4.0` cleanly instead of attempting to recreate `4.3.0`.

## :green_heart: How did you test it?

Ran:

```bash
pnpm changeset status --verbose
```

Confirmed Changesets reports the next minor release as `posthog-php 4.4.0` from the restored changesets.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
