### PR TITLE
fix: Generate personless IDs with UUID v7

### DIFF
--- a/.changeset/gold-cats-jump.md
+++ b/.changeset/gold-cats-jump.md
@@ -1,0 +1,5 @@
+---
+"posthog-php": patch
+---
+
+Generate personless distinct IDs with UUID v7.

--- a/api/public-api.json
+++ b/api/public-api.json
@@ -4473,6 +4473,13 @@
                     "final": false,
                     "returnType": "string",
                     "parameters": []
+                },
+                "v7": {
+                    "static": true,
+                    "abstract": false,
+                    "final": false,
+                    "returnType": "string",
+                    "parameters": []
                 }
             }
         }

--- a/api/public-api.json
+++ b/api/public-api.json
@@ -4473,13 +4473,6 @@
                     "final": false,
                     "returnType": "string",
                     "parameters": []
-                },
-                "v7": {
-                    "static": true,
-                    "abstract": false,
-                    "final": false,
-                    "returnType": "string",
-                    "parameters": []
                 }
             }
         }

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,10 @@
 	"autoload": {
 		"psr-4": {
 			"PostHog\\": "lib/"
-		}
+		},
+		"files": [
+			"lib/Uuid.php"
+		]
 	},
 	"autoload-dev": {
 		"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,7 @@
 	"autoload": {
 		"psr-4": {
 			"PostHog\\": "lib/"
-		},
-		"files": [
-			"lib/Uuid.php"
-		]
+		}
 	},
 	"autoload-dev": {
 		"psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c11900659348ffada66c82406a3d8c6c",
+    "content-hash": "14cfceee7677b783774cabf54cf62c97",
     "packages": [
         {
             "name": "psr/clock",

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -1899,7 +1899,7 @@ class Client implements FeatureFlagEvaluationsHost
         }
 
         if (!$explicitDistinctId) {
-            $msg["distinct_id"] = uuidV7();
+            $msg["distinct_id"] = Uuid::v7();
             $usedGeneratedPersonlessDistinctId = true;
             if (!array_key_exists('$process_person_profile', $msg["properties"])) {
                 $msg["properties"]['$process_person_profile'] = false;

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -1899,7 +1899,7 @@ class Client implements FeatureFlagEvaluationsHost
         }
 
         if (!$explicitDistinctId) {
-            $msg["distinct_id"] = Uuid::v7();
+            $msg["distinct_id"] = uuidV7();
             $usedGeneratedPersonlessDistinctId = true;
             if (!array_key_exists('$process_person_profile', $msg["properties"])) {
                 $msg["properties"]['$process_person_profile'] = false;

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -1899,7 +1899,7 @@ class Client implements FeatureFlagEvaluationsHost
         }
 
         if (!$explicitDistinctId) {
-            $msg["distinct_id"] = Uuid::v4();
+            $msg["distinct_id"] = Uuid::v7();
             $usedGeneratedPersonlessDistinctId = true;
             if (!array_key_exists('$process_person_profile', $msg["properties"])) {
                 $msg["properties"]['$process_person_profile'] = false;

--- a/lib/ExceptionCapture.php
+++ b/lib/ExceptionCapture.php
@@ -433,7 +433,7 @@ class ExceptionCapture
 
             $distinctId = $providerContext['distinctId'];
             if ($distinctId === null) {
-                $distinctId = Uuid::v4();
+                $distinctId = Uuid::v7();
                 $properties['$process_person_profile'] = false;
             }
 

--- a/lib/ExceptionCapture.php
+++ b/lib/ExceptionCapture.php
@@ -433,7 +433,7 @@ class ExceptionCapture
 
             $distinctId = $providerContext['distinctId'];
             if ($distinctId === null) {
-                $distinctId = Uuid::v7();
+                $distinctId = uuidV7();
                 $properties['$process_person_profile'] = false;
             }
 

--- a/lib/ExceptionCapture.php
+++ b/lib/ExceptionCapture.php
@@ -433,7 +433,7 @@ class ExceptionCapture
 
             $distinctId = $providerContext['distinctId'];
             if ($distinctId === null) {
-                $distinctId = uuidV7();
+                $distinctId = Uuid::v7();
                 $properties['$process_person_profile'] = false;
             }
 

--- a/lib/Uuid.php
+++ b/lib/Uuid.php
@@ -29,39 +29,38 @@ final class Uuid
             random_int(0, 0xffff)
         );
     }
-}
 
-/**
- * Generate a UUID v7 string using the RFC 9562 Unix timestamp layout.
- *
- * PHP does not provide a built-in UUID API in the SDK's supported runtimes, so
- * this internal helper keeps UUID v7 generation local without adding a runtime dependency.
- *
- * @internal
- * @return string UUID v7.
- * @throws \Random\RandomException When random_bytes() cannot gather sufficient entropy.
- */
-function uuidV7(): string
-{
-    $bytes = random_bytes(16);
-    $timestamp = (int) floor(microtime(true) * 1000);
+    /**
+     * Generate a UUID v7 string using the RFC 9562 Unix timestamp layout.
+     *
+     * PHP does not provide a built-in UUID API in the SDK's supported runtimes, so
+     * this internal helper keeps UUID v7 generation local without adding a runtime dependency.
+     *
+     * @return string UUID v7.
+     * @throws \Random\RandomException When random_bytes() cannot gather sufficient entropy.
+     */
+    public static function v7(): string
+    {
+        $bytes = random_bytes(16);
+        $timestamp = (int) floor(microtime(true) * 1000);
 
-    for ($i = 5; $i >= 0; --$i) {
-        $bytes[$i] = chr($timestamp & 0xff);
-        $timestamp >>= 8;
+        for ($i = 5; $i >= 0; --$i) {
+            $bytes[$i] = chr($timestamp & 0xff);
+            $timestamp >>= 8;
+        }
+
+        $bytes[6] = chr((ord($bytes[6]) & 0x0f) | 0x70);
+        $bytes[8] = chr((ord($bytes[8]) & 0x3f) | 0x80);
+
+        $hex = bin2hex($bytes);
+
+        return sprintf(
+            '%s-%s-%s-%s-%s',
+            substr($hex, 0, 8),
+            substr($hex, 8, 4),
+            substr($hex, 12, 4),
+            substr($hex, 16, 4),
+            substr($hex, 20, 12)
+        );
     }
-
-    $bytes[6] = chr((ord($bytes[6]) & 0x0f) | 0x70);
-    $bytes[8] = chr((ord($bytes[8]) & 0x3f) | 0x80);
-
-    $hex = bin2hex($bytes);
-
-    return sprintf(
-        '%s-%s-%s-%s-%s',
-        substr($hex, 0, 8),
-        substr($hex, 8, 4),
-        substr($hex, 12, 4),
-        substr($hex, 16, 4),
-        substr($hex, 20, 12)
-    );
 }

--- a/lib/Uuid.php
+++ b/lib/Uuid.php
@@ -29,4 +29,35 @@ final class Uuid
             random_int(0, 0xffff)
         );
     }
+
+    /**
+     * Generate a random UUID v7 string.
+     *
+     * @return string UUID v7.
+     * @throws \Random\RandomException When random_bytes() cannot gather sufficient entropy.
+     */
+    public static function v7(): string
+    {
+        $bytes = random_bytes(16);
+        $timestamp = (int) floor(microtime(true) * 1000);
+
+        for ($i = 5; $i >= 0; --$i) {
+            $bytes[$i] = chr($timestamp & 0xff);
+            $timestamp >>= 8;
+        }
+
+        $bytes[6] = chr((ord($bytes[6]) & 0x0f) | 0x70);
+        $bytes[8] = chr((ord($bytes[8]) & 0x3f) | 0x80);
+
+        $hex = bin2hex($bytes);
+
+        return sprintf(
+            '%s-%s-%s-%s-%s',
+            substr($hex, 0, 8),
+            substr($hex, 8, 4),
+            substr($hex, 12, 4),
+            substr($hex, 16, 4),
+            substr($hex, 20, 12)
+        );
+    }
 }

--- a/lib/Uuid.php
+++ b/lib/Uuid.php
@@ -29,35 +29,39 @@ final class Uuid
             random_int(0, 0xffff)
         );
     }
