### PR TITLE
feat: Add configurable flush interval

### DIFF
--- a/.changeset/brave-otters-flush.md
+++ b/.changeset/brave-otters-flush.md
@@ -1,0 +1,5 @@
+---
+"posthog/posthog-php": minor
+---
+
+Add configurable flush interval support for queued event batching.

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -107,10 +107,15 @@ class Client implements FeatureFlagEvaluationsHost
      *
      * @param string|null $apiKey Your project API key. When omitted or empty, the client is disabled
      *     and uses the noop consumer.
+     * Time-based options use milliseconds unless the option name says otherwise:
+     * `timeout` and `maximum_backoff_duration` are in milliseconds for libcurl/HTTP requests,
+     * while `flush_interval_seconds` is in seconds. For the socket consumer, `timeout` is passed
+     * to pfsockopen() and is in seconds.
+     *
      * @param array{
      *     host?: string,
      *     ssl?: bool,
-     *     timeout?: int,
+     *     timeout?: int|float,
      *     verify_batch_events_request?: bool,
      *     feature_flag_request_timeout_ms?: int,
      *     maximum_backoff_duration?: int,

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -118,6 +118,7 @@ class Client implements FeatureFlagEvaluationsHost
      *     debug?: bool,
      *     max_queue_size?: int,
      *     batch_size?: int,
+     *     flush_interval_seconds?: int|float,
      *     compress_request?: bool|string,
      *     error_handler?: callable,
      *     filename?: string,

--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -24,10 +24,15 @@ class PostHog
      * host option is omitted, POSTHOG_HOST is used when present.
      *
      * @param string|null $apiKey Your project API key.
+     * Time-based options use milliseconds unless the option name says otherwise:
+     * `timeout` and `maximum_backoff_duration` are in milliseconds for libcurl/HTTP requests,
+     * while `flush_interval_seconds` is in seconds. For the socket consumer, `timeout` is passed
+     * to pfsockopen() and is in seconds.
+     *
      * @param array{
      *     host?: string,
      *     ssl?: bool,
-     *     timeout?: int,
+     *     timeout?: int|float,
      *     verify_batch_events_request?: bool,
      *     feature_flag_request_timeout_ms?: int,
      *     maximum_backoff_duration?: int,

--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -34,6 +34,7 @@ class PostHog
      *     debug?: bool,
      *     max_queue_size?: int,
      *     batch_size?: int,
+     *     flush_interval_seconds?: int|float,
      *     compress_request?: bool|string,
      *     error_handler?: callable,
      *     filename?: string,

--- a/lib/QueueConsumer.php
+++ b/lib/QueueConsumer.php
@@ -2,8 +2,14 @@
 
 namespace PostHog;
 
+use Symfony\Component\Clock\Clock;
+
 /**
  * Base class for consumers that batch messages before delivery.
+ *
+ * PHP has no portable in-process background timer, so flush_interval_seconds is enforced
+ * opportunistically when another message is enqueued. Explicit flushes and
+ * destruction still drain pending messages immediately.
  *
  * @internal
  */
@@ -17,6 +23,8 @@ abstract class QueueConsumer extends Consumer
     protected $queue;
     protected $max_queue_size = 1000;
     protected $batch_size = 100;
+    protected $flush_interval = 5.0;
+    protected $flush_after = null;
     protected $maximum_backoff_duration = 10000;    // Set maximum waiting limit to 10s
     protected $host = "us.i.posthog.com";
     protected $compress_request = false;
@@ -24,7 +32,7 @@ abstract class QueueConsumer extends Consumer
     /**
      * Store our api key and options as part of this consumer
      * @param string $apiKey
-     * @param array $options
+     * @param array $options Consumer options.
      */
     public function __construct($apiKey, $options = array())
     {
@@ -36,6 +44,16 @@ abstract class QueueConsumer extends Consumer
 
         if (isset($options["batch_size"])) {
             $this->batch_size = $options["batch_size"];
+        }
+
+        if (isset($options["flush_interval_seconds"])) {
+            $flushInterval = $options["flush_interval_seconds"];
+            if (is_int($flushInterval) || is_float($flushInterval)) {
+                $flushInterval = (float) $flushInterval;
+                if ($flushInterval >= 0) {
+                    $this->flush_interval = $flushInterval;
+                }
+            }
         }
 
         if (isset($options["maximum_backoff_duration"])) {
@@ -117,6 +135,8 @@ abstract class QueueConsumer extends Consumer
             $count = count($this->queue);
         }
 
+        $this->resetFlushTimer();
+
         return $success;
     }
 
@@ -133,13 +153,35 @@ abstract class QueueConsumer extends Consumer
             return false;
         }
 
+        $wasEmpty = $count === 0;
         $count = array_push($this->queue, $item);
 
-        if ($count >= $this->batch_size) {
+        if ($wasEmpty) {
+            $this->resetFlushTimer();
+        }
+
+        if ($this->flush_interval === 0.0 || $count >= $this->batch_size || $this->flushIntervalElapsed()) {
             return $this->flush(); // return ->flush() result: true on success
         }
 
         return true;
+    }
+
+    private function resetFlushTimer(): void
+    {
+        $this->flush_after = count($this->queue) > 0 && $this->flush_interval > 0
+            ? $this->now() + $this->flush_interval
+            : null;
+    }
+
+    private function flushIntervalElapsed(): bool
+    {
+        return $this->flush_after !== null && $this->now() >= $this->flush_after;
+    }
+
+    private function now(): float
+    {
+        return (float) Clock::get()->now()->format('U.u');
     }
 
     /**

--- a/lib/QueueConsumer.php
+++ b/lib/QueueConsumer.php
@@ -50,7 +50,7 @@ abstract class QueueConsumer extends Consumer
             $flushInterval = $options["flush_interval_seconds"];
             if (is_int($flushInterval) || is_float($flushInterval)) {
                 $flushInterval = (float) $flushInterval;
-                if ($flushInterval >= 0) {
+                if (is_finite($flushInterval) && $flushInterval >= 0) {
                     $this->flush_interval = $flushInterval;
                 }
             }

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -626,6 +626,43 @@ class PostHogTest extends TestCase
         }
     }
 
+    public function testNonFiniteCaptureFlushIntervalDefaultsToFiveSeconds(): void
+    {
+        $mockClock = new MockClock(new \DateTimeImmutable('2022-05-01 00:00:00'));
+        Clock::set($mockClock);
+
+        try {
+            $httpClient = new MockedHttpClient("app.posthog.com");
+            $client = new Client(
+                self::FAKE_API_KEY,
+                [
+                    "debug" => true,
+                    "batch_size" => 100,
+                    "flush_interval_seconds" => INF,
+                ],
+                $httpClient,
+                null,
+                false
+            );
+
+            $this->assertTrue($client->capture(["distinctId" => "john", "event" => "one"]));
+            $mockClock->sleep(4);
+            $this->assertTrue($client->capture(["distinctId" => "john", "event" => "two"]));
+            $this->assertSame([], $httpClient->calls ?? []);
+
+            $mockClock->sleep(1);
+            $this->assertTrue($client->capture(["distinctId" => "john", "event" => "three"]));
+
+            $batchCalls = array_values(array_filter(
+                $httpClient->calls ?? [],
+                static fn(array $call): bool => ($call["path"] ?? null) === "/batch/"
+            ));
+            $this->assertCount(1, $batchCalls);
+        } finally {
+            Clock::set(new NativeClock());
+        }
+    }
+
     public function testCaptureIncludesIsServerProperty(): void
     {
         self::assertTrue(

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -11,6 +11,9 @@ use PostHog\Client;
 use PostHog\Consumer\NoOp;
 use PostHog\PostHog;
 use PostHog\Test\Assets\MockedResponses;
+use Symfony\Component\Clock\Clock;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\Clock\NativeClock;
 
 
 class PostHogTest extends TestCase
@@ -446,6 +449,181 @@ class PostHogTest extends TestCase
                 )
             )
         );
+    }
+
+    public function testCaptureFlushesOnNextEnqueueAfterDefaultFlushInterval(): void
+    {
+        $mockClock = new MockClock(new \DateTimeImmutable('2022-05-01 00:00:00'));
+        Clock::set($mockClock);
+
+        try {
+            $httpClient = new MockedHttpClient("app.posthog.com");
+            $client = new Client(
+                self::FAKE_API_KEY,
+                [
+                    "debug" => true,
+                    "batch_size" => 100,
+                ],
+                $httpClient,
+                null,
+                false
+            );
+
+            $this->assertTrue($client->capture(["distinctId" => "john", "event" => "one"]));
+            $this->assertSame([], $httpClient->calls ?? []);
+
+            $mockClock->sleep(4);
+            $this->assertTrue($client->capture(["distinctId" => "john", "event" => "two"]));
+            $this->assertSame([], $httpClient->calls ?? []);
+
+            $mockClock->sleep(1);
+            $this->assertTrue($client->capture(["distinctId" => "john", "event" => "three"]));
+
+            $batchCalls = array_values(array_filter(
+                $httpClient->calls ?? [],
+                static fn(array $call): bool => ($call["path"] ?? null) === "/batch/"
+            ));
+            $this->assertCount(1, $batchCalls);
+
+            $payload = json_decode($batchCalls[0]["payload"], true);
+            $this->assertSame(["one", "two", "three"], array_column($payload["batch"], "event"));
+        } finally {
+            Clock::set(new NativeClock());
+        }
+    }
+
+    public function testCaptureFlushIntervalCanBeConfiguredInSeconds(): void
+    {
+        $mockClock = new MockClock(new \DateTimeImmutable('2022-05-01 00:00:00'));
+        Clock::set($mockClock);
+
+        try {
+            $httpClient = new MockedHttpClient("app.posthog.com");
+            $client = new Client(
+                self::FAKE_API_KEY,
+                [
+                    "debug" => true,
+                    "batch_size" => 100,
+                    "flush_interval_seconds" => 1,
+                ],
+                $httpClient,
+                null,
+                false
+            );
+
+            $this->assertTrue($client->capture(["distinctId" => "john", "event" => "one"]));
+            $mockClock->sleep(1);
+            $this->assertTrue($client->capture(["distinctId" => "john", "event" => "two"]));
+
+            $batchCalls = array_values(array_filter(
+                $httpClient->calls ?? [],
+                static fn(array $call): bool => ($call["path"] ?? null) === "/batch/"
+            ));
+            $this->assertCount(1, $batchCalls);
+        } finally {
+            Clock::set(new NativeClock());
+        }
+    }
+
+    public function testCaptureFlushIntervalZeroFlushesImmediately(): void
+    {
+        $httpClient = new MockedHttpClient("app.posthog.com");
+        $client = new Client(
+            self::FAKE_API_KEY,
+            [
+                "debug" => true,
+                "batch_size" => 100,
+                "flush_interval_seconds" => 0,
+            ],
+            $httpClient,
+            null,
+            false
+        );
+
+        $this->assertTrue($client->capture(["distinctId" => "john", "event" => "one"]));
+
+        $batchCalls = array_values(array_filter(
+            $httpClient->calls ?? [],
+            static fn(array $call): bool => ($call["path"] ?? null) === "/batch/"
+        ));
+        $this->assertCount(1, $batchCalls);
+
+        $payload = json_decode($batchCalls[0]["payload"], true);
+        $this->assertSame(["one"], array_column($payload["batch"], "event"));
+    }
+
+    public function testNegativeCaptureFlushIntervalDefaultsToFiveSeconds(): void
+    {
+        $mockClock = new MockClock(new \DateTimeImmutable('2022-05-01 00:00:00'));
+        Clock::set($mockClock);
+
+        try {
+            $httpClient = new MockedHttpClient("app.posthog.com");
+            $client = new Client(
+                self::FAKE_API_KEY,
+                [
+                    "debug" => true,
+                    "batch_size" => 100,
+                    "flush_interval_seconds" => -1,
+                ],
+                $httpClient,
+                null,
+                false
+            );
+
+            $this->assertTrue($client->capture(["distinctId" => "john", "event" => "one"]));
+            $mockClock->sleep(4);
+            $this->assertTrue($client->capture(["distinctId" => "john", "event" => "two"]));
+            $this->assertSame([], $httpClient->calls ?? []);
+
+            $mockClock->sleep(1);
+            $this->assertTrue($client->capture(["distinctId" => "john", "event" => "three"]));
+
+            $batchCalls = array_values(array_filter(
+                $httpClient->calls ?? [],
+                static fn(array $call): bool => ($call["path"] ?? null) === "/batch/"
+            ));
+            $this->assertCount(1, $batchCalls);
+        } finally {
+            Clock::set(new NativeClock());
+        }
+    }
+
+    public function testInvalidCaptureFlushIntervalDefaultsToFiveSeconds(): void
+    {
+        $mockClock = new MockClock(new \DateTimeImmutable('2022-05-01 00:00:00'));
+        Clock::set($mockClock);
+
+        try {
+            $httpClient = new MockedHttpClient("app.posthog.com");
+            $client = new Client(
+                self::FAKE_API_KEY,
+                [
+                    "debug" => true,
+                    "batch_size" => 100,
+                    "flush_interval_seconds" => "1",
+                ],
+                $httpClient,
+                null,
+                false
+            );
+
+            $this->assertTrue($client->capture(["distinctId" => "john", "event" => "one"]));
+            $mockClock->sleep(4);
+            $this->assertTrue($client->capture(["distinctId" => "john", "event" => "two"]));
+            $this->assertSame([], $httpClient->calls ?? []);
+
+            $mockClock->sleep(1);
+            $this->assertTrue($client->capture(["distinctId" => "john", "event" => "three"]));
+
+            $batchCalls = array_values(array_filter(
+                $httpClient->calls ?? [],
+                static fn(array $call): bool => ($call["path"] ?? null) === "/batch/"
+            ));
+            $this->assertCount(1, $batchCalls);
+        } finally {
+            Clock::set(new NativeClock());
+        }
     }
 
     public function testCaptureIncludesIsServerProperty(): void

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -552,44 +552,19 @@ class PostHogTest extends TestCase
         $this->assertSame(["one"], array_column($payload["batch"], "event"));
     }
 
-    public function testNegativeCaptureFlushIntervalDefaultsToFiveSeconds(): void
+    public static function invalidCaptureFlushIntervalCases(): array
     {
-        $mockClock = new MockClock(new \DateTimeImmutable('2022-05-01 00:00:00'));
-        Clock::set($mockClock);
-
-        try {
-            $httpClient = new MockedHttpClient("app.posthog.com");
-            $client = new Client(
-                self::FAKE_API_KEY,
-                [
-                    "debug" => true,
-                    "batch_size" => 100,
-                    "flush_interval_seconds" => -1,
-                ],
-                $httpClient,
-                null,
-                false
-            );
-
-            $this->assertTrue($client->capture(["distinctId" => "john", "event" => "one"]));
-            $mockClock->sleep(4);
-            $this->assertTrue($client->capture(["distinctId" => "john", "event" => "two"]));
-            $this->assertSame([], $httpClient->calls ?? []);
-
-            $mockClock->sleep(1);
-            $this->assertTrue($client->capture(["distinctId" => "john", "event" => "three"]));
-
-            $batchCalls = array_values(array_filter(
-                $httpClient->calls ?? [],
-                static fn(array $call): bool => ($call["path"] ?? null) === "/batch/"
-            ));
-            $this->assertCount(1, $batchCalls);
-        } finally {
-            Clock::set(new NativeClock());
-        }
+        return [
+            'negative interval' => [-1],
+            'numeric string interval' => ['1'],
+            'non-finite interval' => [INF],
+        ];
     }
 
-    public function testInvalidCaptureFlushIntervalDefaultsToFiveSeconds(): void
+    /**
+     * @dataProvider invalidCaptureFlushIntervalCases
+     */
+    public function testInvalidCaptureFlushIntervalDefaultsToFiveSeconds(mixed $flushInterval): void
     {
         $mockClock = new MockClock(new \DateTimeImmutable('2022-05-01 00:00:00'));
         Clock::set($mockClock);
@@ -601,44 +576,7 @@ class PostHogTest extends TestCase
                 [
                     "debug" => true,
                     "batch_size" => 100,
-                    "flush_interval_seconds" => "1",
-                ],
-                $httpClient,
-                null,
-                false
-            );
-
-            $this->assertTrue($client->capture(["distinctId" => "john", "event" => "one"]));
-            $mockClock->sleep(4);
-            $this->assertTrue($client->capture(["distinctId" => "john", "event" => "two"]));
-            $this->assertSame([], $httpClient->calls ?? []);
-
-            $mockClock->sleep(1);
-            $this->assertTrue($client->capture(["distinctId" => "john", "event" => "three"]));
-
-            $batchCalls = array_values(array_filter(
-                $httpClient->calls ?? [],
-                static fn(array $call): bool => ($call["path"] ?? null) === "/batch/"
-            ));
-            $this->assertCount(1, $batchCalls);
-        } finally {
-            Clock::set(new NativeClock());
-        }
-    }
-
-    public function testNonFiniteCaptureFlushIntervalDefaultsToFiveSeconds(): void
-    {
-        $mockClock = new MockClock(new \DateTimeImmutable('2022-05-01 00:00:00'));
-        Clock::set($mockClock);
-
-        try {
-            $httpClient = new MockedHttpClient("app.posthog.com");
-            $client = new Client(
-                self::FAKE_API_KEY,
-                [
-                    "debug" => true,
-                    "batch_size" => 100,
-                    "flush_interval_seconds" => INF,
+                    "flush_interval_seconds" => $flushInterval,
                 ],
                 $httpClient,
                 null,


### PR DESCRIPTION
## :bulb: Motivation and Context

PHP batching previously flushed queued events only when `batch_size` was reached, via explicit `flush()`, or during cleanup. This adds a configurable flush interval mechanism for low-volume queues while accounting for PHP's lack of a portable in-process background timer.

## :green_heart: How did you test it?

- `php -l lib/QueueConsumer.php && php -l lib/Client.php && php -l lib/PostHog.php && php -l test/PostHogTest.php`
- `./vendor/bin/phpunit test/PostHogTest.php --filter 'FlushInterval|testInvalidCaptureFlushIntervalDefaultsToFiveSeconds' --no-coverage`
- `php scripts/check-public-api.php`
- `git diff --check`
- `! rg -n 'flush_interval_ms|"flush_interval"|flush_interval\?:' lib test README.md composer.json`
- `./vendor/bin/phpunit --no-coverage` — passes with existing warnings/deprecations

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi coding agent assistance. The change keeps the public API minimal with only `flush_interval_seconds`, defaults to 5 seconds, treats invalid, negative, or non-finite values as the default, flushes immediately when set to `0`, and uses opportunistic interval flushing on the next enqueue because PHP does not provide a portable request-local background timer. Follow-up review feedback clarified the existing `timeout` and `maximum_backoff_duration` units in PHPDoc without renaming those options.
