### PR TITLE
fix: remove ignored batch event fields

### DIFF
--- a/.changeset/remove-ignored-batch-fields.md
+++ b/.changeset/remove-ignored-batch-fields.md
@@ -1,0 +1,5 @@
+---
+"posthog-php": patch
+---
+
+Stop sending deprecated, backend-ignored top-level batch event fields. SDK metadata now uses canonical event properties (`$lib`, `$lib_version`, `$lib_consumer`), while legacy top-level SDK metadata values remain supported as fallbacks when canonical values are absent. `type` is ignored, and `send_feature_flags` remains a deprecated capture option but is stripped from the outgoing `/batch/` payload.

--- a/api/public-api.json
+++ b/api/public-api.json
@@ -3227,6 +3227,10 @@
                     "type": "string",
                     "value": "POSTHOG_HOST"
                 },
+                "LIBRARY": {
+                    "type": "string",
+                    "value": "posthog-php"
+                },
                 "VERSION": {
                     "type": "string",
                     "value": "<version>"

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -209,7 +209,11 @@ class Client implements FeatureFlagEvaluationsHost
      *     send_feature_flags?: bool,
      *     sendFeatureFlags?: bool
      * } $message Event payload. `send_feature_flags` and `sendFeatureFlags` are deprecated; pass
-     *     a `flags` snapshot from evaluateFlags() instead.
+     *     a `flags` snapshot from evaluateFlags() instead. Deprecated top-level batch metadata is
+     *     stripped before sending: use `event` instead of `type`, `properties['$lib']` instead of
+     *     `library`, `properties['$lib_version']` instead of `library_version`, and
+     *     `properties['$lib_consumer']` instead of `library_consumer`. Legacy top-level SDK metadata
+     *     values are still used as fallbacks when the canonical property is absent; `type` is ignored.
      * @return bool Whether the capture call succeeded.
      */
     public function capture(array $message)
@@ -222,7 +226,6 @@ class Client implements FeatureFlagEvaluationsHost
             $message = $this->applyCaptureContext($message, $usedGeneratedPersonlessDistinctId);
         }
         $message = $this->message($message);
-        $message["type"] = "capture";
 
         if (array_key_exists('$groups', $message)) {
             $message["properties"]['$groups'] = $message['$groups'];
@@ -277,6 +280,7 @@ class Client implements FeatureFlagEvaluationsHost
             }
         }
 
+        unset($message["send_feature_flags"]);
 
         return $this->consumer->capture($message);
     }
@@ -335,8 +339,8 @@ class Client implements FeatureFlagEvaluationsHost
         }
 
         $message = $this->message($message);
-        $message["type"] = "identify";
         $message["event"] = '$identify';
+        unset($message["send_feature_flags"]);
 
         return $this->consumer->identify($message);
     }
@@ -1185,7 +1189,7 @@ class Client implements FeatureFlagEvaluationsHost
 
         $headers = [
             // Send user agent in the form of {library_name}/{library_version} as per RFC 7231.
-            "User-Agent: posthog-php/" . PostHog::VERSION,
+            "User-Agent: " . PostHog::LIBRARY . "/" . PostHog::VERSION,
             "Authorization: Bearer " . $this->personalAPIKey
         ];
 
