### PR TITLE
feat(flags): support early_exit in local evaluation

### DIFF
--- a/.changeset/feature-flag-early-exit.md
+++ b/.changeset/feature-flag-early-exit.md
@@ -1,0 +1,5 @@
+---
+"posthog-php": minor
+---
+
+Support the `early_exit` flag filter in local evaluation. When a flag's `filters.early_exit` is `true` and a condition group's property filters match (or there are none) but the rollout percentage excludes the user, evaluation now stops and returns `false` immediately instead of falling through to later groups. Mirrors the server-side (Rust) evaluation engine. A property-filter mismatch still falls through as before, and behaviour is unchanged when `early_exit` is unset or `false`.

--- a/lib/ConditionMatch.php
+++ b/lib/ConditionMatch.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace PostHog;
+
+/**
+ * Outcome of evaluating a single feature flag condition group.
+ *
+ * OUT_OF_ROLLOUT_BOUND means the group's property filters matched (or there were none)
+ * but the rollout percentage excluded the user — the only case that triggers a flag's
+ * `early_exit` short-circuit. Mirrors the server-side (Rust) engine's match cases.
+ *
+ * @internal
+ */
+enum ConditionMatch: string
+{
+    case Match = 'match';
+    case NoMatch = 'no_match';
+    case OutOfRolloutBound = 'out_of_rollout_bound';
+}