+}
 
-    /**
-     * Generate a random UUID v7 string.
-     *
-     * @return string UUID v7.
-     * @throws \Random\RandomException When random_bytes() cannot gather sufficient entropy.
-     */
-    public static function v7(): string
-    {
-        $bytes = random_bytes(16);
-        $timestamp = (int) floor(microtime(true) * 1000);
+/**
+ * Generate a UUID v7 string using the RFC 9562 Unix timestamp layout.
+ *
+ * PHP does not provide a built-in UUID API in the SDK's supported runtimes, so
+ * this internal helper keeps UUID v7 generation local without adding a runtime dependency.
+ *
+ * @internal
+ * @return string UUID v7.
+ * @throws \Random\RandomException When random_bytes() cannot gather sufficient entropy.
+ */
+function uuidV7(): string
+{
+    $bytes = random_bytes(16);
+    $timestamp = (int) floor(microtime(true) * 1000);
 
-        for ($i = 5; $i >= 0; --$i) {
-            $bytes[$i] = chr($timestamp & 0xff);
-            $timestamp >>= 8;
-        }
-
-        $bytes[6] = chr((ord($bytes[6]) & 0x0f) | 0x70);
-        $bytes[8] = chr((ord($bytes[8]) & 0x3f) | 0x80);
-
-        $hex = bin2hex($bytes);
-
-        return sprintf(
-            '%s-%s-%s-%s-%s',
-            substr($hex, 0, 8),
-            substr($hex, 8, 4),
-            substr($hex, 12, 4),
-            substr($hex, 16, 4),
-            substr($hex, 20, 12)
-        );
+    for ($i = 5; $i >= 0; --$i) {
+        $bytes[$i] = chr($timestamp & 0xff);
+        $timestamp >>= 8;
     }
+
+    $bytes[6] = chr((ord($bytes[6]) & 0x0f) | 0x70);
+    $bytes[8] = chr((ord($bytes[8]) & 0x3f) | 0x80);
+
+    $hex = bin2hex($bytes);
+
+    return sprintf(
+        '%s-%s-%s-%s-%s',
+        substr($hex, 0, 8),
+        substr($hex, 8, 4),
+        substr($hex, 12, 4),
+        substr($hex, 16, 4),
+        substr($hex, 20, 12)
+    );
 }

--- a/test/ExceptionCaptureTest.php
+++ b/test/ExceptionCaptureTest.php
@@ -169,7 +169,7 @@ class ExceptionCaptureTest extends TestCase
             $this->assertSame('RuntimeException', $event['properties']['$exception_list'][0]['type']);
             $this->assertFalse($event['properties']['$process_person_profile']);
             $this->assertMatchesRegularExpression(
-                '/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
+                '/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
                 $event['distinct_id']
             );
         } finally {

--- a/test/ExceptionPayloadBuilderTest.php
+++ b/test/ExceptionPayloadBuilderTest.php
@@ -396,9 +396,9 @@ PHP;
         $payload   = json_decode($batchCall['payload'], true);
         $event     = $payload['batch'][0];
 
-        // distinct_id should look like a UUID
+        // distinct_id should look like a UUID v7
         $this->assertMatchesRegularExpression(
-            '/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
             $event['distinct_id']
         );
         $this->assertFalse($event['properties']['$process_person_profile']);

--- a/test/RequestContextTest.php
+++ b/test/RequestContextTest.php
@@ -113,7 +113,10 @@ class RequestContextTest extends TestCase
         $event = $this->flushAndGetEvents()[0];
 
         $this->assertIsString($event['distinct_id']);
-        $this->assertNotSame('', $event['distinct_id']);
+        $this->assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
+            $event['distinct_id']
+        );
         $this->assertFalse($event['properties']['$process_person_profile']);
         $this->assertSame('free', $event['properties']['plan']);
     }