@@ -1352,7 +1356,7 @@ class Client implements FeatureFlagEvaluationsHost
             json_encode($payload),
             [
                 // Send user agent in the form of {library_name}/{library_version} as per RFC 7231.
-                "User-Agent: posthog-php/" . PostHog::VERSION,
+                "User-Agent: " . PostHog::LIBRARY . "/" . PostHog::VERSION,
             ],
             [
                 "shouldRetry" => false,
@@ -1420,8 +1424,8 @@ class Client implements FeatureFlagEvaluationsHost
     public function alias(array $message)
     {
         $message = $this->message($message);
-        $message["type"] = "alias";
         $message["event"] = '$create_alias';
+        unset($message["send_feature_flags"]);
 
         $message['properties']['distinct_id'] = $message['distinct_id'];
         $message['properties']['alias'] = $message['alias'];
@@ -1651,13 +1655,29 @@ class Client implements FeatureFlagEvaluationsHost
             $msg["properties"] = array();
         }
 
-        $msg["library"] = 'posthog-php';
-        $msg["library_version"] = PostHog::VERSION;
-        $msg["library_consumer"] = $this->consumer->getConsumer();
+        $legacyLibrary = $msg["library"] ?? null;
+        $legacyLibraryVersion = $msg["library_version"] ?? null;
+        $legacyLibraryConsumer = $msg["library_consumer"] ?? null;
 
-        $msg["properties"]['$lib'] = 'posthog-php';
-        $msg["properties"]['$lib_version'] = PostHog::VERSION;
-        $msg["properties"]['$lib_consumer'] = $this->consumer->getConsumer();
+        unset($msg["type"], $msg["library"], $msg["library_version"], $msg["library_consumer"]);
+
+        if (!array_key_exists('$lib', $msg["properties"])) {
+            $msg["properties"]['$lib'] = is_scalar($legacyLibrary) && (string) $legacyLibrary !== ''
+                ? (string) $legacyLibrary
+                : PostHog::LIBRARY;
+        }
+
+        if (!array_key_exists('$lib_version', $msg["properties"])) {
+            $msg["properties"]['$lib_version'] = is_scalar($legacyLibraryVersion) && (string) $legacyLibraryVersion !== ''
+                ? (string) $legacyLibraryVersion
+                : PostHog::VERSION;
+        }
+
+        if (!array_key_exists('$lib_consumer', $msg["properties"])) {
+            $msg["properties"]['$lib_consumer'] = is_scalar($legacyLibraryConsumer) && (string) $legacyLibraryConsumer !== ''
+                ? (string) $legacyLibraryConsumer
+                : $this->consumer->getConsumer();
+        }
 
         // When running as a server SDK (the default), tag events as server-side so
         // PostHog does not attribute the host machine's device/OS to the event.

--- a/lib/Consumer/ForkCurl.php
+++ b/lib/Consumer/ForkCurl.php
@@ -86,9 +86,7 @@ class ForkCurl extends QueueConsumer
         }
 
         // Send user agent in the form of {library_name}/{library_version} as per RFC 7231.
-        $libName = $messages[0]['library'];
-        $libVersion = $messages[0]['library_version'];
-        $cmd .= " -H 'User-Agent: $libName/$libVersion'";
+        $cmd .= " -H 'User-Agent: " . $this->userAgent() . "'";
 
         if (!$this->debug()) {
             $cmd .= " > /dev/null 2>&1 &";

--- a/lib/Consumer/LibCurl.php
+++ b/lib/Consumer/LibCurl.php
@@ -78,7 +78,7 @@ class LibCurl extends QueueConsumer
             $payload,
             [
                 // Send user agent in the form of {library_name}/{library_version} as per RFC 7231.
-                "User-Agent: {$messages[0]['library']}/{$messages[0]['library_version']}",
+                "User-Agent: {$this->userAgent()}",
             ],
             [
                 'shouldVerify' => $shouldVerify,

--- a/lib/Consumer/Socket.php
+++ b/lib/Consumer/Socket.php
@@ -192,10 +192,7 @@ class Socket extends QueueConsumer
         $req .= "Accept: application/json\r\n";
 
         // Send user agent in the form of {library_name}/{library_version} as per RFC 7231.
-        $content_json = json_decode($content, true);
-        $libName = $content_json['batch'][0]['library'];
-        $libVersion = $content_json['batch'][0]['library_version'];
-        $req .= "User-Agent: $libName/$libVersion\r\n";
+        $req .= "User-Agent: " . $this->userAgent() . "\r\n";
 
         // Compress content if compress_request is true
         if ($this->compress_request) {

--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -9,6 +9,7 @@ use Exception;
  */
 class PostHog
 {
+    public const LIBRARY = 'posthog-php';
     public const VERSION = '4.6.0';
     public const ENV_API_KEY = "POSTHOG_API_KEY";
     public const ENV_HOST = "POSTHOG_HOST";
@@ -124,7 +125,11 @@ class PostHog
      *     send_feature_flags?: bool,
      *     sendFeatureFlags?: bool
      * } $message Event payload. `send_feature_flags` and `sendFeatureFlags` are deprecated; pass
-     *     a `flags` snapshot from evaluateFlags() instead.
+     *     a `flags` snapshot from evaluateFlags() instead. Deprecated top-level batch metadata is
+     *     stripped before sending: use `event` instead of `type`, `properties['$lib']` instead of
+     *     `library`, `properties['$lib_version']` instead of `library_version`, and
+     *     `properties['$lib_consumer']` instead of `library_consumer`. Legacy top-level SDK metadata
+     *     values are still used as fallbacks when the canonical property is absent; `type` is ignored.
      * @return bool Whether the capture call succeeded.
      * @throws Exception
      */
@@ -147,7 +152,6 @@ class PostHog
     public static function identify(array $message)
     {
         self::checkClient();
-        $message["type"] = "identify";
         self::validate($message, "identify");
 
         return self::$client->identify($message);

--- a/lib/QueueConsumer.php
+++ b/lib/QueueConsumer.php
@@ -156,4 +156,14 @@ abstract class QueueConsumer extends Consumer
             "api_key" => $this->apiKey,
         );
     }
+
+    /**
+     * Get the SDK user agent.
+     *
+     * @return string User agent in the form of {library_name}/{library_version}.
+     */
+    protected function userAgent(): string
+    {
+        return PostHog::LIBRARY . "/" . PostHog::VERSION;
+    }
 }

--- a/send.php
+++ b/send.php
@@ -71,7 +71,6 @@ $successful = 0;
 foreach ($lines as $line) {
   if (!trim($line)) continue;
   $payload = json_decode($line, true);
-  $type = $payload["type"];
   $ret = call_user_func_array(array("PostHog\\PostHog", "raw"), array($payload));
   if ($ret) $successful++;
   $total++;

--- a/test/ConsumerFileTest.php
+++ b/test/ConsumerFileTest.php
@@ -44,7 +44,7 @@ class ConsumerFileTest extends TestCase
                 )
             )
         );