--- a/lib/ConditionMatch.php
+++ b/lib/ConditionMatch.php
@@ -5,7 +5,7 @@ namespace PostHog;
 /**
  * Outcome of evaluating a single feature flag condition group.
  *
- * OUT_OF_ROLLOUT_BOUND means the group's property filters matched (or there were none)
+ * OutOfRolloutBound means the group's property filters matched (or there were none)
  * but the rollout percentage excluded the user — the only case that triggers a flag's
  * `early_exit` short-circuit. Mirrors the server-side (Rust) engine's match cases.
  *

--- a/lib/FeatureFlag.php
+++ b/lib/FeatureFlag.php
@@ -654,6 +654,7 @@ class FeatureFlag
         $flagFilters = $flag["filters"] ?? [];
         $flagConditions = $flagFilters["groups"] ?? [];
         $flagAggregation = $flagFilters["aggregation_group_type_index"] ?? null;
+        $earlyExitEnabled = $flagFilters["early_exit"] ?? false;
         $isInconclusive = false;
 
         foreach ($flagConditions as $condition) {
@@ -686,7 +687,9 @@ class FeatureFlag
                     }
                 }
 
-                if (FeatureFlag::isConditionMatch($flag, $effectiveBucketing, $condition, $effectiveProperties, $cohorts, $flagsByKey, $evaluationCache)) {
+                $matchResult = FeatureFlag::isConditionMatch($flag, $effectiveBucketing, $condition, $effectiveProperties, $cohorts, $flagsByKey, $evaluationCache);
+
+                if ($matchResult === ConditionMatch::Match) {
                     $variantOverride = $condition["variant"] ?? null;
                     $flagVariants = ($flagFilters["multivariate"] ?? [])["variants"] ?? [];
                     $variantKeys = array_map(function ($variant) {
@@ -698,6 +701,11 @@ class FeatureFlag
                     } else {
                         return FeatureFlag::getMatchingVariant($flag, $effectiveBucketing) ?? true;
                     }
+                } elseif ($earlyExitEnabled && $matchResult === ConditionMatch::OutOfRolloutBound) {
+                    // The condition's property filters (if any) matched and only the rollout check
+                    // failed, so re-evaluating later groups can't change the outcome. Return a
+                    // definitive false immediately, mirroring the server-side (Rust) engine.
+                    return false;
                 }
             } catch (RequiresServerEvaluationException $e) {
                 // Immediately propagate - this condition requires server-side data
@@ -721,7 +729,7 @@ class FeatureFlag
         return false;
     }
 
-    private static function isConditionMatch($featureFlag, $distinctId, $condition, $properties, $cohorts, $flagsByKey = null, $evaluationCache = null)
+    private static function isConditionMatch($featureFlag, $distinctId, $condition, $properties, $cohorts, $flagsByKey = null, $evaluationCache = null): ConditionMatch
     {
         $rolloutPercentage = array_key_exists("rollout_percentage", $condition) ? $condition["rollout_percentage"] : null;
 
@@ -738,20 +746,20 @@ class FeatureFlag
                 }
 
                 if (!$matches) {
-                    return false;
+                    return ConditionMatch::NoMatch;
                 }
             }
 
             if (is_null($rolloutPercentage)) {
-                return true;
+                return ConditionMatch::Match;
             }
         }
 
         if (!is_null($rolloutPercentage) && FeatureFlag::hash($featureFlag["key"], $distinctId) > ($rolloutPercentage / 100)) { //phpcs:ignore
-            return false;
+            return ConditionMatch::OutOfRolloutBound;
         }
 
-        return true;
+        return ConditionMatch::Match;
     }
 
     private static function isRegularExpression($string)

--- a/lib/FeatureFlag.php
+++ b/lib/FeatureFlag.php
@@ -705,10 +705,12 @@ class FeatureFlag
                     // The condition's property filters (if any) matched and only the rollout check
                     // failed, so re-evaluating later groups can't change the outcome. Return a
                     // definitive false immediately, mirroring the server-side (Rust) engine.
-                    // But if a prior condition was inconclusive, we can't be definitive — fall back
-                    // to server evaluation instead.
+                    // But if a prior condition was inconclusive, we can't be definitive — stop
+                    // evaluating (early exit still applies to later groups) and let the
+                    // post-loop inconclusive check fall back to server evaluation. A throw here
+                    // would be swallowed by the catch below and evaluation would wrongly continue.
                     if ($isInconclusive) {
-                        throw new InconclusiveMatchException("Can't determine if feature flag is enabled or not with given properties"); //phpcs:ignore
+                        break;
                     }
                     return false;
                 }

--- a/lib/FeatureFlag.php
+++ b/lib/FeatureFlag.php
@@ -705,6 +705,11 @@ class FeatureFlag
                     // The condition's property filters (if any) matched and only the rollout check
                     // failed, so re-evaluating later groups can't change the outcome. Return a
                     // definitive false immediately, mirroring the server-side (Rust) engine.
+                    // But if a prior condition was inconclusive, we can't be definitive — fall back
+                    // to server evaluation instead.
+                    if ($isInconclusive) {
+                        throw new InconclusiveMatchException("Can't determine if feature flag is enabled or not with given properties"); //phpcs:ignore
+                    }
                     return false;
                 }
             } catch (RequiresServerEvaluationException $e) {

--- a/test/FeatureFlagLocalEvaluationTest.php
+++ b/test/FeatureFlagLocalEvaluationTest.php
@@ -4646,4 +4646,31 @@ class FeatureFlagLocalEvaluationTest extends TestCase
         self::assertTrue(FeatureFlag::matchFeatureFlagProperties($flag, "test-user", ["name" => "test"]));
         $this->checkEmptyErrorLogs();
     }
+
+    public function testEarlyExitOutOfRolloutBoundAfterInconclusiveConditionThrows(): void
+    {
+        // Repro: first condition is inconclusive (property missing), second is OutOfRolloutBound.
+        // With early_exit=true, the OutOfRolloutBound branch must NOT return false — it must
+        // propagate the inconclusive state so callers fall back to server evaluation.
+        $flag = [
+            "key" => "early-exit-flag",
+            "filters" => [
+                "early_exit" => true,
+                "groups" => [
+                    // Group 1: requires $cohort_id property; without it evaluation is inconclusive.
+                    [
+                        "properties" => [["key" => "name", "type" => "cohort", "value" => 1, "operator" => "exact"]],
+                        "rollout_percentage" => 100,
+                    ],
+                    // Group 2: properties match but rollout 0 → OutOfRolloutBound.
+                    [
+                        "properties" => [["key" => "region", "value" => "us", "operator" => "exact"]],
+                        "rollout_percentage" => 0,
+                    ],
+                ],
+            ],
+        ];
+        $this->expectException(InconclusiveMatchException::class);
+        FeatureFlag::matchFeatureFlagProperties($flag, "test-user", ["region" => "us"], [], []);
+    }
 }

--- a/test/FeatureFlagLocalEvaluationTest.php
+++ b/test/FeatureFlagLocalEvaluationTest.php
@@ -4586,28 +4586,40 @@ class FeatureFlagLocalEvaluationTest extends TestCase
         return ["key" => "early-exit-flag", "filters" => $filters];
     }
 
-    public function testEarlyExitEnabledReturnsFalseWithoutEvaluatingLaterMatchingGroup(): void
+    /**
+     * @dataProvider earlyExitRolloutExclusionProvider
+     */
+    public function testEarlyExitRolloutExclusion($earlyExit, bool $expected): void
     {
-        $flag = self::earlyExitFlag(true);
-        // First group: properties match but rollout 0 excludes the user (OUT_OF_ROLLOUT_BOUND).
-        // early_exit short-circuits to false instead of falling through to the matching group.
-        self::assertFalse(FeatureFlag::matchFeatureFlagProperties($flag, "test-user", ["name" => "test"]));
+        $flag = self::earlyExitFlag($earlyExit);
+        self::assertSame($expected, FeatureFlag::matchFeatureFlagProperties($flag, "test-user", ["name" => "test"]));
         $this->checkEmptyErrorLogs();
     }
 
