### PR TITLE
feat: add flag definition cache provider

### DIFF
--- a/.changeset/tender-dingos-share.md
+++ b/.changeset/tender-dingos-share.md
@@ -1,0 +1,5 @@
+---
+"posthog-php": minor
+---
+
+Add an external flag definition cache provider for sharing local-evaluation definitions across PHP SDK instances.

--- a/api/public-api.json
+++ b/api/public-api.json
@@ -895,6 +895,13 @@
                         }
                     ]
                 },
+                "shutdown": {
+                    "static": false,
+                    "abstract": false,
+                    "final": false,
+                    "returnType": "bool",
+                    "parameters": []
+                },
                 "withContext": {
                     "static": false,
                     "abstract": false,
@@ -2854,6 +2861,57 @@
                 }
             }
         },
+        "PostHog\\FlagDefinitionCacheProvider": {
+            "type": "interface",
+            "abstract": true,
+            "final": false,
+            "readonly": false,
+            "extends": null,
+            "implements": [],
+            "constants": [],
+            "properties": [],
+            "methods": {
+                "getFlagDefinitions": {
+                    "static": false,
+                    "abstract": true,
+                    "final": false,
+                    "returnType": "?array",
+                    "parameters": []
+                },
+                "onFlagDefinitionsReceived": {
+                    "static": false,
+                    "abstract": true,
+                    "final": false,
+                    "returnType": "void",
+                    "parameters": [
+                        {
+                            "name": "data",
+                            "type": "array",
+                            "byReference": false,
+                            "variadic": false,
+                            "optional": false,
+                            "default": null,
+                            "defaultConstant": null,
+                            "hasDefault": false
+                        }
+                    ]
+                },
+                "shouldFetchFlagDefinitions": {
+                    "static": false,
+                    "abstract": true,
+                    "final": false,
+                    "returnType": "bool",
+                    "parameters": []
+                },
+                "shutdown": {
+                    "static": false,
+                    "abstract": true,
+                    "final": false,
+                    "returnType": "void",
+                    "parameters": []
+                }
+            }
+        },
         "PostHog\\HttpClient": {
             "type": "class",
             "abstract": false,
@@ -3904,6 +3962,13 @@
                             "hasDefault": false
                         }
                     ]
