### PR TITLE
feat: add public version API

### DIFF
--- a/.changeset/fresh-cats-compare.md
+++ b/.changeset/fresh-cats-compare.md
@@ -1,0 +1,5 @@
+---
+'posthog/posthog-php': minor
+---
+
+Add a public getVersion API to the PostHog facade.

--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -16,6 +16,16 @@ class PostHog
     private static ?Client $client = null;
 
     /**
+     * Return the SDK version string.
+     *
+     * @return string
+     */
+    public static function getVersion(): string
+    {
+        return self::VERSION;
+    }
+
+    /**
      * Initializes the default client to use. Uses the libcurl consumer by default.
      *
      * When $apiKey is omitted or blank, POSTHOG_API_KEY is used when present. When no

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -155,6 +155,11 @@ class PostHogTest extends TestCase
         PostHog::init("BrpS4SctoaCCsyjlnlun3OzyNJAafdlv__jUWaaJWXg", array("debug" => true));
     }
 
+    public function testGetVersionReturnsVersionConstant(): void
+    {
+        $this->assertSame(PostHog::VERSION, PostHog::getVersion());
+    }
+
     public function testInitWithEnvApiKey(): void
     {
         $this->expectNotToPerformAssertions();


### PR DESCRIPTION
## :bulb: Motivation and Context

Test the public API snapshot workflow after #165 by adding a small new public facade API without updating `api/public-api.json`.

## :green_heart: How did you test it?

- `./vendor/bin/phpunit --no-coverage test/PostHogTest.php --filter testGetVersionReturnsVersionConstant`
- `composer api:check` (expected failure: confirms the public API snapshot is intentionally out of date)

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