-    public function testEarlyExitUnsetFallsThroughToMatchingGroup(): void
+    public static function earlyExitRolloutExclusionProvider(): array
     {
-        $flag = self::earlyExitFlag(null);
-        // No early_exit key: existing behaviour, evaluation falls through to the rollout-100 group.
-        self::assertTrue(FeatureFlag::matchFeatureFlagProperties($flag, "test-user", ["name" => "test"]));
-        $this->checkEmptyErrorLogs();
+        return [
+            'enabled short-circuits to false' => [true, false],
+            'unset falls through to matching group' => [null, true],
+            'explicitly false falls through' => [false, true],
+        ];
     }
 
-    public function testEarlyExitFalseFallsThroughToMatchingGroup(): void
+    public function testEarlyExitOnRolloutOnlyGroupWithNoPropertyFilters(): void
     {
-        $flag = self::earlyExitFlag(false);
-        // Explicit early_exit=false: same as unset, falls through to the matching group.
-        self::assertTrue(FeatureFlag::matchFeatureFlagProperties($flag, "test-user", ["name" => "test"]));
+        // Exercises the path where the properties block is skipped entirely and evaluation
+        // falls straight to the rollout check, returning OutOfRolloutBound.
+        $flag = [
+            "key" => "early-exit-flag",
+            "filters" => [
+                "early_exit" => true,
+                "groups" => [
+                    ["rollout_percentage" => 0],
+                    ["rollout_percentage" => 100],
+                ],
+            ],
+        ];
+        self::assertFalse(FeatureFlag::matchFeatureFlagProperties($flag, "test-user", []));
         $this->checkEmptyErrorLogs();
     }
 

--- a/test/FeatureFlagLocalEvaluationTest.php
+++ b/test/FeatureFlagLocalEvaluationTest.php
@@ -4651,8 +4651,9 @@ class FeatureFlagLocalEvaluationTest extends TestCase
     {
         // Repro: first condition is inconclusive (property missing from person properties),
         // second is OutOfRolloutBound. With early_exit=true, the OutOfRolloutBound branch must
-        // NOT return false — it must propagate the inconclusive state so callers fall back to
-        // server evaluation.
+        // NOT return false — but it must still stop evaluation (the matching third group must
+        // not be reached) and propagate the inconclusive state so callers fall back to server
+        // evaluation.
         $flag = [
             "key" => "early-exit-flag",
             "filters" => [
@@ -4667,6 +4668,11 @@ class FeatureFlagLocalEvaluationTest extends TestCase
                     [
                         "properties" => [["key" => "region", "value" => "us", "operator" => "exact"]],
                         "rollout_percentage" => 0,
+                    ],
+                    // Group 3: would match, but early exit at group 2 must prevent reaching it.
+                    [
+                        "properties" => [["key" => "region", "value" => "us", "operator" => "exact"]],
+                        "rollout_percentage" => 100,
                     ],
                 ],
             ],

--- a/test/FeatureFlagLocalEvaluationTest.php
+++ b/test/FeatureFlagLocalEvaluationTest.php
@@ -4562,4 +4562,76 @@ class FeatureFlagLocalEvaluationTest extends TestCase
         self::assertTrue(FeatureFlag::matchProperty($prop, ["version" => "1.0.0"]));
         self::assertTrue(FeatureFlag::matchProperty($prop, ["version" => 1]));
     }