-        $this->checkWritten("capture");
+        $this->checkWritten("File PHP Event - Microtime");
     }
 
     public function testIdentify(): void
@@ -61,7 +61,7 @@ class ConsumerFileTest extends TestCase
                 )
             )
         );
-        $this->checkWritten("identify");
+        $this->checkWritten('$identify');
     }
 
     public function testAlias(): void
@@ -75,7 +75,7 @@ class ConsumerFileTest extends TestCase
             )
         );
 
-        $this->checkWritten("alias");
+        $this->checkWritten('$create_alias');
     }
 
     public function testSend(): void
@@ -108,14 +108,15 @@ class ConsumerFileTest extends TestCase
         self::assertFalse($captured);
     }
 
-    private function checkWritten($type): void
+    private function checkWritten($event): void
     {
         exec("wc -l " . $this->filename, $output);
         $out = trim($output[0]);
         self::assertSame($out, "1 " . $this->filename);
         $str = file_get_contents($this->filename);
         $json = json_decode(trim($str));
-        self::assertSame($type, $json->type);
+        self::assertObjectNotHasProperty('type', $json);
+        self::assertSame($event, $json->event);
         unlink($this->filename);
     }
 

--- a/test/ExceptionPayloadBuilderTest.php
+++ b/test/ExceptionPayloadBuilderTest.php
@@ -513,14 +513,14 @@ PHP;
             $payload = json_encode([
                 'batch' => [[
                     'event' => '$exception',
-                    'properties' => ['$exception_list' => $exceptionList],
+                    'properties' => [
+                        '$exception_list' => $exceptionList,
+                        '$lib' => 'posthog-php',
+                        '$lib_version' => PostHog::VERSION,
+                        '$lib_consumer' => 'LibCurl',
+                    ],
                     'distinct_id' => 'user-123',
-                    'library' => 'posthog-php',
-                    'library_version' => PostHog::VERSION,
-                    'library_consumer' => 'LibCurl',
-                    'groups' => [],
                     'timestamp' => date('c'),
-                    'type' => 'capture',
                 ]],
                 'api_key' => self::FAKE_API_KEY,
             ]);