+                },
+                "shutdown": {
+                    "static": true,
+                    "abstract": false,
+                    "final": false,
+                    "returnType": "bool",
+                    "parameters": []
                 },
                 "validate": {
                     "static": true,

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -3,12 +3,14 @@
 namespace PostHog;
 
 use Exception;
+use InvalidArgumentException;
 use PostHog\Consumer\File;
 use PostHog\Consumer\ForkCurl;
 use PostHog\Consumer\LibCurl;
 use PostHog\Consumer\NoOp;
 use PostHog\Consumer\Socket;
 use Symfony\Component\Clock\Clock;
+use Throwable;
 
 /**
  * PostHog PHP SDK client for event capture, user identification, feature flags, and error tracking.
@@ -83,6 +85,26 @@ class Client implements FeatureFlagEvaluationsHost
     private $flagsEtag;
 
     /**
+     * @var bool Whether flag definitions have been loaded successfully at least once.
+     */
+    private $flagDefinitionsLoaded;
+
+    /**
+     * @var FlagDefinitionCacheProvider|null External shared cache provider for flag definitions.
+     */
+    private $flagDefinitionCacheProvider;
+
+    /**
+     * @var bool Whether the external flag definition cache provider has been shut down.
+     */
+    private $flagDefinitionCacheProviderShutdown;
+
+    /**
+     * @var bool Whether client shutdown has already run.
+     */
+    private $shutdownComplete;
+
+    /**
      * @var bool
      */
     private $debug;
@@ -122,6 +144,7 @@ class Client implements FeatureFlagEvaluationsHost
      *     error_handler?: callable,
      *     filename?: string,
      *     is_server?: bool,
+     *     flag_definition_cache_provider?: FlagDefinitionCacheProvider,
      *     error_tracking?: array{
      *         enabled?: bool,
      *         capture_errors?: bool,
@@ -146,6 +169,11 @@ class Client implements FeatureFlagEvaluationsHost
         $this->personalAPIKey = StringNormalizer::normalizeOptional($personalAPIKey);
         $this->options = $options;
         $this->debug = $options["debug"] ?? false;
+        $this->flagDefinitionCacheProvider = self::normalizeFlagDefinitionCacheProvider(
+            $options['flag_definition_cache_provider'] ?? null
+        );
+        $this->flagDefinitionCacheProviderShutdown = false;
+        $this->shutdownComplete = false;
         $this->options['host'] = StringNormalizer::normalizeHost($options['host'] ?? null);
         if (!$this->enabled) {
             if (($this->options['consumer'] ?? null) !== 'noop') {
@@ -171,6 +199,7 @@ class Client implements FeatureFlagEvaluationsHost
         $this->featureFlagsByKey = [];
         $this->distinctIdsFeatureFlagsReported = new SizeLimitedHash(self::SIZE_LIMIT);
         $this->flagsEtag = null;
+        $this->flagDefinitionsLoaded = false;
 
         if ($this->enabled) {
             ExceptionCapture::configure($this, $options['error_tracking'] ?? []);
@@ -188,11 +217,51 @@ class Client implements FeatureFlagEvaluationsHost
     }
 
     /**
+     * Validate and normalize an optional external flag definition cache provider.
+     *
+     * @param mixed $provider
+     * @return FlagDefinitionCacheProvider|null
+     */
+    private static function normalizeFlagDefinitionCacheProvider(mixed $provider): ?FlagDefinitionCacheProvider
+    {
+        if ($provider === null) {
+            return null;
+        }
+
+        if (!$provider instanceof FlagDefinitionCacheProvider) {
+            throw new InvalidArgumentException(
+                'flag_definition_cache_provider must implement PostHog\\FlagDefinitionCacheProvider'
+            );
+        }
+
+        return $provider;
+    }
+
+    /**
      * Flush and clean up the underlying consumer when the client is destroyed.
      */
     public function __destruct()
     {
+        $this->shutdown();
+    }
+
+    /**
+     * Flush queued events and release resources held by the client.
+     *
+     * @return bool True if flushing succeeded or the consumer has no flush operation.
+     */
+    public function shutdown(): bool
+    {
+        if ($this->shutdownComplete) {
+            return true;
+        }
+
+        $flushed = $this->flush();
+        $this->shutdownFlagDefinitionCacheProvider();
         $this->consumer->__destruct();
+        $this->shutdownComplete = true;
+
+        return $flushed;
     }
 
     /**
@@ -1118,6 +1187,75 @@ class Client implements FeatureFlagEvaluationsHost
             return;
         }
 
+        $shouldFetch = $this->shouldFetchFlagDefinitionsFromApi();
+
+        if (!$shouldFetch && $this->flagDefinitionCacheProvider !== null) {
+            try {
+                $cachedData = $this->flagDefinitionCacheProvider->getFlagDefinitions();
+                if ($cachedData !== null) {
+                    $normalizedData = $this->normalizeFlagDefinitionCacheData($cachedData);
+                    if ($normalizedData !== null) {
+                        $this->applyFlagDefinitions($normalizedData);
+                        if ($this->debug) {
+                            error_log("[PostHog][Client] Using cached flag definitions from external cache");
+                        }
+                        return;
+                    }
+
+                    $this->logFlagDefinitionCacheWarning('Cache provider returned malformed flag definitions');
+                    if ($this->hasFlagDefinitionsLoaded()) {
+                        return;
+                    }
+                } elseif ($this->hasFlagDefinitionsLoaded()) {
+                    return;
+                }
+
+                $shouldFetch = !is_null($this->personalAPIKey);
+            } catch (Throwable $throwable) {
+                $this->logFlagDefinitionCacheWarning(
+                    'Cache provider read error: ' . $throwable->getMessage()
+                );
+                if ($this->hasFlagDefinitionsLoaded()) {
+                    return;
+                }
+                $shouldFetch = !is_null($this->personalAPIKey);
+            }
+        }
+
+        if ($shouldFetch) {
+            $this->fetchAndApplyFlagDefinitionsFromApi();
+        }
+    }
+
+    /**
+     * Decide whether to fetch flag definitions directly from PostHog.
+     *
+     * @return bool
+     */
+    private function shouldFetchFlagDefinitionsFromApi(): bool
+    {
+        if ($this->flagDefinitionCacheProvider === null) {
+            return true;
+        }
+
+        try {
+            return $this->flagDefinitionCacheProvider->shouldFetchFlagDefinitions();
+        } catch (Throwable $throwable) {
+            $this->logFlagDefinitionCacheWarning(
+                'Cache provider fetch-decision error: ' . $throwable->getMessage()
+            );
+            return true;
+        }
+    }
+
+    /**
+     * Fetch, apply, and optionally store flag definitions from PostHog.
+     *
+     * @return void
+     * @throws Exception
+     */
+    private function fetchAndApplyFlagDefinitionsFromApi(): void
+    {
         $response = $this->localFlags();
 
         // Handle 304 Not Modified - flags haven't changed, skip processing.
@@ -1149,21 +1287,152 @@ class Client implements FeatureFlagEvaluationsHost
             throw new Exception($payload["detail"]);
         }
 
+        if (!is_array($payload)) {
+            error_log("[PostHog][Client] Failed to load feature flags: invalid JSON response");
+            return;
+        }
+
         // On 200 responses, always update ETag (even if null) since we're replacing
         // the cached flag data. A null ETag means the server doesn't support caching.
         $this->flagsEtag = $response->getEtag();
 
-        $this->featureFlags = $payload['flags'] ?? [];
-        $this->groupTypeMapping = $payload['group_type_mapping'] ?? [];
-        $this->cohorts = $payload['cohorts'] ?? [];
+        $data = $this->normalizeFlagDefinitionData($payload);
+        $this->applyFlagDefinitions($data);
+        $this->storeFlagDefinitionsInCacheProvider($data);
+    }
+
+    /**
+     * Normalize API flag definition data using SDK defaults for optional fields.
+     *
+     * @param array<string, mixed> $data
+     * @return array<string, mixed>
+     */
+    private function normalizeFlagDefinitionData(array $data): array
+    {
+        return [
+            'flags' => isset($data['flags']) && is_array($data['flags']) ? $data['flags'] : [],
+            'group_type_mapping' => isset($data['group_type_mapping']) && is_array($data['group_type_mapping'])
+                ? $data['group_type_mapping']
+                : [],
+            'cohorts' => isset($data['cohorts']) && is_array($data['cohorts']) ? $data['cohorts'] : [],
+        ];
+    }
+
+    /**
+     * Validate cached flag definition data from an external cache provider.
+     *
+     * @param array<string, mixed> $data
+     * @return array<string, mixed>|null
+     */
+    private function normalizeFlagDefinitionCacheData(array $data): ?array
+    {
+        if (!isset($data['flags']) || !is_array($data['flags'])) {
+            return null;
+        }
+
+        $groupTypeMapping = $data['group_type_mapping'] ?? $data['groupTypeMapping'] ?? [];
+        if (!is_array($groupTypeMapping)) {
+            return null;
+        }
+
+        $cohorts = $data['cohorts'] ?? [];
+        if (!is_array($cohorts)) {
+            return null;
+        }
+
+        return [
+            'flags' => $data['flags'],
+            'group_type_mapping' => $groupTypeMapping,
+            'cohorts' => $cohorts,
+        ];
+    }
+
+    /**
+     * Apply flag definitions to in-memory state.
+     *
+     * @param array<string, mixed> $data
+     * @return void
+     */
+    private function applyFlagDefinitions(array $data): void
+    {
+        $this->featureFlags = $data['flags'];
+        $this->groupTypeMapping = $data['group_type_mapping'];
+        $this->cohorts = $data['cohorts'];
 
         // Build flags by key dictionary for dependency resolution
         $this->featureFlagsByKey = [];
         foreach ($this->featureFlags as $flag) {
-            $this->featureFlagsByKey[$flag['key']] = $flag;
+            if (is_array($flag) && array_key_exists('key', $flag)) {
+                $this->featureFlagsByKey[$flag['key']] = $flag;
+            }
+        }
+
+        $this->flagDefinitionsLoaded = true;
+    }
+
+    /**
+     * Store fetched flag definitions in the configured external cache provider.
+     *
+     * @param array<string, mixed> $data
+     * @return void
+     */
+    private function storeFlagDefinitionsInCacheProvider(array $data): void
+    {
+        if ($this->flagDefinitionCacheProvider === null) {
+            return;
+        }
+
+        try {
+            $this->flagDefinitionCacheProvider->onFlagDefinitionsReceived($data);
+        } catch (Throwable $throwable) {
+            $this->logFlagDefinitionCacheWarning(
+                'Cache provider store error: ' . $throwable->getMessage()
+            );
         }
     }
 
+    /**
+     * Whether this client has successfully loaded a complete flag definition set.
+     *
+     * @return bool
+     */
+    private function hasFlagDefinitionsLoaded(): bool
+    {
+        return $this->flagDefinitionsLoaded;
+    }
+
+    /**
+     * Release resources held by the configured external cache provider.
+     *
+     * @return void
+     */
+    private function shutdownFlagDefinitionCacheProvider(): void
+    {
+        if ($this->flagDefinitionCacheProvider === null || $this->flagDefinitionCacheProviderShutdown) {
+            return;
+        }
+
+        try {
+            $this->flagDefinitionCacheProvider->shutdown();
+        } catch (Throwable $throwable) {
+            $this->logFlagDefinitionCacheWarning(
+                'Cache provider shutdown error: ' . $throwable->getMessage()
+            );
+        } finally {
+            $this->flagDefinitionCacheProviderShutdown = true;
+        }
+    }
+
+    /**
+     * Emit a non-fatal warning for flag definition cache provider failures.
+     *
+     * @param string $message Warning message without the SDK prefix.
+     * @return void
+     */
+    private function logFlagDefinitionCacheWarning(string $message): void
+    {
+        $this->logWarning('Flag definition cache warning: ' . $message);
+    }
 
     /**
      * Fetch local feature flag definitions from the PostHog API.

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -1244,7 +1244,7 @@ class Client implements FeatureFlagEvaluationsHost
             $this->logFlagDefinitionCacheWarning(
                 'Cache provider fetch-decision error: ' . $throwable->getMessage()
             );
-            return true;
+            return !is_null($this->personalAPIKey);
         }
     }
 
@@ -1326,24 +1326,31 @@ class Client implements FeatureFlagEvaluationsHost
      */
     private function normalizeFlagDefinitionCacheData(array $data): ?array
     {
-        if (!isset($data['flags']) || !is_array($data['flags'])) {
+        if (!array_key_exists('flags', $data) || !is_array($data['flags'])) {
             return null;
         }
 
-        $groupTypeMapping = $data['group_type_mapping'] ?? $data['groupTypeMapping'] ?? [];
+        $hasSnakeCaseGroupTypeMapping = array_key_exists('group_type_mapping', $data);
+        $hasCamelCaseGroupTypeMapping = array_key_exists('groupTypeMapping', $data);
+        if (!$hasSnakeCaseGroupTypeMapping && !$hasCamelCaseGroupTypeMapping) {
+            return null;
+        }
+
+        $groupTypeMapping = $hasSnakeCaseGroupTypeMapping
+            ? $data['group_type_mapping']
+            : $data['groupTypeMapping'];
         if (!is_array($groupTypeMapping)) {
             return null;
         }
 
-        $cohorts = $data['cohorts'] ?? [];
-        if (!is_array($cohorts)) {
+        if (!array_key_exists('cohorts', $data) || !is_array($data['cohorts'])) {
             return null;
         }
 
         return [
             'flags' => $data['flags'],
             'group_type_mapping' => $groupTypeMapping,
-            'cohorts' => $cohorts,
+            'cohorts' => $data['cohorts'],
         ];
     }
 

--- a/lib/FlagDefinitionCacheProvider.php
+++ b/lib/FlagDefinitionCacheProvider.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace PostHog;
+
+/**
+ * External cache provider for local-evaluation feature flag definitions.
+ *
+ * Implement this interface to share downloaded flag definitions across PHP workers, serverless
+ * invocations, or other distributed SDK instances. Provider methods are called synchronously by the
+ * SDK and any thrown error is logged as a warning without crashing application code.
+ */
+interface FlagDefinitionCacheProvider
+{
+    /**
+     * Retrieve cached local-evaluation flag definitions.
+     *
+     * Return null when the external cache is empty or unavailable. Returned data should include the
+     * complete definition set: flags, group_type_mapping, and cohorts. groupTypeMapping is also
+     * accepted when reading cached data for integrations that prefer camelCase.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function getFlagDefinitions(): ?array;
+
+    /**
+     * Decide whether this SDK instance should fetch fresh definitions from PostHog.
+     *
+     * Return false when another worker is responsible for fetching and this instance should read the
+     * latest definitions from getFlagDefinitions() instead.
+     *
+     * @return bool
+     */
+    public function shouldFetchFlagDefinitions(): bool;
+
+    /**
+     * Receive definitions fetched successfully from PostHog so they can be stored externally.
+     *
+     * @param array<string, mixed> $data
+     * @return void
+     */
+    public function onFlagDefinitionsReceived(array $data): void;
+
+    /**
+     * Release provider resources during SDK shutdown.
+     *
+     * @return void
+     */
+    public function shutdown(): void;
+}

--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -37,6 +37,7 @@ class PostHog
      *     compress_request?: bool|string,
      *     error_handler?: callable,
      *     filename?: string,
+     *     flag_definition_cache_provider?: FlagDefinitionCacheProvider,
      *     error_tracking?: array{
      *         enabled?: bool,
      *         capture_errors?: bool,
@@ -531,6 +532,19 @@ class PostHog
         self::checkClient();
 
         return self::$client->flush();
+    }
+
+    /**
+     * Flush queued events and release resources on the underlying client.
+     *
+     * @return bool True when shutdown flushing succeeded or the consumer has no flush operation.
+     * @throws Exception
+     */
+    public static function shutdown(): bool
+    {
+        self::checkClient();
+
+        return self::$client->shutdown();
     }
 
     /**

--- a/test/FlagDefinitionCacheProviderTest.php
+++ b/test/FlagDefinitionCacheProviderTest.php
@@ -173,6 +173,27 @@ class FlagDefinitionCacheProviderTest extends TestCase
         $this->assertWarningContains('Cache provider fetch-decision error: Lock acquisition failed');
     }
 
+    public function testProviderFetchDecisionFailureWithoutPersonalApiKeyDoesNotFetchDirectly(): void
+    {
+        $provider = new MockFlagDefinitionCacheProvider();
+        $provider->shouldFetchError = new \RuntimeException('Lock acquisition failed');
+        $httpClient = new MockedHttpClient(host: "app.posthog.com");
+        $client = new Client(
+            self::FAKE_API_KEY,
+            ['flag_definition_cache_provider' => $provider],
+            $httpClient,
+            null,
+            false
+        );
+
+        $client->loadFlags();
+
+        $this->assertSame(1, $provider->shouldFetchCallCount);
+        $this->assertSame(1, $provider->getCallCount);
+        $this->assertSame([], $httpClient->calls ?? []);
+        $this->assertWarningContains('Cache provider fetch-decision error: Lock acquisition failed');
+    }
+
     public function testProviderStoreFailureKeepsFetchedDefinitionsUsable(): void
     {
         $provider = new MockFlagDefinitionCacheProvider();
@@ -221,6 +242,29 @@ class FlagDefinitionCacheProviderTest extends TestCase
         $client->loadFlags();
 
         $this->assertSame('beta-ui', $client->featureFlags[0]['key']);
+        $this->assertCount(1, $httpClient->calls);
+        $this->assertWarningContains('Cache provider returned malformed flag definitions');
+    }
+
+    public function testIncompleteProviderCacheDataDoesNotClearExistingDefinitions(): void
+    {
+        $provider = new MockFlagDefinitionCacheProvider();
+        $provider->shouldFetch = true;
+        $httpClient = new MockedHttpClient(
+            host: "app.posthog.com",
+            flagEndpointResponse: $this->sampleFlagDefinitionData()
+        );
+        $client = $this->createClient($provider, $httpClient);
+
+        $provider->shouldFetch = false;
+        $provider->cachedData = [
+            'flags' => [['key' => 'incomplete-flag', 'active' => true, 'filters' => []]],
+        ];
+        $client->loadFlags();
+
+        $this->assertSame('beta-ui', $client->featureFlags[0]['key']);
+        $this->assertSame(['0' => 'company'], $client->groupTypeMapping);
+        $this->assertSame(['1' => ['type' => 'AND', 'values' => []]], $client->cohorts);
         $this->assertCount(1, $httpClient->calls);
         $this->assertWarningContains('Cache provider returned malformed flag definitions');
     }

--- a/test/FlagDefinitionCacheProviderTest.php
+++ b/test/FlagDefinitionCacheProviderTest.php
@@ -1,0 +1,306 @@
+<?php
+// phpcs:ignoreFile
+namespace PostHog\Test;
+
+require_once 'test/error_log_mock.php';
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use PostHog\Client;
+use PostHog\FlagDefinitionCacheProvider;
+use PostHog\Test\Assets\MockedResponses;
+
+class MockFlagDefinitionCacheProvider implements FlagDefinitionCacheProvider
+{
+    public ?array $cachedData = null;
+    public bool $shouldFetch = true;
+    public int $getCallCount = 0;
+    public int $shouldFetchCallCount = 0;
+    public int $onReceivedCallCount = 0;
+    public int $shutdownCallCount = 0;
+    public ?array $storedData = null;
+    public ?\Throwable $shouldFetchError = null;
+    public ?\Throwable $getError = null;
+    public ?\Throwable $onReceivedError = null;
+    public ?\Throwable $shutdownError = null;
+
+    public function getFlagDefinitions(): ?array
+    {
+        $this->getCallCount++;
+        if ($this->getError !== null) {
+            throw $this->getError;
+        }
+
+        return $this->cachedData;
+    }
+
+    public function shouldFetchFlagDefinitions(): bool
+    {
+        $this->shouldFetchCallCount++;
+        if ($this->shouldFetchError !== null) {
+            throw $this->shouldFetchError;
+        }
+
+        return $this->shouldFetch;
+    }
+
+    public function onFlagDefinitionsReceived(array $data): void
+    {
+        $this->onReceivedCallCount++;
+        if ($this->onReceivedError !== null) {
+            throw $this->onReceivedError;
+        }
+
+        $this->storedData = $data;
+    }
+
+    public function shutdown(): void
+    {
+        $this->shutdownCallCount++;
+        if ($this->shutdownError !== null) {
+            throw $this->shutdownError;
+        }
+    }
+}
+
+class FlagDefinitionCacheProviderTest extends TestCase
+{
+    protected const FAKE_API_KEY = "random_key";
+
+    public function setUp(): void
+    {
+        global $errorMessages;
+        $errorMessages = [];
+    }
+
+    public function testUsesCachedDataWhenProviderSaysNotToFetch(): void
+    {
+        $provider = new MockFlagDefinitionCacheProvider();
+        $provider->shouldFetch = false;
+        $provider->cachedData = $this->sampleFlagDefinitionData();
+        $httpClient = new MockedHttpClient(
+            host: "app.posthog.com",
+            flagEndpointResponse: MockedResponses::LOCAL_EVALUATION_REQUEST
+        );
+
+        $client = $this->createClient($provider, $httpClient);
+
+        $this->assertSame(1, $provider->shouldFetchCallCount);
+        $this->assertSame(1, $provider->getCallCount);
+        $this->assertSame(0, $provider->onReceivedCallCount);
+        $this->assertSame([], $httpClient->calls ?? []);
+        $this->assertSame('beta-ui', $client->featureFlags[0]['key']);
+        $this->assertSame(['0' => 'company'], $client->groupTypeMapping);
+        $this->assertSame(['1' => ['type' => 'AND', 'values' => []]], $client->cohorts);
+        $this->assertArrayHasKey('beta-ui', $client->featureFlagsByKey);
+    }
+
+    public function testStoresDefinitionsAfterProviderAllowsApiFetch(): void
+    {
+        $provider = new MockFlagDefinitionCacheProvider();
+        $provider->shouldFetch = true;
+        $httpClient = new MockedHttpClient(
+            host: "app.posthog.com",
+            flagEndpointResponse: $this->sampleFlagDefinitionData()
+        );
+
+        $client = $this->createClient($provider, $httpClient);
+
+        $this->assertSame(1, $provider->shouldFetchCallCount);
+        $this->assertSame(0, $provider->getCallCount);
+        $this->assertSame(1, $provider->onReceivedCallCount);
+        $this->assertCount(1, $httpClient->calls);
+        $this->assertSame('beta-ui', $client->featureFlags[0]['key']);
+        $this->assertSame('beta-ui', $provider->storedData['flags'][0]['key']);
+        $this->assertSame(['0' => 'company'], $provider->storedData['group_type_mapping']);
+        $this->assertSame(['1' => ['type' => 'AND', 'values' => []]], $provider->storedData['cohorts']);
+    }
+
+    public function testEmptyCacheFallsBackToApiWhenNoDefinitionsLoaded(): void
+    {
+        $provider = new MockFlagDefinitionCacheProvider();
+        $provider->shouldFetch = false;
+        $provider->cachedData = null;
+        $httpClient = new MockedHttpClient(
+            host: "app.posthog.com",
+            flagEndpointResponse: $this->sampleFlagDefinitionData()
+        );
+
+        $client = $this->createClient($provider, $httpClient);
+
+        $this->assertSame(1, $provider->getCallCount);
+        $this->assertSame(1, $provider->onReceivedCallCount);
+        $this->assertCount(1, $httpClient->calls);
+        $this->assertSame('beta-ui', $client->featureFlags[0]['key']);
+    }
+
+    public function testProviderReadFailurePreservesPreviouslyLoadedDefinitions(): void
+    {
+        $provider = new MockFlagDefinitionCacheProvider();
+        $provider->shouldFetch = true;
+        $httpClient = new MockedHttpClient(
+            host: "app.posthog.com",
+            flagEndpointResponse: $this->sampleFlagDefinitionData()
+        );
+        $client = $this->createClient($provider, $httpClient);
+        $this->assertSame('beta-ui', $client->featureFlags[0]['key']);
+
+        $provider->shouldFetch = false;
+        $provider->getError = new \RuntimeException('Redis read failed');
+        $client->loadFlags();
+
+        $this->assertSame(2, $provider->shouldFetchCallCount);
+        $this->assertSame(1, $provider->getCallCount);
+        $this->assertCount(1, $httpClient->calls);
+        $this->assertSame('beta-ui', $client->featureFlags[0]['key']);
+        $this->assertWarningContains('Cache provider read error: Redis read failed');
+    }
+
+    public function testProviderFetchDecisionFailureFailsSafeToDirectFetch(): void
+    {
+        $provider = new MockFlagDefinitionCacheProvider();
+        $provider->shouldFetchError = new \RuntimeException('Lock acquisition failed');
+        $httpClient = new MockedHttpClient(
+            host: "app.posthog.com",
+            flagEndpointResponse: $this->sampleFlagDefinitionData()
+        );
+
+        $client = $this->createClient($provider, $httpClient);
+
+        $this->assertCount(1, $httpClient->calls);
+        $this->assertSame('beta-ui', $client->featureFlags[0]['key']);
+        $this->assertSame(1, $provider->onReceivedCallCount);
+        $this->assertWarningContains('Cache provider fetch-decision error: Lock acquisition failed');
+    }
+
+    public function testProviderStoreFailureKeepsFetchedDefinitionsUsable(): void
+    {
+        $provider = new MockFlagDefinitionCacheProvider();
+        $provider->shouldFetch = true;
+        $provider->onReceivedError = new \RuntimeException('Redis write failed');
+        $httpClient = new MockedHttpClient(
+            host: "app.posthog.com",
+            flagEndpointResponse: $this->sampleFlagDefinitionData()
+        );
+
+        $client = $this->createClient($provider, $httpClient);
+
+        $this->assertSame('beta-ui', $client->featureFlags[0]['key']);
+        $this->assertSame(1, $provider->onReceivedCallCount);
+        $this->assertWarningContains('Cache provider store error: Redis write failed');
+    }
+
+    public function testProviderShutdownIsInvokedAndIsolatedFromSdkShutdown(): void
+    {
+        $provider = new MockFlagDefinitionCacheProvider();
+        $provider->shutdownError = new \RuntimeException('Redis close failed');
+        $httpClient = new MockedHttpClient(
+            host: "app.posthog.com",
+            flagEndpointResponse: $this->sampleFlagDefinitionData()
+        );
+        $client = $this->createClient($provider, $httpClient);
+
+        $this->assertTrue($client->shutdown());
+
+        $this->assertSame(1, $provider->shutdownCallCount);
+        $this->assertWarningContains('Cache provider shutdown error: Redis close failed');
+    }
+
+    public function testMalformedProviderCacheDataDoesNotClearExistingDefinitions(): void
+    {
+        $provider = new MockFlagDefinitionCacheProvider();
+        $provider->shouldFetch = true;
+        $httpClient = new MockedHttpClient(
+            host: "app.posthog.com",
+            flagEndpointResponse: $this->sampleFlagDefinitionData()
+        );
+        $client = $this->createClient($provider, $httpClient);
+
+        $provider->shouldFetch = false;
+        $provider->cachedData = ['flags' => 'not an array'];
+        $client->loadFlags();
+
+        $this->assertSame('beta-ui', $client->featureFlags[0]['key']);
+        $this->assertCount(1, $httpClient->calls);
+        $this->assertWarningContains('Cache provider returned malformed flag definitions');
+    }
+
+    public function testCamelCaseGroupTypeMappingIsAcceptedFromCache(): void
+    {
+        $provider = new MockFlagDefinitionCacheProvider();
+        $provider->shouldFetch = false;
+        $provider->cachedData = [
+            'flags' => [['key' => 'camel-flag', 'active' => true, 'filters' => []]],
+            'groupTypeMapping' => ['0' => 'organization'],
+            'cohorts' => [],
+        ];
+        $httpClient = new MockedHttpClient(host: "app.posthog.com");
+
+        $client = $this->createClient($provider, $httpClient);
+
+        $this->assertSame('camel-flag', $client->featureFlags[0]['key']);
+        $this->assertSame(['0' => 'organization'], $client->groupTypeMapping);
+        $this->assertSame([], $httpClient->calls ?? []);
+    }
+
+    public function testInvalidProviderOptionThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('flag_definition_cache_provider must implement');
+
+        new Client(
+            self::FAKE_API_KEY,
+            ['flag_definition_cache_provider' => new \stdClass()],
+            new MockedHttpClient(host: "app.posthog.com"),
+            "test",
+            false
+        );
+    }
+
+    private function createClient(MockFlagDefinitionCacheProvider $provider, MockedHttpClient $httpClient): Client
+    {
+        return new Client(
+            self::FAKE_API_KEY,
+            ['flag_definition_cache_provider' => $provider],
+            $httpClient,
+            "test"
+        );
+    }
+
+    private function sampleFlagDefinitionData(): array
+    {
+        return [
+            'flags' => [
+                [
+                    'id' => 1,
+                    'key' => 'beta-ui',
+                    'active' => true,
+                    'filters' => [
+                        'groups' => [
+                            [
+                                'properties' => [],
+                                'rollout_percentage' => 100,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'group_type_mapping' => ['0' => 'company'],
+            'cohorts' => ['1' => ['type' => 'AND', 'values' => []]],
+        ];
+    }
+
+    private function assertWarningContains(string $expected): void
+    {
+        global $errorMessages;
+        $matched = false;
+        foreach ($errorMessages as $message) {
+            if (str_contains($message, $expected)) {
+                $matched = true;
+                break;
+            }
+        }
+
+        $this->assertTrue($matched, "Expected warning containing '{$expected}', got: " . implode("\n", $errorMessages));
+    }
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

Implements the flag definition loader spec requirement for external flag definition cache providers in the PHP SDK, so distributed/stateless PHP SDK instances can share local-evaluation flag definitions instead of every instance fetching directly from PostHog.

Related to #161

## :green_heart: How did you test it?

- `vendor/bin/phpunit --no-coverage --colors=never test/FlagDefinitionCacheProviderTest.php test/EtagSupportTest.php`
- `vendor/bin/phpcs --standard=phpcs.xml lib/Client.php lib/PostHog.php lib/FlagDefinitionCacheProvider.php test/FlagDefinitionCacheProviderTest.php`
- `composer api:check`
- `vendor/bin/phpunit --no-coverage --colors=never test/` (passes with existing warnings/deprecations)

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
