### PR TITLE
fix: validate top-level event uuids

### DIFF
--- a/.changeset/clever-uuids-validate.md
+++ b/.changeset/clever-uuids-validate.md
@@ -1,0 +1,5 @@
+---
+"posthog-php": patch
+---
+
+Validate top-level event UUIDs and replace invalid values with generated UUIDs.

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -280,10 +280,13 @@ class Client implements FeatureFlagEvaluationsHost
      *     properties?: array<string, mixed>,
      *     groups?: array<string, mixed>,
      *     timestamp?: mixed,
+     *     uuid?: string,
      *     flags?: FeatureFlagEvaluations,
      *     send_feature_flags?: bool,
      *     sendFeatureFlags?: bool
-     * } $message Event payload. `send_feature_flags` and `sendFeatureFlags` are deprecated; pass
+     * } $message Event payload. If a top-level `uuid` is supplied it must be a valid UUID;
+     *     invalid values are replaced with a generated UUID v4. `send_feature_flags` and
+     *     `sendFeatureFlags` are deprecated; pass
      *     a `flags` snapshot from evaluateFlags() instead. Deprecated top-level batch metadata is
      *     stripped before sending: use `event` instead of `type`, `properties['$lib']` instead of
      *     `library`, `properties['$lib_version']` instead of `library_version`, and
@@ -302,6 +305,7 @@ class Client implements FeatureFlagEvaluationsHost
             $message = $this->applyCaptureContext($message, $usedGeneratedPersonlessDistinctId);
         }
         $message = $this->message($message);
+        $message = $this->normalizeMessageUuid($message);
 
         if (!array_key_exists('$groups', $message) && $hasGroups) {
             $message['$groups'] = $message['groups'];
@@ -1726,12 +1730,13 @@ class Client implements FeatureFlagEvaluationsHost
     /**
      * Queue a raw, already-prepared message.
      *
-     * @param array<string, mixed> $message Prepared message payload.
+     * @param array<string, mixed> $message Prepared message payload. If a top-level `uuid` is supplied
+     *     it must be a valid UUID; invalid values are replaced with a generated UUID v4.
      * @return mixed Whether the underlying consumer accepted the message.
      */
     public function raw(array $message)
     {
-        return $this->consumer->enqueue($message);
+        return $this->consumer->enqueue($this->normalizeMessageUuid($message));
     }
 
     /**
@@ -1928,6 +1933,27 @@ class Client implements FeatureFlagEvaluationsHost
         }
 
         return false;
+    }
+
+    private function normalizeMessageUuid(array $msg): array
+    {
+        if (array_key_exists('uuid', $msg) && !$this->isValidUuid($msg['uuid'])) {
+            $msg['uuid'] = Uuid::v4();
+        }
+
+        return $msg;
+    }
+
+    private function isValidUuid(mixed $uuid): bool
+    {
+        if (!is_string($uuid)) {
+            return false;
+        }
+
+        return preg_match(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i',
+            $uuid
+        ) === 1;
     }
 
     /**

--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -128,10 +128,13 @@ class PostHog
      *     properties?: array<string, mixed>,
      *     groups?: array<string, mixed>,
      *     timestamp?: mixed,
+     *     uuid?: string,
      *     flags?: FeatureFlagEvaluations,
      *     send_feature_flags?: bool,
      *     sendFeatureFlags?: bool
-     * } $message Event payload. `send_feature_flags` and `sendFeatureFlags` are deprecated; pass
+     * } $message Event payload. If a top-level `uuid` is supplied it must be a valid UUID;
+     *     invalid values are replaced with a generated UUID v4. `send_feature_flags` and
+     *     `sendFeatureFlags` are deprecated; pass
      *     a `flags` snapshot from evaluateFlags() instead. Deprecated top-level batch metadata is
      *     stripped before sending: use `event` instead of `type`, `properties['$lib']` instead of
      *     `library`, `properties['$lib_version']` instead of `library_version`, and
@@ -505,7 +508,8 @@ class PostHog
     /**
      * Send a raw, already-prepared message to the underlying consumer queue.
      *
-     * @param array<string, mixed> $message Prepared message payload.
+     * @param array<string, mixed> $message Prepared message payload. If a top-level `uuid` is supplied
+     *     it must be a valid UUID; invalid values are replaced with a generated UUID v4.
      * @return mixed Whether the underlying consumer accepted the message.
      */
     public static function raw(array $message)

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -70,6 +70,14 @@ class PostHogTest extends TestCase
         self::fail("Expected a /batch/ call to have been made");
     }
 
+    private function assertValidUuidV4(string $uuid): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
+            $uuid
+        );
+    }
+
     private function withEnvApiKey(?string $apiKey, callable $callback): void
     {
         $previousApiKey = getenv(PostHog::ENV_API_KEY);
@@ -688,6 +696,61 @@ class PostHogTest extends TestCase
         } finally {
             Clock::set(new NativeClock());
         }