--- a/test/FeatureFlagLocalEvaluationTest.php
+++ b/test/FeatureFlagLocalEvaluationTest.php
@@ -1453,7 +1453,7 @@ class FeatureFlagLocalEvaluationTest extends TestCase
                     ),
                     1 => array(
                         "path" => "/batch/",
-                        'payload' => '{"batch":[{"properties":{"$feature_flag":"simple-flag","$feature_flag_response":true,"$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$is_server":true,"$groups":[]},"distinct_id":"some-distinct-id","event":"$feature_flag_called","$groups":[],"library":"posthog-php","library_version":"' . PostHog::VERSION . '","library_consumer":"LibCurl","groups":[],"timestamp":"2022-05-01T00:00:00+00:00","type":"capture"}],"api_key":"random_key"}',
+                        'payload' => '{"batch":[{"properties":{"$feature_flag":"simple-flag","$feature_flag_response":true,"$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$is_server":true,"$groups":[]},"distinct_id":"some-distinct-id","event":"$feature_flag_called","$groups":[],"groups":[],"timestamp":"2022-05-01T00:00:00+00:00"}],"api_key":"random_key"}',
                         "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                         "requestOptions" => array('shouldVerify' => true),
                     ),

--- a/test/FeatureFlagTest.php
+++ b/test/FeatureFlagTest.php
@@ -97,7 +97,7 @@ class FeatureFlagTest extends TestCase
                     ),
                 1 => array(
                     "path" => "/batch/",
-                    "payload" => '{"batch":[{"properties":{"$feature_flag":"simple-test","$feature_flag_response":true,"$feature_flag_request_id":"98487c8a-287a-4451-a085-299cd76228dd","$feature_flag_id":6,"$feature_flag_version":1,"$feature_flag_reason":"Matched condition set 1","$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$is_server":true,"$groups":[]},"distinct_id":"user-id","event":"$feature_flag_called","$groups":[],"library":"posthog-php","library_version":"' . PostHog::VERSION . '","library_consumer":"LibCurl","groups":[],"timestamp":"2022-05-01T00:00:00+00:00","type":"capture"}],"api_key":"random_key"}',
+                    "payload" => '{"batch":[{"properties":{"$feature_flag":"simple-test","$feature_flag_response":true,"$feature_flag_request_id":"98487c8a-287a-4451-a085-299cd76228dd","$feature_flag_id":6,"$feature_flag_version":1,"$feature_flag_reason":"Matched condition set 1","$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$is_server":true,"$groups":[]},"distinct_id":"user-id","event":"$feature_flag_called","$groups":[],"groups":[],"timestamp":"2022-05-01T00:00:00+00:00"}],"api_key":"random_key"}',
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array('shouldVerify' => true),
                     ),
@@ -196,7 +196,7 @@ class FeatureFlagTest extends TestCase
                 ),
                 1 => array(
                     "path" => "/batch/",
-                    "payload" => '{"batch":[{"properties":{"$feature_flag":"multivariate-test","$feature_flag_response":"variant-value","$feature_flag_request_id":"98487c8a-287a-4451-a085-299cd76228dd","$feature_flag_id":7,"$feature_flag_version":3,"$feature_flag_reason":"Matched condition set 2","$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$is_server":true,"$groups":[]},"distinct_id":"user-id","event":"$feature_flag_called","$groups":[],"library":"posthog-php","library_version":"' . PostHog::VERSION . '","library_consumer":"LibCurl","groups":[],"timestamp":"2022-05-01T00:00:00+00:00","type":"capture"}],"api_key":"random_key"}',
+                    "payload" => '{"batch":[{"properties":{"$feature_flag":"multivariate-test","$feature_flag_response":"variant-value","$feature_flag_request_id":"98487c8a-287a-4451-a085-299cd76228dd","$feature_flag_id":7,"$feature_flag_version":3,"$feature_flag_reason":"Matched condition set 2","$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$is_server":true,"$groups":[]},"distinct_id":"user-id","event":"$feature_flag_called","$groups":[],"groups":[],"timestamp":"2022-05-01T00:00:00+00:00"}],"api_key":"random_key"}',
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array('shouldVerify' => true),
                 ),

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -476,6 +476,88 @@ class PostHogTest extends TestCase
         self::assertTrue($properties['$is_server']);
     }
 
