### PR TITLE
fix: no-op when uninitialized or non-operational

### DIFF
--- a/.changeset/brave-foxes-noop.md
+++ b/.changeset/brave-foxes-noop.md
@@ -1,0 +1,5 @@
+---
+'posthog-php': patch
+---
+
+No-op facade and feature flag APIs when the SDK is uninitialized or non-operational.

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -147,7 +147,9 @@ class Client implements FeatureFlagEvaluationsHost
         $this->debug = $options["debug"] ?? false;
         $this->options['host'] = StringNormalizer::normalizeHost($options['host'] ?? null);
         if (!$this->enabled) {
-            error_log('[PostHog][Client] apiKey is empty after trimming whitespace; check your project API key');
+            if (($this->options['consumer'] ?? null) !== 'noop') {
+                error_log('[PostHog][Client] apiKey is empty after trimming whitespace; check your project API key');
+            }
             $this->options['consumer'] = 'noop';
         }
         $Consumer = self::CONSUMERS[$this->options["consumer"] ?? "lib_curl"];
@@ -1076,7 +1078,6 @@ class Client implements FeatureFlagEvaluationsHost
      * @param array<string, mixed> $personProperties Person properties to use for flag evaluation.
      * @param array<string, array<string, mixed>> $groupProperties Group properties to use for flag evaluation.
      * @return array<string, bool|string> Feature flag values by key.
