### PR TITLE
docs: centralize SDK examples in official docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,12 @@
 # PostHog PHP
 
-[![PHP Version](https://img.shields.io/packagist/php-v/posthog/posthog-php?logo=php)](https://packagist.org/packages/posthog/posthog-php)
-[![CI](https://github.com/PostHog/posthog-php/actions/workflows/php.yml/badge.svg)](https://github.com/PostHog/posthog-php/actions/workflows/php.yml)
-
 Please see the main [PostHog docs](https://posthog.com/docs).
 
-Specifically, the [PHP integration](https://posthog.com/docs/integrations/php-integration) details.
+SDK usage examples and code snippets live in the official documentation so they stay up to date.
 
-## Features
+## Documentation
 
-- ✅ Event capture and user identification
-- ✅ Feature flags, including local evaluation, multivariate flags, payloads, and flag dependencies
-- ✅ Group analytics
-- ✅ Error tracking with manual exception capture and opt-in automatic PHP exception, error, and fatal shutdown capture
-- ✅ Request context helpers for applying distinct IDs, session IDs, and common properties across a request
-- ✅ Comprehensive test coverage
+- [PHP library docs](https://posthog.com/docs/libraries/php)
 
 ## Questions?
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # PostHog PHP
 
+[![PHP Version](https://img.shields.io/packagist/php-v/posthog/posthog-php?logo=php)](https://packagist.org/packages/posthog/posthog-php)
+[![CI](https://github.com/PostHog/posthog-php/actions/workflows/php.yml/badge.svg)](https://github.com/PostHog/posthog-php/actions/workflows/php.yml)
+
 Please see the main [PostHog docs](https://posthog.com/docs).
 
 SDK usage examples and code snippets live in the official documentation so they stay up to date.
@@ -7,6 +10,7 @@ SDK usage examples and code snippets live in the official documentation so they 
 ## Documentation
 
 - [PHP library docs](https://posthog.com/docs/libraries/php)
+- [Laravel integration docs](https://posthog.com/docs/libraries/laravel)
 
 ## Questions?
 


### PR DESCRIPTION
## :bulb: Motivation and Context

SDK README and usage markdown files duplicated code snippets that can drift from the official documentation. This keeps public SDK usage examples in the official docs as the single source of truth while preserving local repository information like badges, Questions/community links, and example setup instructions.

## :green_heart: How did you test it?

- Ran `git diff --check`.
- Verified stale `USAGE.md`/old integration-doc links were removed or updated.
- Verified existing badges and Questions/community sections are preserved.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
