### PR TITLE
chore: fix changeset package name

### DIFF
--- a/.changeset/brave-otters-flush.md
+++ b/.changeset/brave-otters-flush.md
@@ -1,5 +1,5 @@
 ---
-"posthog/posthog-php": minor
+"posthog-php": minor
 ---
 
 Add configurable flush interval support for queued event batching.


### PR DESCRIPTION
## :bulb: Motivation and Context

The release workflow failed because the pending changeset referenced the Composer package name (`posthog/posthog-php`) instead of the Changesets workspace package name (`posthog-php`). Changesets could not find that package in the workspace, so `pnpm changeset version` exited before creating the release.


## :green_heart: How did you test it?

- Ran `pnpm install --frozen-lockfile`
- Ran `pnpm changeset status` and confirmed `posthog-php` is detected for a minor bump


## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

An agent inspected the failed release logs, identified the mismatch between the changeset package name and `package.json`, and updated the existing changeset to reference `posthog-php`. Validation used Changesets status output rather than creating a new changeset, because this PR only fixes release metadata for an already pending changeset.