-     * @throws Exception
      */
     public function fetchFeatureVariants(
         string $distinctId,
@@ -1090,16 +1091,17 @@ class Client implements FeatureFlagEvaluationsHost
 
     /**
      * @param string $distinctId
-     * @param array $groups
-     * @return array of feature flags
-     * @throws Exception
+     * @param array<string, mixed> $groups
+     * @param array<string, mixed> $personProperties
+     * @param array<string, array<string, mixed>> $groupProperties
+     * @return array<string, mixed> Feature flags response.
      */
     private function fetchFlagsResponse(
         string $distinctId,
         array $groups = [],
         array $personProperties = [],
         array $groupProperties = []
-    ): ?array {
+    ): array {
         return $this->flags($distinctId, $groups, $personProperties, $groupProperties);
     }
 

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -872,7 +872,7 @@ class Client implements FeatureFlagEvaluationsHost
 
         if ($shouldHitRemote) {
             try {
-                $response = $this->flags(
+                $response = $this->requestFlags(
                     $distinctId,
                     $groups,
                     $personProperties,
@@ -1279,7 +1279,6 @@ class Client implements FeatureFlagEvaluationsHost
      * @param bool $disableGeoip Whether to disable GeoIP enrichment during remote evaluation.
      * @param list<string>|null $flagKeys Optional list of flag keys to evaluate.
      * @return array<string, mixed> The normalized feature flags response.
-     * @throws HttpException On network errors, API errors, or quota limits.
      */
     public function flags(
         string $distinctId,
@@ -1289,12 +1288,28 @@ class Client implements FeatureFlagEvaluationsHost
         bool $disableGeoip = false,
         ?array $flagKeys = null
     ): array {
+        try {
+            return $this->requestFlags($distinctId, $groups, $personProperties, $groupProperties, $disableGeoip, $flagKeys);
+        } catch (HttpException $e) {
+            error_log('[PostHog][Client] Unable to fetch feature flags: ' . $e->getMessage());
+            return $this->emptyFlagsResponse();
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     * @throws HttpException On network errors, API errors, or quota limits.
+     */
+    private function requestFlags(
+        string $distinctId,
+        array $groups = array(),
+        array $personProperties = [],
+        array $groupProperties = [],
+        bool $disableGeoip = false,
+        ?array $flagKeys = null
+    ): array {
         if (!$this->enabled) {
-            return [
-                'featureFlags' => [],
-                'featureFlagPayloads' => [],
-                'flags' => [],
-            ];
+            return $this->emptyFlagsResponse();
         }
 
         $payload = array(
@@ -1369,6 +1384,16 @@ class Client implements FeatureFlagEvaluationsHost
         }
 
         return $this->normalizeFeatureFlags($httpResponse->getResponse());
+    }
+
+    /** @return array{featureFlags: array<string, mixed>, featureFlagPayloads: array<string, mixed>, flags: array<string, mixed>} */
+    private function emptyFlagsResponse(): array
+    {
+        return [
+            'featureFlags' => [],
+            'featureFlagPayloads' => [],
+            'flags' => [],
+        ];
     }
 
     /**

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -542,7 +542,7 @@ class Client implements FeatureFlagEvaluationsHost
 
         if (!$flagWasEvaluatedLocally && !$onlyEvaluateLocally) {
             try {
-                $response = $this->fetchFlagsResponse($distinctId, $groups, $personProperties, $groupProperties);
+                $response = $this->requestFlags($distinctId, $groups, $personProperties, $groupProperties);
                 $errors = [];
 
                 if (isset($response['errorsWhileComputingFlags']) && $response['errorsWhileComputingFlags']) {
@@ -1289,7 +1289,14 @@ class Client implements FeatureFlagEvaluationsHost
         ?array $flagKeys = null
     ): array {
         try {
-            return $this->requestFlags($distinctId, $groups, $personProperties, $groupProperties, $disableGeoip, $flagKeys);
+            return $this->requestFlags(
+                $distinctId,
+                $groups,
+                $personProperties,
+                $groupProperties,
+                $disableGeoip,
+                $flagKeys
+            );
         } catch (HttpException $e) {
             error_log('[PostHog][Client] Unable to fetch feature flags: ' . $e->getMessage());
             return $this->emptyFlagsResponse();

--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -417,7 +417,6 @@ class PostHog
      * @param string $distinctId The user's distinct ID.
      * @param array<string, mixed> $groups Group identifiers for group-based flags.
      * @return array<string, bool|string>
-     * @throws Exception
      */
     public static function fetchFeatureVariants(string $distinctId, array $groups = array()): array
     {
@@ -577,6 +576,7 @@ class PostHog
             return;
         }
 
+        error_log('[PostHog] PostHog::init() was not called; SDK will no-op.');
         self::$client = new Client(null, array('consumer' => 'noop'), null, null, false);
     }
 

--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -13,7 +13,7 @@ class PostHog
     public const ENV_API_KEY = "POSTHOG_API_KEY";
     public const ENV_HOST = "POSTHOG_HOST";
 
-    private static Client $client;
+    private static ?Client $client = null;
 
     /**
      * Initializes the default client to use. Uses the libcurl consumer by default.
@@ -330,6 +330,8 @@ class PostHog
         array $personProperties = array(),
         array $groupProperties = array(),
     ): mixed {
+        self::checkClient();
+
         return self::$client->getFeatureFlagPayload(
             $key,
             $distinctId,
@@ -498,6 +500,8 @@ class PostHog
      */
     public static function raw(array $message)
     {
+        self::checkClient();
+
         return self::$client->raw($message);
     }
 
@@ -564,9 +568,8 @@ class PostHog
     }
 
     /**
-     * Check the client.
-     *
-     * @throws Exception
+     * Ensure the default client exists. If init() was never called, install a disabled no-op client
+     * so public SDK methods do not throw into the host application.
      */
     private static function checkClient()
     {
@@ -574,7 +577,7 @@ class PostHog
             return;
         }
 
-        throw new Exception("PostHog::init() must be called before any other capturing method.");
+        self::$client = new Client(null, array('consumer' => 'noop'), null, null, false);
     }
 
     /**

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -76,6 +76,15 @@ class PostHogTest extends TestCase
         }
     }
 
+    private function unsetFacadeClient(): void
+    {
+        $resetClient = \Closure::bind(function (): void {
+            self::$client = null;
+        }, null, PostHog::class);
+
+        $resetClient();
+    }
+
     public static function initNoOpApiKeyCases(): array
     {
         return [
@@ -310,6 +319,41 @@ class PostHogTest extends TestCase
         ]));
         $this->assertSame([], $client->{$flagsMethod}("john"));
         $this->assertSame([], $httpClient->calls ?? []);
+    }
+
+    public function testFacadeMethodsNoOpBeforeInit(): void
+    {
+        $this->unsetFacadeClient();
+
+        try {
+            $this->assertFalse(PostHog::capture([
+                "distinctId" => "john",
+                "event" => "Module PHP Event",
+            ]));
+            $this->assertFalse(PostHog::identify(["distinctId" => "john"]));
+            $this->assertFalse(PostHog::alias(["distinctId" => "john", "alias" => "anonymous"]));
+            $this->assertFalse(PostHog::groupIdentify(["groupType" => "organization", "groupKey" => "id:5"]));
+            $this->assertFalse(PostHog::raw(["type" => "capture"]));
+            $this->assertFalse(PostHog::flush());
+            $this->assertNull(PostHog::getFeatureFlagPayload("flag", "john"));
+            $this->assertSame([], PostHog::fetchFeatureVariants("john"));
+            $this->assertInstanceOf(NoOp::class, $this->getConsumer(PostHog::getClient()));
+        } finally {
+            PostHog::init(null, null, $this->client);
+        }
+    }
+
+    public function testDirectFlagsApisReturnDefaultsOnApiError(): void
+    {
+        $httpClient = new MockedHttpClient("app.posthog.com", flagsEndpointResponseCode: 401);
+        $client = new Client(self::FAKE_API_KEY, ["debug" => true], $httpClient, null, false);
+
+        $this->assertSame([
+            'featureFlags' => [],
+            'featureFlagPayloads' => [],
+            'flags' => [],
+        ], $client->flags("john"));
+        $this->assertSame([], $client->fetchFeatureVariants("john"));
     }
 
     public function testDisabledClientLoadFlagsDoesNotMutateCachedFlags(): void

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -101,6 +101,53 @@ class PostHogTest extends TestCase
         ];
     }
 
+    public static function facadeNoOpBeforeInitCases(): array
+    {
+        return [
+            'capture' => [
+                static fn() => PostHog::capture([
+                    "distinctId" => "john",
+                    "event" => "Module PHP Event",
+                ]),
+                false,
+            ],
+            'identify' => [
+                static fn() => PostHog::identify(["distinctId" => "john"]),
+                false,
+            ],
+            'alias' => [
+                static fn() => PostHog::alias([
+                    "distinctId" => "john",
+                    "alias" => "anonymous",
+                ]),
+                false,
+            ],
+            'groupIdentify' => [
+                static fn() => PostHog::groupIdentify([
+                    "groupType" => "organization",
+                    "groupKey" => "id:5",
+                ]),
+                false,
+            ],
+            'raw' => [
+                static fn() => PostHog::raw(["type" => "capture"]),
+                false,
+            ],
+            'flush' => [
+                static fn() => PostHog::flush(),
+                false,
+            ],
+            'getFeatureFlagPayload' => [
+                static fn() => PostHog::getFeatureFlagPayload("flag", "john"),
+                null,
+            ],
+            'fetchFeatureVariants' => [
+                static fn() => PostHog::fetchFeatureVariants("john"),
+                [],
+            ],
+        ];
+    }
+
     public function testInitWithParamApiKey(): void
     {
         $this->expectNotToPerformAssertions();
@@ -321,23 +368,26 @@ class PostHogTest extends TestCase
         $this->assertSame([], $httpClient->calls ?? []);
     }
 
-    public function testFacadeMethodsNoOpBeforeInit(): void
+    /**
+     * @dataProvider facadeNoOpBeforeInitCases
+     */
+    public function testFacadeMethodsNoOpBeforeInit(callable $call, mixed $expectedValue): void
     {
         $this->unsetFacadeClient();
 
         try {
-            $this->assertFalse(PostHog::capture([
-                "distinctId" => "john",
-                "event" => "Module PHP Event",
-            ]));
-            $this->assertFalse(PostHog::identify(["distinctId" => "john"]));
-            $this->assertFalse(PostHog::alias(["distinctId" => "john", "alias" => "anonymous"]));
-            $this->assertFalse(PostHog::groupIdentify(["groupType" => "organization", "groupKey" => "id:5"]));
-            $this->assertFalse(PostHog::raw(["type" => "capture"]));
-            $this->assertFalse(PostHog::flush());
-            $this->assertNull(PostHog::getFeatureFlagPayload("flag", "john"));
-            $this->assertSame([], PostHog::fetchFeatureVariants("john"));
+            $this->assertSame($expectedValue, $call());
             $this->assertInstanceOf(NoOp::class, $this->getConsumer(PostHog::getClient()));
+
+            global $errorMessages;
+            $this->assertContains(
+                '[PostHog] PostHog::init() was not called; SDK will no-op.',
+                $errorMessages
+            );
+            $this->assertNotContains(
+                '[PostHog][Client] apiKey is empty after trimming whitespace; check your project API key',
+                $errorMessages
+            );
         } finally {
             PostHog::init(null, null, $this->client);
         }


### PR DESCRIPTION
## :bulb: Motivation and Context

The PHP SDK should no-op instead of throwing into the host app when the default facade is used before `PostHog::init()` or when public flag APIs hit API/auth/network failures. Some facade methods also accessed the typed static client directly, which could fatal before initialization.

Changes:
- Lazily create a disabled no-op client when facade methods are called before initialization.
- Guard `raw()` and `getFeatureFlagPayload()` with the same client initialization path.
- Return empty feature flag defaults from public direct flags APIs on API errors.
- Add regression tests for uninitialized facade calls and flag API failures.

## :green_heart: How did you test it?

- `vendor/bin/phpunit --do-not-fail-on-warning --do-not-fail-on-deprecation --do-not-fail-on-phpunit-deprecation --do-not-fail-on-phpunit-warning test/PostHogTest.php`
- `php -l lib/PostHog.php && php -l lib/Client.php && php -l test/PostHogTest.php`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