--- a/test/UuidTest.php
+++ b/test/UuidTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace PostHog\Test;
+
+use PHPUnit\Framework\TestCase;
+use PostHog\Uuid;
+
+class UuidTest extends TestCase
+{
+    public function testV7GeneratesValidVersionAndVariant(): void
+    {
+        $uuid = Uuid::v7();
+
+        $this->assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
+            $uuid
+        );
+    }
+
+    public function testV7EmbedsCurrentTimestamp(): void
+    {
+        $before = (int) floor(microtime(true) * 1000);
+        $uuid = Uuid::v7();
+        $after = (int) floor(microtime(true) * 1000);
+
+        $timestamp = hexdec(substr(str_replace('-', '', $uuid), 0, 12));
+
+        $this->assertGreaterThanOrEqual($before, $timestamp);
+        $this->assertLessThanOrEqual($after, $timestamp);
+    }
+
+    public function testV7GeneratesUniqueValues(): void
+    {
+        $uuids = [];
+
+        for ($i = 0; $i < 100; ++$i) {
+            $uuid = Uuid::v7();
+            $this->assertArrayNotHasKey($uuid, $uuids);
+            $uuids[$uuid] = true;
+        }
+    }
+}

--- a/test/UuidTest.php
+++ b/test/UuidTest.php
@@ -3,13 +3,14 @@
 namespace PostHog\Test;
 
 use PHPUnit\Framework\TestCase;