+
+    // A flag whose first condition group matches on properties but excludes the user via
+    // rollout 0, and a later group that would match (properties + rollout 100). Without
+    // early_exit, evaluation falls through to the second group and returns true.
+    private static function earlyExitFlag($earlyExit): array
+    {
+        $filters = [
+            "groups" => [
+                [
+                    "properties" => [["key" => "name", "value" => "test", "operator" => "exact"]],
+                    "rollout_percentage" => 0,
+                ],
+                [
+                    "properties" => [["key" => "name", "value" => "test", "operator" => "exact"]],
+                    "rollout_percentage" => 100,
+                ],
+            ],
+        ];
+        if (!is_null($earlyExit)) {
+            $filters["early_exit"] = $earlyExit;
+        }
+        return ["key" => "early-exit-flag", "filters" => $filters];
+    }
+
+    public function testEarlyExitEnabledReturnsFalseWithoutEvaluatingLaterMatchingGroup(): void
+    {
+        $flag = self::earlyExitFlag(true);
+        // First group: properties match but rollout 0 excludes the user (OUT_OF_ROLLOUT_BOUND).
+        // early_exit short-circuits to false instead of falling through to the matching group.
+        self::assertFalse(FeatureFlag::matchFeatureFlagProperties($flag, "test-user", ["name" => "test"]));
+        $this->checkEmptyErrorLogs();
+    }
+
+    public function testEarlyExitUnsetFallsThroughToMatchingGroup(): void
+    {
+        $flag = self::earlyExitFlag(null);
+        // No early_exit key: existing behaviour, evaluation falls through to the rollout-100 group.
+        self::assertTrue(FeatureFlag::matchFeatureFlagProperties($flag, "test-user", ["name" => "test"]));
+        $this->checkEmptyErrorLogs();
+    }
+
+    public function testEarlyExitFalseFallsThroughToMatchingGroup(): void
+    {
+        $flag = self::earlyExitFlag(false);
+        // Explicit early_exit=false: same as unset, falls through to the matching group.
+        self::assertTrue(FeatureFlag::matchFeatureFlagProperties($flag, "test-user", ["name" => "test"]));
+        $this->checkEmptyErrorLogs();
+    }
+
+    public function testEarlyExitDoesNotTriggerOnPropertyMismatch(): void
+    {
+        // First group: property filter fails (NO_MATCH, not a rollout exclusion), so even with
+        // early_exit enabled evaluation must fall through to the second matching group.
+        $flag = [
+            "key" => "early-exit-flag",
+            "filters" => [
+                "early_exit" => true,
+                "groups" => [
+                    [
+                        "properties" => [["key" => "name", "value" => "other", "operator" => "exact"]],
+                        "rollout_percentage" => 0,
+                    ],
+                    [
+                        "properties" => [["key" => "name", "value" => "test", "operator" => "exact"]],
+                        "rollout_percentage" => 100,
+                    ],
+                ],
+            ],
+        ];
+        self::assertTrue(FeatureFlag::matchFeatureFlagProperties($flag, "test-user", ["name" => "test"]));
+        $this->checkEmptyErrorLogs();
+    }
 }

--- a/test/FeatureFlagLocalEvaluationTest.php
+++ b/test/FeatureFlagLocalEvaluationTest.php
@@ -4649,17 +4649,18 @@ class FeatureFlagLocalEvaluationTest extends TestCase
 
     public function testEarlyExitOutOfRolloutBoundAfterInconclusiveConditionThrows(): void
     {
-        // Repro: first condition is inconclusive (property missing), second is OutOfRolloutBound.
-        // With early_exit=true, the OutOfRolloutBound branch must NOT return false — it must
-        // propagate the inconclusive state so callers fall back to server evaluation.
+        // Repro: first condition is inconclusive (property missing from person properties),
+        // second is OutOfRolloutBound. With early_exit=true, the OutOfRolloutBound branch must
+        // NOT return false — it must propagate the inconclusive state so callers fall back to
+        // server evaluation.
         $flag = [
             "key" => "early-exit-flag",
             "filters" => [
                 "early_exit" => true,
                 "groups" => [
-                    // Group 1: requires $cohort_id property; without it evaluation is inconclusive.
+                    // Group 1: requires "missing_prop" which is absent → InconclusiveMatchException.
                     [
-                        "properties" => [["key" => "name", "type" => "cohort", "value" => 1, "operator" => "exact"]],
+                        "properties" => [["key" => "missing_prop", "value" => "x", "operator" => "exact"]],
                         "rollout_percentage" => 100,
                     ],
                     // Group 2: properties match but rollout 0 → OutOfRolloutBound.
@@ -4671,6 +4672,6 @@ class FeatureFlagLocalEvaluationTest extends TestCase
             ],
         ];
         $this->expectException(InconclusiveMatchException::class);
-        FeatureFlag::matchFeatureFlagProperties($flag, "test-user", ["region" => "us"], [], []);
+        FeatureFlag::matchFeatureFlagProperties($flag, "test-user", ["region" => "us"]);
     }
 }