+    }
+
+    public function testCaptureKeepsValidTopLevelUuid(): void
+    {
+        $uuid = '01890f87-d7e7-7c75-8d35-8a1e16b6b0bf';
+
+        self::assertTrue(
+            PostHog::capture(
+                array(
+                    "distinctId" => "john",
+                    "event" => "Module PHP Event",
+                    "uuid" => $uuid,
+                )
+            )
+        );
+        PostHog::flush();
+
+        $event = $this->firstBatchEvent();
+
+        self::assertSame($uuid, $event['uuid']);
+    }
+
+    public function testCaptureReplacesInvalidTopLevelUuid(): void
+    {
+        self::assertTrue(
+            PostHog::capture(
+                array(
+                    "distinctId" => "john",
+                    "event" => "Module PHP Event",
+                    "uuid" => "not-a-uuid",
+                )
+            )
+        );
+        PostHog::flush();
+
+        $event = $this->firstBatchEvent();
+
+        self::assertNotSame('not-a-uuid', $event['uuid']);
+        $this->assertValidUuidV4($event['uuid']);
+    }
+
+    public function testRawReplacesInvalidTopLevelUuid(): void
+    {
+        $this->client->raw(
+            array(
+                "event" => "Raw Event",
+                "uuid" => false,
+            )
+        );
+        PostHog::flush();
+
+        $event = $this->firstBatchEvent();
+
+        self::assertNotSame(false, $event['uuid']);
+        $this->assertValidUuidV4($event['uuid']);
     }
 
     public function testCaptureIncludesIsServerProperty(): void

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -141,6 +141,32 @@ class PostHogTest extends TestCase
         ];
     }
 
+    public static function validTopLevelUuidCases(): array
+    {
+        return [
+            'v1 UUID' => ['01890f87-d7e7-1c75-8d35-8a1e16b6b0bf'],
+            'v2 UUID' => ['01890f87-d7e7-2c75-8d35-8a1e16b6b0bf'],
+            'v3 UUID' => ['01890f87-d7e7-3c75-8d35-8a1e16b6b0bf'],
+            'v4 UUID' => ['01890f87-d7e7-4c75-8d35-8a1e16b6b0bf'],
+            'v5 UUID' => ['01890f87-d7e7-5c75-8d35-8a1e16b6b0bf'],
+            'v6 UUID' => ['01890f87-d7e7-6c75-8d35-8a1e16b6b0bf'],
+            'v7 UUID' => ['01890f87-d7e7-7c75-8d35-8a1e16b6b0bf'],
+            'v8 UUID' => ['01890f87-d7e7-8c75-8d35-8a1e16b6b0bf'],
+        ];
+    }
+
+    public static function invalidTopLevelUuidCases(): array
+    {
+        return [
+            'null' => [null],
+            'empty string' => [''],
+            'zero' => [0],
+            'false' => [false],
+            'non-UUID string' => ['not-a-uuid'],
+            'nil UUID' => ['00000000-0000-0000-0000-000000000000'],
+        ];
+    }
+
     public static function facadeNoOpBeforeInitCases(): array
     {
         return [
@@ -698,10 +724,11 @@ class PostHogTest extends TestCase
         }
     }
 
-    public function testCaptureKeepsValidTopLevelUuid(): void
+    /**
+     * @dataProvider validTopLevelUuidCases
+     */
+    public function testCaptureKeepsValidTopLevelUuid(string $uuid): void
     {
-        $uuid = '01890f87-d7e7-7c75-8d35-8a1e16b6b0bf';
-
         self::assertTrue(
             PostHog::capture(
                 array(
@@ -718,14 +745,17 @@ class PostHogTest extends TestCase
         self::assertSame($uuid, $event['uuid']);
     }
 
-    public function testCaptureReplacesInvalidTopLevelUuid(): void
+    /**
+     * @dataProvider invalidTopLevelUuidCases
+     */
+    public function testCaptureReplacesInvalidTopLevelUuid(mixed $uuid): void
     {
         self::assertTrue(
             PostHog::capture(
                 array(
                     "distinctId" => "john",
                     "event" => "Module PHP Event",
-                    "uuid" => "not-a-uuid",
+                    "uuid" => $uuid,
                 )
             )
         );
@@ -733,23 +763,26 @@ class PostHogTest extends TestCase
 
         $event = $this->firstBatchEvent();
 
-        self::assertNotSame('not-a-uuid', $event['uuid']);
+        self::assertNotSame($uuid, $event['uuid']);
         $this->assertValidUuidV4($event['uuid']);
     }
 
-    public function testRawReplacesInvalidTopLevelUuid(): void
+    /**
+     * @dataProvider invalidTopLevelUuidCases
+     */
+    public function testRawReplacesInvalidTopLevelUuid(mixed $uuid): void
     {
         $this->client->raw(
             array(
                 "event" => "Raw Event",
-                "uuid" => false,
+                "uuid" => $uuid,
             )
         );
         PostHog::flush();
 
         $event = $this->firstBatchEvent();
 
-        self::assertNotSame(false, $event['uuid']);
+        self::assertNotSame($uuid, $event['uuid']);
         $this->assertValidUuidV4($event['uuid']);
     }
 


### PR DESCRIPTION
## :bulb: Motivation and Context

Top-level event `uuid` values can be passed through capture/raw payloads, but invalid values were sent unchanged. This validates supplied UUIDs and replaces invalid values with a generated UUID v4 so queued events keep a valid event identifier.

## :green_heart: How did you test it?

- `./vendor/bin/phpunit --no-coverage test/PostHogTest.php --filter 'Uuid|TopLevelUuid'`
- `./vendor/bin/phpunit --no-coverage`
- `composer api:check`
- `php -l lib/Client.php && php -l lib/PostHog.php && php -l test/PostHogTest.php`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Generated a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi coding agent implemented the requested UUID validation in a dedicated worktree. The change keeps valid supplied UUIDs, replaces invalid top-level `uuid` values for `capture()` and `raw()` payloads with generated UUID v4 values, documents the behavior in the PHPDoc, and adds parameterized coverage for valid UUID versions v1-v8 plus invalid fallback cases.