-use PostHog\Uuid;
+
+use function PostHog\uuidV7;
 
 class UuidTest extends TestCase
 {
     public function testV7GeneratesValidVersionAndVariant(): void
     {
-        $uuid = Uuid::v7();
+        $uuid = uuidV7();
 
         $this->assertMatchesRegularExpression(
             '/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
@@ -20,7 +21,7 @@ class UuidTest extends TestCase
     public function testV7EmbedsCurrentTimestamp(): void
     {
         $before = (int) floor(microtime(true) * 1000);
-        $uuid = Uuid::v7();
+        $uuid = uuidV7();
         $after = (int) floor(microtime(true) * 1000);
 
         $timestamp = hexdec(substr(str_replace('-', '', $uuid), 0, 12));
@@ -34,7 +35,7 @@ class UuidTest extends TestCase
         $uuids = [];
 
         for ($i = 0; $i < 100; ++$i) {
-            $uuid = Uuid::v7();
+            $uuid = uuidV7();
             $this->assertArrayNotHasKey($uuid, $uuids);
             $uuids[$uuid] = true;
         }

--- a/test/UuidTest.php
+++ b/test/UuidTest.php
@@ -3,14 +3,13 @@
 namespace PostHog\Test;
 
 use PHPUnit\Framework\TestCase;
-
-use function PostHog\uuidV7;
+use PostHog\Uuid;
 
 class UuidTest extends TestCase
 {
     public function testV7GeneratesValidVersionAndVariant(): void
     {
-        $uuid = uuidV7();
+        $uuid = Uuid::v7();
 
         $this->assertMatchesRegularExpression(
             '/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
@@ -21,7 +20,7 @@ class UuidTest extends TestCase
     public function testV7EmbedsCurrentTimestamp(): void
     {
         $before = (int) floor(microtime(true) * 1000);
-        $uuid = uuidV7();
+        $uuid = Uuid::v7();
         $after = (int) floor(microtime(true) * 1000);
 
         $timestamp = hexdec(substr(str_replace('-', '', $uuid), 0, 12));
@@ -35,7 +34,7 @@ class UuidTest extends TestCase
         $uuids = [];
 
         for ($i = 0; $i < 100; ++$i) {
-            $uuid = uuidV7();
+            $uuid = Uuid::v7();
             $this->assertArrayNotHasKey($uuid, $uuids);
             $uuids[$uuid] = true;
         }


### PR DESCRIPTION
## :bulb: Motivation and Context

Generated personless identifiers should be time-ordered UUID v7 values. The PHP SDK still generated v4 values for personless capture distinct IDs and exception auto-capture fallback IDs.

This PR adds internal UUID v7 generation following the RFC 9562 Unix timestamp layout and uses it for SDK-generated personless `distinct_id` values. The helper is autoloaded internally without adding `Uuid::v7()` to the public API snapshot.

## :green_heart: How did you test it?

- `composer validate`
- `composer api:check`
- `vendor/bin/phpcs --warning-severity=0 lib/Uuid.php lib/Client.php lib/ExceptionCapture.php test/UuidTest.php`
- `vendor/bin/phpunit --no-coverage test/UuidTest.php`
- `vendor/bin/phpunit --no-coverage test/RequestContextTest.php --filter Personless`
- `vendor/bin/phpunit --no-coverage test/ExceptionPayloadBuilderTest.php --filter testCaptureExceptionWithoutDistinctIdGeneratesUuidAndSetsNoProfile`
- `vendor/bin/phpunit --no-coverage test/ExceptionCaptureTest.php --filter testExceptionHandlerUsesCurrentClientContextProperties`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented by a coding agent from a human request to migrate SDK-generated UUID v4/random IDs to UUID v7. Follow-up review feedback made UUID v7 generation internal rather than public API and documented the RFC 9562 layout / no PHP core UUID v7 API in supported runtimes.