--- a/test/FeatureFlagLocalEvaluationTest.php
+++ b/test/FeatureFlagLocalEvaluationTest.php
@@ -4647,6 +4647,32 @@ class FeatureFlagLocalEvaluationTest extends TestCase
         $this->checkEmptyErrorLogs();
     }
 
+    public function testEarlyExitInconclusiveThenMatchingConditionReturnsTrue(): void
+    {
+        // An inconclusive condition must not poison later groups: a subsequent conclusive
+        // match still decides the flag locally, even with early_exit enabled.
+        $flag = [
+            "key" => "early-exit-flag",
+            "filters" => [
+                "early_exit" => true,
+                "groups" => [
+                    // Group 1: requires "missing_prop" which is absent → InconclusiveMatchException.
+                    [
+                        "properties" => [["key" => "missing_prop", "value" => "x", "operator" => "exact"]],
+                        "rollout_percentage" => 100,
+                    ],
+                    // Group 2: conclusive match.
+                    [
+                        "properties" => [["key" => "region", "value" => "us", "operator" => "exact"]],
+                        "rollout_percentage" => 100,
+                    ],
+                ],
+            ],
+        ];
+        self::assertTrue(FeatureFlag::matchFeatureFlagProperties($flag, "test-user", ["region" => "us"]));
+        $this->checkEmptyErrorLogs();
+    }
+
     public function testEarlyExitOutOfRolloutBoundAfterInconclusiveConditionThrows(): void
     {
         // Repro: first condition is inconclusive (property missing from person properties),


### PR DESCRIPTION
## :bulb: Motivation and Context

PostHog added an "early exit" option to feature flags in the server-side (Rust) evaluation engine. When a flag's `filters.early_exit` is `true`, local condition evaluation must STOP and return a definitive `false`/disabled as soon as a condition group's property filters match (or the group has no property filters) but the rollout percentage EXCLUDES the user — instead of falling through to evaluate later condition groups.

This was already ported to `posthog-node` and `posthog-python`; this PR ports the same behavior to `posthog-php` so local evaluation matches the server.

### Behavior

For each condition group, evaluation now distinguishes three outcomes:

- **MATCH** — property filters matched AND rollout included the user → flag matches (existing behavior).
- **NO_MATCH** — a property filter did NOT match → continue to the next group. Always falls through, even when `early_exit` is enabled.
- **OUT_OF_ROLLOUT_BOUND** — property filters matched (or none) but rollout EXCLUDED the user.

When `early_exit` is enabled AND a group's outcome is `OUT_OF_ROLLOUT_BOUND`, evaluation returns `false` immediately. When `early_exit` is unset or `false`, existing behavior is preserved exactly.

Implementation: `isConditionMatch` now returns a tri-state `ConditionMatch` enum (`Match` / `NoMatch` / `OutOfRolloutBound`) instead of a bool, letting `matchFeatureFlagProperties` short-circuit on rollout exclusion only.

## :green_heart: How did you test it?

Added unit tests to `FeatureFlagLocalEvaluationTest` covering: `early_exit` enabled returns `false` without evaluating a later matching group; `early_exit` unset falls through (regression); `early_exit` explicitly `false` falls through; and property-filter failure (not rollout) does NOT early-exit even when enabled.

Full suite green: `vendor/bin/phpunit` → 334 tests, 3362 assertions, 0 failures. `vendor/bin/phpcs` (PSR12) → 0 errors on changed files.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