+    public function testCaptureStripsDeprecatedTopLevelBatchFields(): void
+    {
+        self::assertTrue(
+            PostHog::capture(
+                array(
+                    "distinctId" => "john",
+                    "event" => "Module PHP Event",
+                    "type" => "capture",
+                    "library" => "custom-lib",
+                    "library_version" => "0.0.1",
+                    "library_consumer" => "CustomConsumer",
+                    "send_feature_flags" => false,
+                )
+            )
+        );
+        PostHog::flush();
+
+        $batchCall = null;
+        foreach ($this->http_client->calls as $call) {
+            if (($call["path"] ?? null) === "/batch/") {
+                $batchCall = $call;
+                break;
+            }
+        }
+        self::assertNotNull($batchCall, "Expected a /batch/ call to have been made");
+
+        $decoded = json_decode($batchCall["payload"], true);
+        $event = $decoded["batch"][0];
+
+        self::assertArrayNotHasKey('type', $event);
+        self::assertSame('Module PHP Event', $event['event']);
+        self::assertArrayNotHasKey('library', $event);
+        self::assertArrayNotHasKey('library_version', $event);
+        self::assertArrayNotHasKey('library_consumer', $event);
+        self::assertArrayNotHasKey('send_feature_flags', $event);
+        self::assertSame(array('User-Agent: posthog-php/' . PostHog::VERSION), $batchCall['extraHeaders']);
+        self::assertSame('custom-lib', $event['properties']['$lib']);
+        self::assertSame('0.0.1', $event['properties']['$lib_version']);
+        self::assertSame('CustomConsumer', $event['properties']['$lib_consumer']);
+    }
+
+    public function testCaptureCanonicalSdkPropertiesOverrideDeprecatedTopLevelFields(): void
+    {
+        self::assertTrue(
+            PostHog::capture(
+                array(
+                    "distinctId" => "john",
+                    "event" => "Module PHP Event",
+                    "library" => "custom-lib",
+                    "library_version" => "0.0.1",
+                    "library_consumer" => "CustomConsumer",
+                    "properties" => array(
+                        '$lib' => 'canonical-lib',
+                        '$lib_version' => '1.2.3',
+                        '$lib_consumer' => 'CanonicalConsumer',
+                    ),
+                )
+            )
+        );
+        PostHog::flush();
+
+        $batchCall = null;
+        foreach ($this->http_client->calls as $call) {
+            if (($call["path"] ?? null) === "/batch/") {
+                $batchCall = $call;
+                break;
+            }
+        }
+        self::assertNotNull($batchCall, "Expected a /batch/ call to have been made");
+
+        $decoded = json_decode($batchCall["payload"], true);
+        $event = $decoded["batch"][0];
+
+        self::assertArrayNotHasKey('library', $event);
+        self::assertArrayNotHasKey('library_version', $event);
+        self::assertArrayNotHasKey('library_consumer', $event);
+        self::assertSame(array('User-Agent: posthog-php/' . PostHog::VERSION), $batchCall['extraHeaders']);
+        self::assertSame('canonical-lib', $event['properties']['$lib']);
+        self::assertSame('1.2.3', $event['properties']['$lib_version']);
+        self::assertSame('CanonicalConsumer', $event['properties']['$lib_consumer']);
+    }
+
     public function testCaptureOmitsIsServerPropertyWhenDisabled(): void
     {
         $this->http_client = new MockedHttpClient("app.posthog.com");
@@ -552,7 +634,7 @@ class PostHogTest extends TestCase
                     ),
                     1 => array (
                         "path" => "/batch/",
-                        "payload" => '{"batch":[{"event":"Module PHP Event","send_feature_flags":true,"properties":{"$feature\/true-flag":true,"$active_feature_flags":["true-flag"],"$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$is_server":true},"library":"posthog-php","library_version":"' . PostHog::VERSION . '","library_consumer":"LibCurl","distinct_id":"john","groups":[],"timestamp":"2022-05-01T00:00:00+00:00","type":"capture"}],"api_key":"random_key"}',
+                        "payload" => '{"batch":[{"event":"Module PHP Event","properties":{"$feature\/true-flag":true,"$active_feature_flags":["true-flag"],"$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$is_server":true},"distinct_id":"john","groups":[],"timestamp":"2022-05-01T00:00:00+00:00"}],"api_key":"random_key"}',
                         "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                         "requestOptions" => array('shouldVerify' => true),
                     ),
