### PR TITLE
fix: include group context in $feature_flag_called dedupe key

### DIFF
--- a/.changeset/include-group-context-in-flag-called-dedupe.md
+++ b/.changeset/include-group-context-in-flag-called-dedupe.md
@@ -1,0 +1,5 @@
+---
+'posthog-php': patch
+---
+
+Include group context in the `$feature_flag_called` dedupe element so group-scoped flags fire a separate event for each group a user is evaluated under, instead of being dedup-ed against the first group context the same `(distinct_id, flag)` was seen under.

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -936,10 +936,11 @@ class Client implements FeatureFlagEvaluationsHost
     }
 
     /**
-     * Fire a $feature_flag_called event the first time a (flag key, distinct id) pair is seen by
-     * this Client, deduped via the per-distinct_id cache shared with every other flag-reading code
-     * path. Properties are built by the caller so each call site can shape the payload to match its
-     * available metadata.
+     * Fire a $feature_flag_called event the first time a (flag key, distinct id, groups) tuple is
+     * seen by this Client, deduped via the per-distinct_id cache shared with every other
+     * flag-reading code path. Group context is included so that group-scoped flags fire a separate
+     * event for each group a user is evaluated under. Properties are built by the caller so each
+     * call site can shape the payload to match its available metadata.
      *
      * @param string $distinctId The distinct ID that accessed the flag.
      * @param string $key Feature flag key.
@@ -953,7 +954,8 @@ class Client implements FeatureFlagEvaluationsHost
         array $properties,
         array $groups = []
     ): void {
-        if ($this->distinctIdsFeatureFlagsReported->contains($key, $distinctId)) {
+        $dedupElement = $distinctId . self::canonicalGroupsRepr($groups);
+        if ($this->distinctIdsFeatureFlagsReported->contains($key, $dedupElement)) {
             return;
         }
 
@@ -963,7 +965,24 @@ class Client implements FeatureFlagEvaluationsHost
             'event' => '$feature_flag_called',
             '$groups' => $groups,
         ]);
-        $this->distinctIdsFeatureFlagsReported->add($key, $distinctId);
+        $this->distinctIdsFeatureFlagsReported->add($key, $dedupElement);
+    }
+
+    /**
+     * Canonicalize the groups map so two equal arrays with keys in a different order produce the
+     * same dedup suffix. Empty / missing groups produce an empty string so the legacy "no groups"
+     * dedupe shape is preserved.
+     *
+     * @param array<string, mixed> $groups
+     * @return string
+     */
+    private static function canonicalGroupsRepr(array $groups): string
+    {
+        if (empty($groups)) {
+            return '';
+        }
+        ksort($groups);
+        return '_' . json_encode($groups, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     }
 
     /**

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -982,7 +982,7 @@ class Client implements FeatureFlagEvaluationsHost
             return '';
         }
         ksort($groups);
-        return '_' . json_encode($groups, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        return '_' . json_encode($groups, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
     }
 
     /**

--- a/test/FeatureFlagEvaluationsTest.php
+++ b/test/FeatureFlagEvaluationsTest.php
@@ -595,46 +595,42 @@ class FeatureFlagEvaluationsTest extends TestCase
         $this->assertContains('org-b', $seen);
     }
 
-    public function testFeatureFlagCalledDedupesAcrossRepeatedCallsUnderSameGroup(): void
+    /**
+     * @return array<string, array{list<array<string,string>>, int}>
+     */
+    public static function dedupCallsProvider(): array
     {
-        $this->makeClient();
-
-        $snap = PostHog::evaluateFlags('user-1', groups: ['organization' => 'org-a']);
-        $snap->isEnabled('simple-test');
-        $snap->isEnabled('simple-test');
-        $snap->isEnabled('simple-test');
-
-        PostHog::flush();
-
-        $count = 0;
-        foreach ($this->batchRequests() as $batch) {
-            foreach ($batch['batch'] as $event) {
-                if ($event['event'] === '$feature_flag_called'
-                    && ($event['properties']['$feature_flag'] ?? null) === 'simple-test') {
-                    $count++;
-                }
-            }
-        }
-        $this->assertSame(1, $count, 'expected a single deduped $feature_flag_called event');
+        return [
+            'repeated calls under same group' => [
+                [
+                    ['organization' => 'org-a'],
+                    ['organization' => 'org-a'],
+                    ['organization' => 'org-a'],
+                ],
+                1,
+            ],
+            'same groups different key insertion order' => [
+                [
+                    ['organization' => 'org-a', 'team' => 'red'],
+                    ['team' => 'red', 'organization' => 'org-a'],
+                ],
+                1,
+            ],
+        ];
     }
 
-    public function testFeatureFlagCalledDedupesAcrossGroupKeyOrder(): void
+    /**
+     * @dataProvider dedupCallsProvider
+     * @param list<array<string,string>> $groupsPerCall
+     */
+    public function testFeatureFlagCalledDedupes(array $groupsPerCall, int $expectedCount): void
     {
         $this->makeClient();
 
-        // Same groups, two different array insertion orders. Both must produce the same canonical
-        // dedup element so only one event is fired.
-        $snapA = PostHog::evaluateFlags(
-            'user-1',
-            groups: ['organization' => 'org-a', 'team' => 'red']
-        );
-        $snapA->isEnabled('simple-test');
-
-        $snapB = PostHog::evaluateFlags(
-            'user-1',
-            groups: ['team' => 'red', 'organization' => 'org-a']
-        );
-        $snapB->isEnabled('simple-test');
+        foreach ($groupsPerCall as $groups) {
+            $snap = PostHog::evaluateFlags('user-1', groups: $groups);
+            $snap->isEnabled('simple-test');
+        }
 
         PostHog::flush();
 
@@ -647,7 +643,7 @@ class FeatureFlagEvaluationsTest extends TestCase
                 }
             }
         }
