### PR TITLE
fix: support groups key for capture events

### DIFF
--- a/.changeset/great-groups-capture.md
+++ b/.changeset/great-groups-capture.md
@@ -1,0 +1,5 @@
+---
+"posthog-php": patch
+---
+
+Copy capture `groups` input to the `$groups` event property so grouped events are associated correctly.

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -216,6 +216,7 @@ class Client implements FeatureFlagEvaluationsHost
     {
         $flagsSnapshot = $message["flags"] ?? null;
         unset($message["flags"]);
+        $hasGroups = array_key_exists("groups", $message);
 
         $usedGeneratedPersonlessDistinctId = false;
         if ($this->shouldApplyCaptureContext($message)) {
@@ -223,6 +224,10 @@ class Client implements FeatureFlagEvaluationsHost
         }
         $message = $this->message($message);
         $message["type"] = "capture";
+
+        if (!array_key_exists('$groups', $message) && $hasGroups) {
+            $message['$groups'] = $message['groups'];
+        }
 
         if (array_key_exists('$groups', $message)) {
             $message["properties"]['$groups'] = $message['$groups'];

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -105,6 +105,14 @@ class PostHogTest extends TestCase
         ];
     }
 
+    public static function captureGroupsCases(): array
+    {
+        return [
+            'groups key' => ["groups"],
+            '$groups key' => ['$groups'],
+        ];
+    }
+
     public static function disabledClientNoRequestCases(): array
     {
         return [
@@ -460,33 +468,17 @@ class PostHogTest extends TestCase
         );
     }
 
-    public function testCaptureCopiesGroupsKeyToDollarGroupsProperty(): void
+    /**
+     * @dataProvider captureGroupsCases
+     */
+    public function testCaptureAddsGroupsProperty(string $groupsKey): void
     {
         self::assertTrue(
             PostHog::capture(
                 array(
                     "distinctId" => "john",
                     "event" => "grouped event",
-                    "groups" => array("team" => 1),
-                )
-            )
-        );
-        PostHog::flush();
-
-        $event = $this->firstBatchEvent();
-
-        self::assertSame(array("team" => 1), $event["properties"]['$groups']);
-        self::assertSame(array("team" => 1), $event["groups"]);
-    }
-
-    public function testCaptureKeepsDollarGroupsCompatibility(): void
-    {
-        self::assertTrue(
-            PostHog::capture(
-                array(
-                    "distinctId" => "john",
-                    "event" => "grouped event",
-                    '$groups' => array("team" => 1),
+                    $groupsKey => array("team" => 1),
                 )
             )
         );

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -55,6 +55,18 @@ class PostHogTest extends TestCase
         return $consumerProp->getValue($client);
     }
 
+    private function firstBatchEvent(): array
+    {
+        foreach ($this->http_client->calls as $call) {
+            if (($call["path"] ?? null) === "/batch/") {
+                $decoded = json_decode($call["payload"], true);
+                return $decoded["batch"][0];
+            }
+        }
+
+        self::fail("Expected a /batch/ call to have been made");
+    }
+
     private function withEnvApiKey(?string $apiKey, callable $callback): void
     {
         $previousApiKey = getenv(PostHog::ENV_API_KEY);
@@ -446,6 +458,43 @@ class PostHogTest extends TestCase
                 )
             )
         );
+    }
+
+    public function testCaptureCopiesGroupsKeyToDollarGroupsProperty(): void
+    {
+        self::assertTrue(
+            PostHog::capture(
+                array(
+                    "distinctId" => "john",
+                    "event" => "grouped event",
+                    "groups" => array("team" => 1),
+                )
+            )
+        );
+        PostHog::flush();
+
+        $event = $this->firstBatchEvent();
+
+        self::assertSame(array("team" => 1), $event["properties"]['$groups']);
+        self::assertSame(array("team" => 1), $event["groups"]);
+    }
+
+    public function testCaptureKeepsDollarGroupsCompatibility(): void
+    {
+        self::assertTrue(
+            PostHog::capture(
+                array(
+                    "distinctId" => "john",
+                    "event" => "grouped event",
+                    '$groups' => array("team" => 1),
+                )
+            )
+        );
+        PostHog::flush();
+
+        $event = $this->firstBatchEvent();
+
+        self::assertSame(array("team" => 1), $event["properties"]['$groups']);
     }
 
     public function testCaptureIncludesIsServerProperty(): void


### PR DESCRIPTION
## :bulb: Motivation and Context

Fixes https://github.com/PostHog/posthog-php/issues/71.

`capture()` documents and examples have allowed passing group context with the `groups` key, but PostHog ingestion associates events with groups via the `$groups` event property. This PR preserves backwards compatibility by promoting an explicitly supplied `groups` key to `$groups` before enqueueing the capture event, while keeping existing `$groups` behavior unchanged.

## :green_heart: How did you test it?

- `./vendor/bin/phpunit --no-coverage test/PostHogTest.php --filter '/testCaptureCopiesGroupsKeyToDollarGroupsProperty|testCaptureKeepsDollarGroupsCompatibility/'`
- `./vendor/bin/phpunit --no-coverage`
- `composer api:check`
- `./vendor/bin/phpcs --standard=phpcs.xml --warning-severity=0 lib/Client.php test/PostHogTest.php`
- `git diff --check`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This PR was implemented with the pi coding agent. We investigated the PostHog ingestion path and confirmed that event grouping is read from `properties.$groups`; top-level `groups` is not consumed by backend event ingestion. The chosen fix keeps the existing public `groups` capture input working by promoting it to `$groups`, without changing feature flag `groups` behavior or removing existing `$groups` compatibility.
