### PR TITLE
chore: add PHP formatting check

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -93,7 +93,17 @@ jobs:
       - name: Install PHP_CodeSniffer
         run: |
           curl -OL https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar
+          curl -OL https://squizlabs.github.io/PHP_CodeSniffer/phpcbf.phar
           php phpcs.phar --version
+          php phpcbf.phar --version
+
+      - name: Check PHP formatting
+        run: |
+          php phpcbf.phar --standard=phpcs.xml --no-colors --report=summary || phpcbf_status=$?
+          if [ "${phpcbf_status:-0}" -gt 1 ]; then
+            exit "$phpcbf_status"
+          fi
+          git diff --exit-code -- lib test
 
       - uses: tinovyatkin/action-php-codesniffer@0043b33b3629611c37e8bc7ee8a4e061dc9a7ea2 # v1
         with:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Check PHP formatting
         run: |
-          php phpcbf.phar --standard=phpcs.xml --no-colors --report=summary || phpcbf_status=$?
+          php phpcbf.phar --standard=phpcs.xml --no-colors || phpcbf_status=$?
           if [ "${phpcbf_status:-0}" -gt 1 ]; then
             exit "$phpcbf_status"
           fi

--- a/test/FeatureFlagEvaluationsTest.php
+++ b/test/FeatureFlagEvaluationsTest.php
@@ -579,8 +579,10 @@ class FeatureFlagEvaluationsTest extends TestCase
         $events = [];
         foreach ($this->batchRequests() as $batch) {
             foreach ($batch['batch'] as $event) {
-                if ($event['event'] === '$feature_flag_called'
-                    && ($event['properties']['$feature_flag'] ?? null) === 'simple-test') {
+                if (
+                    $event['event'] === '$feature_flag_called'
+                    && ($event['properties']['$feature_flag'] ?? null) === 'simple-test'
+                ) {
                     $events[] = $event;
                 }
             }
@@ -637,8 +639,10 @@ class FeatureFlagEvaluationsTest extends TestCase
         $count = 0;
         foreach ($this->batchRequests() as $batch) {
             foreach ($batch['batch'] as $event) {
-                if ($event['event'] === '$feature_flag_called'
-                    && ($event['properties']['$feature_flag'] ?? null) === 'simple-test') {
+                if (
+                    $event['event'] === '$feature_flag_called'
+                    && ($event['properties']['$feature_flag'] ?? null) === 'simple-test'
+                ) {
                     $count++;
                 }
             }


### PR DESCRIPTION
## :bulb: Motivation and Context
Add a PHP formatting check to CI so PSR-12 auto-fixable formatting issues are caught before merge.

## :green_heart: How did you test it?
- `vendor/bin/phpcs --standard=phpcs.xml test/FeatureFlagEvaluationsTest.php`
- `actionlint .github/workflows/php.yml`
- `git diff --check`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