@@ -608,7 +690,7 @@ class PostHogTest extends TestCase
                     ),
                     1 => array (
                         "path" => "/batch/",
-                        "payload" => '{"batch":[{"event":"Module PHP Event","send_feature_flags":true,"properties":{"$feature\/true-flag":true,"$active_feature_flags":["true-flag"],"$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$is_server":true},"library":"posthog-php","library_version":"' . PostHog::VERSION . '","library_consumer":"LibCurl","distinct_id":"john","groups":[],"timestamp":"2022-05-01T00:00:00+00:00","type":"capture"}],"api_key":"random_key"}',
+                        "payload" => '{"batch":[{"event":"Module PHP Event","properties":{"$feature\/true-flag":true,"$active_feature_flags":["true-flag"],"$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$is_server":true},"distinct_id":"john","groups":[],"timestamp":"2022-05-01T00:00:00+00:00"}],"api_key":"random_key"}',
                         "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                         "requestOptions" => array('shouldVerify' => true),
                     ),
@@ -658,7 +740,7 @@ class PostHogTest extends TestCase
                     ),
                     1 => array (
                         "path" => "/batch/",
-                        "payload" => '{"batch":[{"event":"Module PHP Event","properties":{"$feature\/true-flag":"random-override","$active_feature_flags":["true-flag"],"$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$is_server":true},"send_feature_flags":true,"library":"posthog-php","library_version":"' . PostHog::VERSION . '","library_consumer":"LibCurl","distinct_id":"john","groups":[],"timestamp":"2022-05-01T00:00:00+00:00","type":"capture"}],"api_key":"random_key"}',
+                        "payload" => '{"batch":[{"event":"Module PHP Event","properties":{"$feature\/true-flag":"random-override","$active_feature_flags":["true-flag"],"$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$is_server":true},"distinct_id":"john","groups":[],"timestamp":"2022-05-01T00:00:00+00:00"}],"api_key":"random_key"}',
                         "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                         "requestOptions" => array('shouldVerify' => true),
                     ),
@@ -960,7 +1042,7 @@ class PostHogTest extends TestCase
                     ),
                     1 => array (
                         "path" => "/batch/",
-                        "payload" => '{"batch":[{"event":"Module PHP Event","send_feature_flags":false,"properties":{"$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$is_server":true},"library":"posthog-php","library_version":"' . PostHog::VERSION . '","library_consumer":"LibCurl","distinct_id":"john","groups":[],"timestamp":"2022-05-01T00:00:00+00:00","type":"capture"}],"api_key":"random_key"}',
+                        "payload" => '{"batch":[{"event":"Module PHP Event","properties":{"$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$is_server":true},"distinct_id":"john","groups":[],"timestamp":"2022-05-01T00:00:00+00:00"}],"api_key":"random_key"}',
                         "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                         "requestOptions" => array('shouldVerify' => true),
                     ),


### PR DESCRIPTION
## :bulb: Motivation and Context

The backend `/batch/` endpoint ignores several legacy top-level fields on individual events (`type`, `library`, `library_version`, `library_consumer`, and `send_feature_flags`). Keeping them in SDK payloads adds noise and can confuse which fields are canonical.

This change strips those deprecated top-level fields before sending events and keeps the backend-supported canonical SDK metadata in event properties instead. For backwards compatibility, legacy top-level `library`, `library_version`, and `library_consumer` values are still used as event-property fallbacks when the canonical `$lib`, `$lib_version`, or `$lib_consumer` values are absent. Top-level `type` is ignored and not used as a fallback. The HTTP `User-Agent` now always uses the official `PostHog::LIBRARY` / `PostHog::VERSION` constants regardless of event metadata.

## :green_heart: How did you test it?

- `composer run api:check`
- `php -l` on changed PHP files
- `./vendor/bin/phpunit --testsuite posthog-php` (tests pass: 339 tests / 3391 assertions; command exits non-zero because PHPUnit reports no code coverage driver)
- `git diff --check`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

An AI coding agent made the implementation and validation changes at the direction of the maintainer. The backend batch schema was checked first, then the SDK was updated to stop sending ignored per-event top-level fields while preserving canonical `$lib`, `$lib_version`, and `$lib_consumer` properties. Backwards compatibility was preserved for legacy top-level SDK metadata values as event-property fallbacks when canonical values are absent; `type` remains a no-op. Existing payload assertions and file-consumer expectations were updated to match the canonical shape.
