### PR TITLE
fix: validate batch size option

### DIFF
--- a/.changeset/quiet-lions-batch.md
+++ b/.changeset/quiet-lions-batch.md
@@ -1,0 +1,5 @@
+---
+'posthog-php': patch
+---
+
+Keep the default batch size when invalid non-positive values are configured.

--- a/lib/QueueConsumer.php
+++ b/lib/QueueConsumer.php
@@ -34,8 +34,8 @@ abstract class QueueConsumer extends Consumer
             $this->max_queue_size = $options["max_queue_size"];
         }
 
-        if (isset($options["batch_size"])) {
-            $this->batch_size = $options["batch_size"];
+        if (isset($options["batch_size"]) && (int) $options["batch_size"] > 0) {
+            $this->batch_size = (int) $options["batch_size"];
         }
 
         if (isset($options["maximum_backoff_duration"])) {

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -101,11 +101,12 @@ class PostHogTest extends TestCase
         ];
     }
 
-    public static function invalidBatchSizeCases(): array
+    public static function queuedBatchSizeCases(): array
     {
         return [
-            'zero' => [0],
-            'negative' => [-1],
+            'default' => [["debug" => true]],
+            'zero' => [["debug" => true, "batch_size" => 0]],
+            'negative' => [["debug" => true, "batch_size" => -1]],
         ];
     }
 
@@ -376,10 +377,13 @@ class PostHogTest extends TestCase
         $this->assertSame([], $httpClient->calls ?? []);
     }
 
-    public function testLowVolumeCapturesStayQueuedUntilFlush(): void
+    /**
+     * @dataProvider queuedBatchSizeCases
+     */
+    public function testCapturesStayQueuedUntilFlush(array $options): void
     {
         $httpClient = new MockedHttpClient("app.posthog.com");
-        $client = new Client(self::FAKE_API_KEY, ["debug" => true], $httpClient, null, false);
+        $client = new Client(self::FAKE_API_KEY, $options, $httpClient, null, false);
 
         $this->assertTrue($client->capture([
             "distinctId" => "john",
@@ -411,30 +415,6 @@ class PostHogTest extends TestCase
         $this->assertSame('/batch/', $httpClient->calls[0]['path']);
     }
 
-    /**
-     * @dataProvider invalidBatchSizeCases
-     */
-    public function testInvalidBatchSizeUsesDefault(int $batchSize): void
-    {
-        $httpClient = new MockedHttpClient("app.posthog.com");
-        $client = new Client(
-            self::FAKE_API_KEY,
-            ["debug" => true, "batch_size" => $batchSize],
-            $httpClient,
-            null,
-            false
-        );
-
-        $this->assertTrue($client->capture([
-            "distinctId" => "john",
-            "event" => "Module PHP Event",
-        ]));
-        $this->assertSame(0, count($httpClient->calls ?? []));
-
-        $this->assertTrue($client->flush());
-        $this->assertSame(1, count($httpClient->calls ?? []));
-        $this->assertSame('/batch/', $httpClient->calls[0]['path']);
-    }
 
     /**
      * @dataProvider facadeNoOpBeforeInitCases

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -101,6 +101,14 @@ class PostHogTest extends TestCase
         ];
     }
 
+    public static function invalidBatchSizeCases(): array
+    {
+        return [
+            'zero' => [0],
+            'negative' => [-1],
+        ];
+    }
+
     public static function facadeNoOpBeforeInitCases(): array
     {
         return [
@@ -366,6 +374,66 @@ class PostHogTest extends TestCase
         ]));
         $this->assertSame([], $client->{$flagsMethod}("john"));
         $this->assertSame([], $httpClient->calls ?? []);
+    }
+
+    public function testLowVolumeCapturesStayQueuedUntilFlush(): void
+    {
+        $httpClient = new MockedHttpClient("app.posthog.com");
+        $client = new Client(self::FAKE_API_KEY, ["debug" => true], $httpClient, null, false);
+
+        $this->assertTrue($client->capture([
+            "distinctId" => "john",
+            "event" => "Module PHP Event",
+        ]));
+        $this->assertSame(0, count($httpClient->calls ?? []));
+
+        $this->assertTrue($client->flush());
+        $this->assertSame(1, count($httpClient->calls ?? []));
+        $this->assertSame('/batch/', $httpClient->calls[0]['path']);
+    }
+
+    public function testBatchSizeOneFlushesImmediately(): void
+    {
+        $httpClient = new MockedHttpClient("app.posthog.com");
+        $client = new Client(
+            self::FAKE_API_KEY,
+            ["debug" => true, "batch_size" => 1],
+            $httpClient,
+            null,
+            false
+        );
+
+        $this->assertTrue($client->capture([
+            "distinctId" => "john",
+            "event" => "Module PHP Event",
+        ]));
+        $this->assertSame(1, count($httpClient->calls ?? []));
+        $this->assertSame('/batch/', $httpClient->calls[0]['path']);
+    }
+
+    /**
+     * @dataProvider invalidBatchSizeCases
+     */
+    public function testInvalidBatchSizeUsesDefault(int $batchSize): void
+    {
+        $httpClient = new MockedHttpClient("app.posthog.com");
+        $client = new Client(
+            self::FAKE_API_KEY,
+            ["debug" => true, "batch_size" => $batchSize],
+            $httpClient,
+            null,
+            false
+        );
+
+        $this->assertTrue($client->capture([
+            "distinctId" => "john",
+            "event" => "Module PHP Event",
+        ]));
+        $this->assertSame(0, count($httpClient->calls ?? []));
+
+        $this->assertTrue($client->flush());
+        $this->assertSame(1, count($httpClient->calls ?? []));
+        $this->assertSame('/batch/', $httpClient->calls[0]['path']);
     }
 
     /**


### PR DESCRIPTION
## :bulb: Motivation and Context

Invalid `batch_size` values such as `0` or negative numbers could make queued consumers flush with a non-positive batch size. This hardens the option so non-positive values keep the default batch size, while documenting the intended queue behavior with parameterized tests.

## :green_heart: How did you test it?

- `./vendor/bin/phpunit --no-coverage test/PostHogTest.php --filter 'CapturesStayQueued|BatchSizeOne'`
- `./vendor/bin/phpunit --no-coverage test/PostHogTest.php`
- `./vendor/bin/phpunit --no-coverage`
- `git diff --check`
- `./vendor/bin/phpcs lib/QueueConsumer.php`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi coding agent assistance. The change keeps the queue consumer behavior minimal: valid positive `batch_size` values still apply, while invalid non-positive values fall back to the existing default. Tests cover default batching, invalid non-positive `batch_size` fallback behavior, and immediate flushing with `batch_size => 1`; review feedback was addressed by parameterizing the shared queued-until-flush cases.
