### PR TITLE
chore: add dependency update delay settings

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
 packages:
   - '.'
+
+minimumReleaseAge: 10080


### PR DESCRIPTION
## :bulb: Motivation and Context
Dependency automation should avoid opening updates immediately after packages are published. This adds the requested Dependabot cooldown and/or pnpm minimum release age configuration where applicable.


## :green_heart: How did you test it?
Not run (configuration-only change).


## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