-        $this->assertSame(1, $count, 'expected a single deduped $feature_flag_called event');
+        $this->assertSame($expectedCount, $count, 'unexpected $feature_flag_called event count');
     }
 
     /**

--- a/test/FeatureFlagEvaluationsTest.php
+++ b/test/FeatureFlagEvaluationsTest.php
@@ -563,6 +563,93 @@ class FeatureFlagEvaluationsTest extends TestCase
         $this->assertCount(1, $batches[0]['batch']);
     }
 
+    public function testFeatureFlagCalledFiresPerGroupContext(): void
+    {
+        $this->makeClient();
+
+        // Same user, same flag, two different group contexts must produce two events.
+        $snapA = PostHog::evaluateFlags('user-1', groups: ['organization' => 'org-a']);
+        $snapA->isEnabled('simple-test');
+
+        $snapB = PostHog::evaluateFlags('user-1', groups: ['organization' => 'org-b']);
+        $snapB->isEnabled('simple-test');
+
+        PostHog::flush();
+
+        $events = [];
+        foreach ($this->batchRequests() as $batch) {
+            foreach ($batch['batch'] as $event) {
+                if ($event['event'] === '$feature_flag_called'
+                    && ($event['properties']['$feature_flag'] ?? null) === 'simple-test') {
+                    $events[] = $event;
+                }
+            }
+        }
+
+        $this->assertCount(2, $events, 'expected one $feature_flag_called event per group context');
+        $seen = array_map(
+            fn($e) => $e['properties']['$groups']['organization'] ?? null,
+            $events
+        );
+        $this->assertContains('org-a', $seen);
+        $this->assertContains('org-b', $seen);
+    }
+
+    public function testFeatureFlagCalledDedupesAcrossRepeatedCallsUnderSameGroup(): void
+    {
+        $this->makeClient();
+
+        $snap = PostHog::evaluateFlags('user-1', groups: ['organization' => 'org-a']);
+        $snap->isEnabled('simple-test');
+        $snap->isEnabled('simple-test');
+        $snap->isEnabled('simple-test');
+
+        PostHog::flush();
+
+        $count = 0;
+        foreach ($this->batchRequests() as $batch) {
+            foreach ($batch['batch'] as $event) {
+                if ($event['event'] === '$feature_flag_called'
+                    && ($event['properties']['$feature_flag'] ?? null) === 'simple-test') {
+                    $count++;
+                }
+            }
+        }
+        $this->assertSame(1, $count, 'expected a single deduped $feature_flag_called event');
+    }
+
+    public function testFeatureFlagCalledDedupesAcrossGroupKeyOrder(): void
+    {
+        $this->makeClient();
+
+        // Same groups, two different array insertion orders. Both must produce the same canonical
+        // dedup element so only one event is fired.
+        $snapA = PostHog::evaluateFlags(
+            'user-1',
+            groups: ['organization' => 'org-a', 'team' => 'red']
+        );
+        $snapA->isEnabled('simple-test');
+
+        $snapB = PostHog::evaluateFlags(
+            'user-1',
+            groups: ['team' => 'red', 'organization' => 'org-a']
+        );
+        $snapB->isEnabled('simple-test');
+
+        PostHog::flush();
+
+        $count = 0;
+        foreach ($this->batchRequests() as $batch) {
+            foreach ($batch['batch'] as $event) {
+                if ($event['event'] === '$feature_flag_called'
+                    && ($event['properties']['$feature_flag'] ?? null) === 'simple-test') {
+                    $count++;
+                }
+            }
+        }
+        $this->assertSame(1, $count, 'expected a single deduped $feature_flag_called event');
+    }
+
     /**
      * @return list<string> the deprecation messages emitted while running $callable
      */


### PR DESCRIPTION
## :bulb: Motivation and Context

In `Client::captureFlagCalledIfNeeded` (`lib/Client.php`), the per-`distinct_id` dedupe element only included the distinct ID under the flag key. For group-scoped flags this meant that when the same user was evaluated under a different group, no new `$feature_flag_called` event was fired — causing per-group exposure undercount for experiments scoped to a group key.

Mirrors the posthog-node fix in PostHog/posthog-js#3658 (which closes PostHog/posthog-js#3651). Both SDKs share the same dedupe shape, so backend evaluation needs the same change.

## :green_heart: How did you test it?

Added three PHPUnit tests in `test/FeatureFlagEvaluationsTest.php`:

- `testFeatureFlagCalledFiresPerGroupContext` — same user, same flag, two different group contexts → two events fired with the expected `$groups` payloads.
- `testFeatureFlagCalledDedupesAcrossRepeatedCallsUnderSameGroup` — repeated access under the same group → one event.
- `testFeatureFlagCalledDedupesAcrossGroupKeyOrder` — same groups passed with different array insertion order → still one event (canonicalized via `ksort` + `json_encode`).

`vendor/bin/phpunit` is green (311 tests pass).

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*