### PR TITLE
chore: update PHP CI workflow

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - "**.php"
       - "bin/posthog"
+      - "composer.json"
+      - "composer.lock"
       - "phpcs.xml"
       - "phpunit.xml"
       - ".github/workflows/php.yml"
@@ -14,14 +16,35 @@ on:
     paths:
       - "**.php"
       - "bin/posthog"
+      - "composer.json"
+      - "composer.lock"
       - "phpcs.xml"
       - "phpunit.xml"
       - ".github/workflows/php.yml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  composer-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
+        with:
+          php-version: 8.4
+          tools: composer
+
+      - name: Validate composer files
+        run: composer validate --strict
+
   phpunit:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         php-version: [8.2, 8.3, 8.4, 8.5]
     steps:
@@ -31,13 +54,30 @@ jobs:
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
         with:
           php-version: ${{ matrix.php-version }}
-          extensions: xdebug
           tools: composer, phpunit
 
       - name: Install Dependencies
         run: composer install --prefer-dist --no-progress
 
       - name: Run PHPUnit Tests
+        run: ./vendor/bin/phpunit --bootstrap vendor/autoload.php --configuration phpunit.xml
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up PHP 8.4
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
+        with:
+          php-version: 8.4
+          extensions: xdebug
+          tools: composer, phpunit
+
+      - name: Install Dependencies
+        run: composer install --prefer-dist --no-progress
+
+      - name: Run PHPUnit Coverage
         run: XDEBUG_MODE=coverage ./vendor/bin/phpunit --bootstrap vendor/autoload.php --configuration phpunit.xml --coverage-text
 
   phpcs:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -39,7 +39,7 @@ jobs:
           tools: composer
 
       - name: Validate composer files
-        run: composer validate --strict
+        run: composer validate --no-check-lock --no-check-version --strict
 
   phpunit:
     runs-on: ubuntu-latest
@@ -64,6 +64,7 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
+    needs: phpunit
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
## :bulb: Motivation and Context
Keep the PHP CI workflow aligned with project metadata changes, reduce wasted CI work, and separate regular test runs from coverage collection.

## :green_heart: How did you test it?
- `composer validate --no-check-lock --no-check-version --strict`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
