### PR TITLE
fix: Dedupe feature flag called events by response

### DIFF
--- a/.changeset/tidy-falcons-sip.md
+++ b/.changeset/tidy-falcons-sip.md
@@ -1,0 +1,5 @@
+---
+"posthog-php": patch
+---
+
+Dedupe feature flag called events by response value.

--- a/api/public-api.json
+++ b/api/public-api.json
@@ -223,6 +223,16 @@
                             "hasDefault": false
                         },
                         {
+                            "name": "response",
+                            "type": null,
+                            "byReference": false,
+                            "variadic": false,
+                            "optional": false,
+                            "default": null,
+                            "defaultConstant": null,
+                            "hasDefault": false
+                        },
+                        {
                             "name": "properties",
                             "type": "array",
                             "byReference": false,
@@ -2717,6 +2727,16 @@
                         {
                             "name": "key",
                             "type": "string",
+                            "byReference": false,
+                            "variadic": false,
+                            "optional": false,
+                            "default": null,
+                            "defaultConstant": null,
+                            "hasDefault": false
+                        },
+                        {
+                            "name": "response",
+                            "type": null,
                             "byReference": false,
                             "variadic": false,
                             "optional": false,

--- a/api/public-api.json
+++ b/api/public-api.json
@@ -196,6 +196,64 @@
                         }
                     ]
                 },
+                "captureFlagCalledIfNeeded": {
+                    "static": false,
+                    "abstract": false,
+                    "final": false,
+                    "returnType": "void",
+                    "parameters": [
+                        {
+                            "name": "distinctId",
+                            "type": "string",
+                            "byReference": false,
+                            "variadic": false,
+                            "optional": false,
+                            "default": null,
+                            "defaultConstant": null,
+                            "hasDefault": false
+                        },
+                        {
+                            "name": "key",
+                            "type": "string",
+                            "byReference": false,
+                            "variadic": false,
+                            "optional": false,
+                            "default": null,
+                            "defaultConstant": null,
+                            "hasDefault": false
+                        },
+                        {
+                            "name": "response",
+                            "type": null,
+                            "byReference": false,
+                            "variadic": false,
+                            "optional": false,
+                            "default": null,
+                            "defaultConstant": null,
+                            "hasDefault": false
+                        },
+                        {
+                            "name": "properties",
+                            "type": "array",
+                            "byReference": false,
+                            "variadic": false,
+                            "optional": false,
+                            "default": null,
+                            "defaultConstant": null,
+                            "hasDefault": false
+                        },
+                        {
+                            "name": "groups",
+                            "type": "array",
+                            "byReference": false,
+                            "variadic": false,
+                            "optional": true,
+                            "default": [],
+                            "defaultConstant": null,
+                            "hasDefault": true
+                        }
+                    ]
+                },
                 "contextFromHeaders": {
                     "static": false,
                     "abstract": false,
@@ -2542,16 +2600,6 @@
                             "default": false,
                             "defaultConstant": null,
                             "hasDefault": true
-                        },
-                        {
-                            "name": "captureFlagCalled",
-                            "type": "?Closure",
-                            "byReference": false,
-                            "variadic": false,
-                            "optional": true,
-                            "default": null,
-                            "defaultConstant": null,
-                            "hasDefault": true
                         }
                     ]
                 },
@@ -2660,6 +2708,64 @@
             "constants": [],
             "properties": [],
             "methods": {
+                "captureFlagCalledIfNeeded": {
+                    "static": false,
+                    "abstract": true,
+                    "final": false,
+                    "returnType": "void",
+                    "parameters": [
+                        {
+                            "name": "distinctId",
+                            "type": "string",
+                            "byReference": false,
+                            "variadic": false,
+                            "optional": false,
+                            "default": null,
+                            "defaultConstant": null,
+                            "hasDefault": false
+                        },
+                        {
+                            "name": "key",
+                            "type": "string",
+                            "byReference": false,
+                            "variadic": false,
+                            "optional": false,
+                            "default": null,
+                            "defaultConstant": null,
+                            "hasDefault": false
+                        },
+                        {
+                            "name": "response",
+                            "type": null,
+                            "byReference": false,
+                            "variadic": false,
+                            "optional": false,
+                            "default": null,
+                            "defaultConstant": null,
+                            "hasDefault": false
+                        },
+                        {
+                            "name": "properties",
+                            "type": "array",
+                            "byReference": false,
+                            "variadic": false,
+                            "optional": false,
+                            "default": null,
+                            "defaultConstant": null,
+                            "hasDefault": false
+                        },
+                        {
+                            "name": "groups",
+                            "type": "array",
+                            "byReference": false,
+                            "variadic": false,
+                            "optional": false,
+                            "default": null,
+                            "defaultConstant": null,
+                            "hasDefault": false
+                        }
+                    ]
+                },
                 "logWarning": {
                     "static": false,
                     "abstract": true,

--- a/api/public-api.json
+++ b/api/public-api.json
@@ -196,64 +196,6 @@
                         }
                     ]
                 },
-                "captureFlagCalledIfNeeded": {
-                    "static": false,
-                    "abstract": false,
-                    "final": false,
-                    "returnType": "void",
-                    "parameters": [
-                        {
-                            "name": "distinctId",
-                            "type": "string",
-                            "byReference": false,
-                            "variadic": false,
-                            "optional": false,
-                            "default": null,
-                            "defaultConstant": null,
-                            "hasDefault": false
-                        },
-                        {
-                            "name": "key",
-                            "type": "string",
-                            "byReference": false,
-                            "variadic": false,
-                            "optional": false,
-                            "default": null,
-                            "defaultConstant": null,
-                            "hasDefault": false
-                        },
-                        {
-                            "name": "response",
-                            "type": null,
-                            "byReference": false,
-                            "variadic": false,
-                            "optional": false,
-                            "default": null,
-                            "defaultConstant": null,
-                            "hasDefault": false
-                        },
-                        {
-                            "name": "properties",
-                            "type": "array",
-                            "byReference": false,
-                            "variadic": false,
-                            "optional": false,
-                            "default": null,
-                            "defaultConstant": null,
-                            "hasDefault": false
-                        },
-                        {
-                            "name": "groups",
-                            "type": "array",
-                            "byReference": false,
-                            "variadic": false,
-                            "optional": true,
-                            "default": [],
-                            "defaultConstant": null,
-                            "hasDefault": true
-                        }
-                    ]
-                },
                 "contextFromHeaders": {
                     "static": false,
                     "abstract": false,
@@ -2600,6 +2542,16 @@
                             "default": false,
                             "defaultConstant": null,
                             "hasDefault": true
+                        },
+                        {
+                            "name": "captureFlagCalled",
+                            "type": "?Closure",
+                            "byReference": false,
+                            "variadic": false,
+                            "optional": true,
+                            "default": null,
+                            "defaultConstant": null,
+                            "hasDefault": true
                         }
                     ]
                 },
@@ -2708,64 +2660,6 @@
             "constants": [],
             "properties": [],
             "methods": {
-                "captureFlagCalledIfNeeded": {
-                    "static": false,
-                    "abstract": true,
-                    "final": false,
-                    "returnType": "void",
-                    "parameters": [
-                        {
-                            "name": "distinctId",
-                            "type": "string",
-                            "byReference": false,
-                            "variadic": false,
-                            "optional": false,
-                            "default": null,
-                            "defaultConstant": null,
-                            "hasDefault": false
-                        },
-                        {
-                            "name": "key",
-                            "type": "string",
-                            "byReference": false,
-                            "variadic": false,
-                            "optional": false,
-                            "default": null,
-                            "defaultConstant": null,
-                            "hasDefault": false
-                        },
-                        {
-                            "name": "response",
-                            "type": null,
-                            "byReference": false,
-                            "variadic": false,
-                            "optional": false,
-                            "default": null,
-                            "defaultConstant": null,
-                            "hasDefault": false
-                        },
-                        {
-                            "name": "properties",
-                            "type": "array",
-                            "byReference": false,
-                            "variadic": false,
-                            "optional": false,
-                            "default": null,
-                            "defaultConstant": null,
-                            "hasDefault": false
-                        },
-                        {
-                            "name": "groups",
-                            "type": "array",
-                            "byReference": false,
-                            "variadic": false,
-                            "optional": false,
-                            "default": null,
-                            "defaultConstant": null,
-                            "hasDefault": false
-                        }
-                    ]
-                },
                 "logWarning": {
                     "static": false,
                     "abstract": true,

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -265,6 +265,7 @@ class Client implements FeatureFlagEvaluationsHost
         $flushed = $this->flush();
         $this->shutdownFlagDefinitionCacheProvider();
         $this->consumer->__destruct();
+        // Release the per-client feature-flag-called dedupe cache once the client is shut down.
         $this->distinctIdsFeatureFlagsReported = new SizeLimitedHash(self::SIZE_LIMIT);
         $this->shutdownComplete = true;
 
@@ -1084,7 +1085,7 @@ class Client implements FeatureFlagEvaluationsHost
      */
     private static function featureFlagResponseCacheKey($response): string
     {
-        return '|' . gettype($response) . ':' . json_encode($response);
+        return '|' . json_encode($response, JSON_THROW_ON_ERROR);
     }
 
     /**

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -715,7 +715,7 @@ class Client implements FeatureFlagEvaluationsHost
                 $properties['$feature_flag_error'] = $featureFlagError;
             }
 
-            $this->captureFlagCalledIfNeeded($distinctId, $key, $properties, $groups);
+            $this->captureFlagCalledIfNeeded($distinctId, $key, $result, $properties, $groups);
         }
 
         if (is_null($result)) {
@@ -1049,6 +1049,7 @@ class Client implements FeatureFlagEvaluationsHost
      *
      * @param string $distinctId The distinct ID that accessed the flag.
      * @param string $key Feature flag key.
+     * @param mixed $response Evaluated feature flag response for deduping.
      * @param array<string, mixed> $properties Event properties for the $feature_flag_called event.
      * @param array<string, mixed> $groups Group identifiers for group-based flags.
      * @return void
@@ -1056,12 +1057,10 @@ class Client implements FeatureFlagEvaluationsHost
     public function captureFlagCalledIfNeeded(
         string $distinctId,
         string $key,
+        $response,
         array $properties,
         array $groups = []
     ): void {
-        $response = array_key_exists('$feature_flag_response', $properties)
-            ? $properties['$feature_flag_response']
-            : null;
         $dedupElement = $distinctId . self::featureFlagResponseCacheKey($response) . self::canonicalGroupsRepr($groups);
         if ($this->distinctIdsFeatureFlagsReported->contains($key, $dedupElement)) {
             return;

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -1037,6 +1037,7 @@ class Client implements FeatureFlagEvaluationsHost
             null,
             $errorsWhileComputing,
             $quotaLimited,
+            $this->featureFlagCalledCallback(),
         );
     }
 
@@ -1054,7 +1055,7 @@ class Client implements FeatureFlagEvaluationsHost
      * @param array<string, mixed> $groups Group identifiers for group-based flags.
      * @return void
      */
-    public function captureFlagCalledIfNeeded(
+    private function captureFlagCalledIfNeeded(
         string $distinctId,
         string $key,
         $response,
@@ -1073,6 +1074,19 @@ class Client implements FeatureFlagEvaluationsHost
             '$groups' => $groups,
         ]);
         $this->distinctIdsFeatureFlagsReported->add($key, $dedupElement);
+    }
+
+    private function featureFlagCalledCallback(): \Closure
+    {
+        return function (
+            string $distinctId,
+            string $key,
+            $response,
+            array $properties,
+            array $groups
+        ): void {
+            $this->captureFlagCalledIfNeeded($distinctId, $key, $response, $properties, $groups);
+        };
     }
 
     /**

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -1037,7 +1037,6 @@ class Client implements FeatureFlagEvaluationsHost
             null,
             $errorsWhileComputing,
             $quotaLimited,
-            $this->featureFlagCalledCallback(),
         );
     }
 
@@ -1055,7 +1054,7 @@ class Client implements FeatureFlagEvaluationsHost
      * @param array<string, mixed> $groups Group identifiers for group-based flags.
      * @return void
      */
-    private function captureFlagCalledIfNeeded(
+    public function captureFlagCalledIfNeeded(
         string $distinctId,
         string $key,
         $response,
@@ -1074,19 +1073,6 @@ class Client implements FeatureFlagEvaluationsHost
             '$groups' => $groups,
         ]);
         $this->distinctIdsFeatureFlagsReported->add($key, $dedupElement);
-    }
-
-    private function featureFlagCalledCallback(): \Closure
-    {
-        return function (
-            string $distinctId,
-            string $key,
-            $response,
-            array $properties,
-            array $groups
-        ): void {
-            $this->captureFlagCalledIfNeeded($distinctId, $key, $response, $properties, $groups);
-        };
     }
 
     /**

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -265,6 +265,7 @@ class Client implements FeatureFlagEvaluationsHost
         $flushed = $this->flush();
         $this->shutdownFlagDefinitionCacheProvider();
         $this->consumer->__destruct();
+        $this->distinctIdsFeatureFlagsReported = new SizeLimitedHash(self::SIZE_LIMIT);
         $this->shutdownComplete = true;
 
         return $flushed;
@@ -1039,8 +1040,8 @@ class Client implements FeatureFlagEvaluationsHost
     }
 
     /**
-     * Fire a $feature_flag_called event the first time a (flag key, distinct id, groups) tuple is
-     * seen by this Client, deduped via the per-distinct_id cache shared with every other
+     * Fire a $feature_flag_called event the first time a (flag key, distinct id, response, groups)
+     * tuple is seen by this Client, deduped via the per-distinct_id cache shared with every other
      * flag-reading code path. Group context is included so that group-scoped flags fire a separate
      * event for each group a user is evaluated under. Properties are built by the caller so each
      * call site can shape the payload to match its available metadata.
@@ -1057,7 +1058,10 @@ class Client implements FeatureFlagEvaluationsHost
         array $properties,
         array $groups = []
     ): void {
-        $dedupElement = $distinctId . self::canonicalGroupsRepr($groups);
+        $response = array_key_exists('$feature_flag_response', $properties)
+            ? $properties['$feature_flag_response']
+            : null;
+        $dedupElement = $distinctId . self::featureFlagResponseCacheKey($response) . self::canonicalGroupsRepr($groups);
         if ($this->distinctIdsFeatureFlagsReported->contains($key, $dedupElement)) {
             return;
         }
@@ -1069,6 +1073,18 @@ class Client implements FeatureFlagEvaluationsHost
             '$groups' => $groups,
         ]);
         $this->distinctIdsFeatureFlagsReported->add($key, $dedupElement);
+    }
+
+    /**
+     * Build a stable cache fragment for the evaluated response so true, false, null, and variants
+     * dedupe independently for the same distinct id and flag key.
+     *
+     * @param mixed $response
+     * @return string
+     */
+    private static function featureFlagResponseCacheKey($response): string
+    {
+        return '|' . gettype($response) . ':' . json_encode($response);
     }
 
     /**

--- a/lib/FeatureFlagEvaluations.php
+++ b/lib/FeatureFlagEvaluations.php
@@ -2,6 +2,8 @@
 
 namespace PostHog;
 
+use Closure;
+
 /**
  * Snapshot of feature flag evaluations for a single distinct id.
  *
@@ -13,6 +15,7 @@ class FeatureFlagEvaluations
 {
     /** @var array<string, bool> */
     private array $accessed;
+    private readonly Closure $captureFlagCalled;
 
     /**
      * Create a feature flag evaluation snapshot.
@@ -26,6 +29,7 @@ class FeatureFlagEvaluations
      * @param array<string, bool>|null $accessed Flags already accessed on this snapshot.
      * @param bool $errorsWhileComputing Whether the remote response reported computation errors.
      * @param bool $quotaLimited Whether the remote response was quota limited.
+     * @param Closure|null $captureFlagCalled Emits deduped $feature_flag_called events.
      */
     public function __construct(
         private readonly string $distinctId,
@@ -37,8 +41,11 @@ class FeatureFlagEvaluations
         ?array $accessed = null,
         private readonly bool $errorsWhileComputing = false,
         private readonly bool $quotaLimited = false,
+        ?Closure $captureFlagCalled = null,
     ) {
         $this->accessed = $accessed ?? [];
+        $this->captureFlagCalled = $captureFlagCalled ?? static function (...$_): void {
+        };
     }
 
     /**
@@ -220,7 +227,7 @@ class FeatureFlagEvaluations
             $properties['$feature_flag_error'] = implode(',', $errors);
         }
 
-        $this->host->captureFlagCalledIfNeeded(
+        ($this->captureFlagCalled)(
             $this->distinctId,
             $key,
             $response,

--- a/lib/FeatureFlagEvaluations.php
+++ b/lib/FeatureFlagEvaluations.php
@@ -172,11 +172,12 @@ class FeatureFlagEvaluations
             return;
         }
 
+        $response = $record?->getValue();
         $properties = [
             '$feature_flag' => $key,
             // Missing flags get a null response (not false), matching the legacy single-flag path
             // so consumers can distinguish "flag exists and is disabled" from "flag not found".
-            '$feature_flag_response' => $record?->getValue(),
+            '$feature_flag_response' => $response,
             // Always set explicitly so consumers don't have to infer "missing key means remote".
             'locally_evaluated' => $record?->locallyEvaluated ?? false,
         ];
@@ -222,6 +223,7 @@ class FeatureFlagEvaluations
         $this->host->captureFlagCalledIfNeeded(
             $this->distinctId,
             $key,
+            $response,
             $properties,
             $this->groups
         );

--- a/lib/FeatureFlagEvaluations.php
+++ b/lib/FeatureFlagEvaluations.php
@@ -2,8 +2,6 @@
 
 namespace PostHog;
 
-use Closure;
-
 /**
  * Snapshot of feature flag evaluations for a single distinct id.
  *
@@ -15,7 +13,6 @@ class FeatureFlagEvaluations
 {
     /** @var array<string, bool> */
     private array $accessed;
-    private readonly Closure $captureFlagCalled;
 
     /**
      * Create a feature flag evaluation snapshot.
@@ -29,7 +26,6 @@ class FeatureFlagEvaluations
      * @param array<string, bool>|null $accessed Flags already accessed on this snapshot.
      * @param bool $errorsWhileComputing Whether the remote response reported computation errors.
      * @param bool $quotaLimited Whether the remote response was quota limited.
-     * @param Closure|null $captureFlagCalled Emits deduped $feature_flag_called events.
      */
     public function __construct(
         private readonly string $distinctId,
@@ -41,11 +37,8 @@ class FeatureFlagEvaluations
         ?array $accessed = null,
         private readonly bool $errorsWhileComputing = false,
         private readonly bool $quotaLimited = false,
-        ?Closure $captureFlagCalled = null,
     ) {
         $this->accessed = $accessed ?? [];
-        $this->captureFlagCalled = $captureFlagCalled ?? static function (...$_): void {
-        };
     }
 
     /**
@@ -227,7 +220,7 @@ class FeatureFlagEvaluations
             $properties['$feature_flag_error'] = implode(',', $errors);
         }
 
-        ($this->captureFlagCalled)(
+        $this->host->captureFlagCalledIfNeeded(
             $this->distinctId,
             $key,
             $response,

--- a/lib/FeatureFlagEvaluationsHost.php
+++ b/lib/FeatureFlagEvaluationsHost.php
@@ -13,6 +13,28 @@ namespace PostHog;
 interface FeatureFlagEvaluationsHost
 {
     /**
+     * Fire a $feature_flag_called event for ($distinctId, $key) unless it has already been recorded
+     * for this distinct id within the dedup window.
+     *
+     * The properties array is built by the caller so this helper does not need to reconstruct the
+     * shape from raw response data.
+     *
+     * @param string $distinctId The distinct ID that accessed the flag.
+     * @param string $key Feature flag key.
+     * @param mixed $response Evaluated feature flag response for deduping.
+     * @param array<string, mixed> $properties Event properties for the $feature_flag_called event.
+     * @param array<string, mixed> $groups Group identifiers for group-based flags.
+     * @return void
+     */
+    public function captureFlagCalledIfNeeded(
+        string $distinctId,
+        string $key,
+        $response,
+        array $properties,
+        array $groups
+    ): void;
+
+    /**
      * Emit a non-fatal warning.
      *
      * @param string $message Warning message.

--- a/lib/FeatureFlagEvaluationsHost.php
+++ b/lib/FeatureFlagEvaluationsHost.php
@@ -13,28 +13,6 @@ namespace PostHog;
 interface FeatureFlagEvaluationsHost
 {
     /**
-     * Fire a $feature_flag_called event for ($distinctId, $key) unless it has already been recorded
-     * for this distinct id within the dedup window.
-     *
-     * The properties array is built by the caller so this helper does not need to reconstruct the
-     * shape from raw response data.
-     *
-     * @param string $distinctId The distinct ID that accessed the flag.
-     * @param string $key Feature flag key.
-     * @param mixed $response Evaluated feature flag response for deduping.
-     * @param array<string, mixed> $properties Event properties for the $feature_flag_called event.
-     * @param array<string, mixed> $groups Group identifiers for group-based flags.
-     * @return void
-     */
-    public function captureFlagCalledIfNeeded(
-        string $distinctId,
-        string $key,
-        $response,
-        array $properties,
-        array $groups
-    ): void;
-
-    /**
      * Emit a non-fatal warning.
      *
      * @param string $message Warning message.

--- a/lib/FeatureFlagEvaluationsHost.php
+++ b/lib/FeatureFlagEvaluationsHost.php
@@ -21,6 +21,7 @@ interface FeatureFlagEvaluationsHost
      *
      * @param string $distinctId The distinct ID that accessed the flag.
      * @param string $key Feature flag key.
+     * @param mixed $response Evaluated feature flag response for deduping.
      * @param array<string, mixed> $properties Event properties for the $feature_flag_called event.
      * @param array<string, mixed> $groups Group identifiers for group-based flags.
      * @return void
@@ -28,6 +29,7 @@ interface FeatureFlagEvaluationsHost
     public function captureFlagCalledIfNeeded(
         string $distinctId,
         string $key,
+        $response,
         array $properties,
         array $groups
     ): void;

--- a/test/FakeFlagEvaluationsHost.php
+++ b/test/FakeFlagEvaluationsHost.php
@@ -20,10 +20,14 @@ class FakeFlagEvaluationsHost implements FeatureFlagEvaluationsHost
     public function captureFlagCalledIfNeeded(
         string $distinctId,
         string $key,
+        $response,
         array $properties,
         array $groups
     ): void {
-        $cacheKey = $distinctId . "\0" . $key;
+        $cacheKey = $distinctId
+            . "\0" . $key
+            . "\0" . json_encode($response, JSON_THROW_ON_ERROR)
+            . "\0" . json_encode($groups, JSON_THROW_ON_ERROR);
         if (isset($this->seen[$cacheKey])) {
             return;
         }
@@ -31,6 +35,7 @@ class FakeFlagEvaluationsHost implements FeatureFlagEvaluationsHost
         $this->captures[] = [
             'distinct_id' => $distinctId,
             'key' => $key,
+            'response' => $response,
             'properties' => $properties,
             'groups' => $groups,
         ];

--- a/test/FakeFlagEvaluationsHost.php
+++ b/test/FakeFlagEvaluationsHost.php
@@ -10,36 +10,8 @@ use PostHog\FeatureFlagEvaluationsHost;
  */
 class FakeFlagEvaluationsHost implements FeatureFlagEvaluationsHost
 {
-    /** @var array<int, array<string, mixed>> */
-    public array $captures = [];
     /** @var list<string> */
     public array $warnings = [];
-    /** @var array<string, true> */
-    private array $seen = [];
-
-    public function captureFlagCalledIfNeeded(
-        string $distinctId,
-        string $key,
-        $response,
-        array $properties,
-        array $groups
-    ): void {
-        $cacheKey = $distinctId
-            . "\0" . $key
-            . "\0" . json_encode($response, JSON_THROW_ON_ERROR)
-            . "\0" . json_encode($groups, JSON_THROW_ON_ERROR);
-        if (isset($this->seen[$cacheKey])) {
-            return;
-        }
-        $this->seen[$cacheKey] = true;
-        $this->captures[] = [
-            'distinct_id' => $distinctId,
-            'key' => $key,
-            'response' => $response,
-            'properties' => $properties,
-            'groups' => $groups,
-        ];
-    }
 
     public function logWarning(string $message): void
     {

--- a/test/FakeFlagEvaluationsHost.php
+++ b/test/FakeFlagEvaluationsHost.php
@@ -10,8 +10,36 @@ use PostHog\FeatureFlagEvaluationsHost;
  */
 class FakeFlagEvaluationsHost implements FeatureFlagEvaluationsHost
 {
+    /** @var array<int, array<string, mixed>> */
+    public array $captures = [];
     /** @var list<string> */
     public array $warnings = [];
+    /** @var array<string, true> */
+    private array $seen = [];
+
+    public function captureFlagCalledIfNeeded(
+        string $distinctId,
+        string $key,
+        $response,
+        array $properties,
+        array $groups
+    ): void {
+        $cacheKey = $distinctId
+            . "\0" . $key
+            . "\0" . json_encode($response, JSON_THROW_ON_ERROR)
+            . "\0" . json_encode($groups, JSON_THROW_ON_ERROR);
+        if (isset($this->seen[$cacheKey])) {
+            return;
+        }
+        $this->seen[$cacheKey] = true;
+        $this->captures[] = [
+            'distinct_id' => $distinctId,
+            'key' => $key,
+            'response' => $response,
+            'properties' => $properties,
+            'groups' => $groups,
+        ];
+    }
 
     public function logWarning(string $message): void
     {

--- a/test/FeatureFlagEvaluationsTest.php
+++ b/test/FeatureFlagEvaluationsTest.php
@@ -6,6 +6,7 @@ namespace PostHog\Test;
 // comment out below to print all logs instead of failing tests
 require_once 'test/error_log_mock.php';
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use PostHog\Client;
 use PostHog\EvaluatedFlagRecord;
@@ -563,30 +564,35 @@ class FeatureFlagEvaluationsTest extends TestCase
         $this->assertCount(1, $batches[0]['batch']);
     }
 
-    public function testFeatureFlagCalledDedupesByResponseValue(): void
+    /**
+     * @return array<string, array{list<mixed>, list<mixed>}>
+     */
+    public static function featureFlagCalledResponseDedupCases(): array
+    {
+        return [
+            'true and false' => [[true, false, true, false], [true, false]],
+            'false and true' => [[false, true, false, true], [false, true]],
+            'null and variant' => [[null, 'variant-a', null, 'variant-a'], [null, 'variant-a']],
+            'boolean and matching string' => [[true, 'true', true, 'true'], [true, 'true']],
+        ];
+    }
+
+    /**
+     * @param list<mixed> $responses
+     * @param list<mixed> $expectedResponses
+     */
+    #[DataProvider('featureFlagCalledResponseDedupCases')]
+    public function testFeatureFlagCalledDedupesByResponseValue(array $responses, array $expectedResponses): void
     {
         $this->makeClient();
 
-        $this->client->captureFlagCalledIfNeeded(
-            'user-1',
-            'changing-flag',
-            ['$feature_flag' => 'changing-flag', '$feature_flag_response' => true]
-        );
-        $this->client->captureFlagCalledIfNeeded(
-            'user-1',
-            'changing-flag',
-            ['$feature_flag' => 'changing-flag', '$feature_flag_response' => false]
-        );
-        $this->client->captureFlagCalledIfNeeded(
-            'user-1',
-            'changing-flag',
-            ['$feature_flag' => 'changing-flag', '$feature_flag_response' => true]
-        );
-        $this->client->captureFlagCalledIfNeeded(
-            'user-1',
-            'changing-flag',
-            ['$feature_flag' => 'changing-flag', '$feature_flag_response' => false]
-        );
+        foreach ($responses as $response) {
+            $this->client->captureFlagCalledIfNeeded(
+                'user-1',
+                'changing-flag',
+                ['$feature_flag' => 'changing-flag', '$feature_flag_response' => $response]
+            );
+        }
 
         PostHog::flush();
 
@@ -602,9 +608,11 @@ class FeatureFlagEvaluationsTest extends TestCase
             }
         }
 
-        $this->assertCount(2, $events, 'expected one event for true and one event for false');
-        $this->assertSame(true, $events[0]['properties']['$feature_flag_response']);
-        $this->assertSame(false, $events[1]['properties']['$feature_flag_response']);
+        $this->assertCount(count($expectedResponses), $events, 'unexpected $feature_flag_called event count');
+        $this->assertSame(
+            $expectedResponses,
+            array_map(fn($event) => $event['properties']['$feature_flag_response'], $events)
+        );
     }
 
     public function testFeatureFlagCalledFiresPerGroupContext(): void

--- a/test/FeatureFlagEvaluationsTest.php
+++ b/test/FeatureFlagEvaluationsTest.php
@@ -94,6 +94,34 @@ class FeatureFlagEvaluationsTest extends TestCase
         );
     }
 
+    private function flagsResponseForChangingFlag(mixed $response): array
+    {
+        $flagsResponse = MockedResponses::FLAGS_V2_RESPONSE;
+        unset($flagsResponse['flags']['changing-flag']);
+
+        if ($response === null) {
+            return $flagsResponse;
+        }
+
+        $flagsResponse['flags']['changing-flag'] = [
+            'key' => 'changing-flag',
+            'enabled' => is_bool($response) ? $response : true,
+            'variant' => is_string($response) ? $response : null,
+            'reason' => [
+                'code' => 'condition_match',
+                'description' => 'Matched condition set 1',
+                'condition_index' => 0,
+            ],
+            'metadata' => [
+                'id' => 999,
+                'payload' => null,
+                'version' => 1,
+            ],
+        ];
+
+        return $flagsResponse;
+    }
+
     public function testEvaluateFlagsReturnsSnapshotAndMakesOneFlagsRequest(): void
     {
         $this->makeClient();
@@ -585,14 +613,12 @@ class FeatureFlagEvaluationsTest extends TestCase
     public function testFeatureFlagCalledDedupesByResponseValue(array $responses, array $expectedResponses): void
     {
         $this->makeClient();
+        $this->http_client->setFlagsEndpointResponseQueue(
+            array_map(fn($response) => $this->flagsResponseForChangingFlag($response), $responses)
+        );
 
-        foreach ($responses as $response) {
-            $this->client->captureFlagCalledIfNeeded(
-                'user-1',
-                'changing-flag',
-                $response,
-                ['$feature_flag' => 'changing-flag', '$feature_flag_response' => $response]
-            );
+        foreach ($responses as $_) {
+            PostHog::evaluateFlags('user-1')->getFlag('changing-flag');
         }
 
         PostHog::flush();

--- a/test/FeatureFlagEvaluationsTest.php
+++ b/test/FeatureFlagEvaluationsTest.php
@@ -94,34 +94,6 @@ class FeatureFlagEvaluationsTest extends TestCase
         );
     }
 
-    private function flagsResponseForChangingFlag(mixed $response): array
-    {
-        $flagsResponse = MockedResponses::FLAGS_V2_RESPONSE;
-        unset($flagsResponse['flags']['changing-flag']);
-
-        if ($response === null) {
-            return $flagsResponse;
-        }
-
-        $flagsResponse['flags']['changing-flag'] = [
-            'key' => 'changing-flag',
-            'enabled' => is_bool($response) ? $response : true,
-            'variant' => is_string($response) ? $response : null,
-            'reason' => [
-                'code' => 'condition_match',
-                'description' => 'Matched condition set 1',
-                'condition_index' => 0,
-            ],
-            'metadata' => [
-                'id' => 999,
-                'payload' => null,
-                'version' => 1,
-            ],
-        ];
-
-        return $flagsResponse;
-    }
-
     public function testEvaluateFlagsReturnsSnapshotAndMakesOneFlagsRequest(): void
     {
         $this->makeClient();
@@ -613,12 +585,14 @@ class FeatureFlagEvaluationsTest extends TestCase
     public function testFeatureFlagCalledDedupesByResponseValue(array $responses, array $expectedResponses): void
     {
         $this->makeClient();
-        $this->http_client->setFlagsEndpointResponseQueue(
-            array_map(fn($response) => $this->flagsResponseForChangingFlag($response), $responses)
-        );
 
-        foreach ($responses as $_) {
-            PostHog::evaluateFlags('user-1')->getFlag('changing-flag');
+        foreach ($responses as $response) {
+            $this->client->captureFlagCalledIfNeeded(
+                'user-1',
+                'changing-flag',
+                $response,
+                ['$feature_flag' => 'changing-flag', '$feature_flag_response' => $response]
+            );
         }
 
         PostHog::flush();

--- a/test/FeatureFlagEvaluationsTest.php
+++ b/test/FeatureFlagEvaluationsTest.php
@@ -563,6 +563,50 @@ class FeatureFlagEvaluationsTest extends TestCase
         $this->assertCount(1, $batches[0]['batch']);
     }
 
+    public function testFeatureFlagCalledDedupesByResponseValue(): void
+    {
+        $this->makeClient();
+
+        $this->client->captureFlagCalledIfNeeded(
+            'user-1',
+            'changing-flag',
+            ['$feature_flag' => 'changing-flag', '$feature_flag_response' => true]
+        );
+        $this->client->captureFlagCalledIfNeeded(
+            'user-1',
+            'changing-flag',
+            ['$feature_flag' => 'changing-flag', '$feature_flag_response' => false]
+        );
+        $this->client->captureFlagCalledIfNeeded(
+            'user-1',
+            'changing-flag',
+            ['$feature_flag' => 'changing-flag', '$feature_flag_response' => true]
+        );
+        $this->client->captureFlagCalledIfNeeded(
+            'user-1',
+            'changing-flag',
+            ['$feature_flag' => 'changing-flag', '$feature_flag_response' => false]
+        );
+
+        PostHog::flush();
+
+        $events = [];
+        foreach ($this->batchRequests() as $batch) {
+            foreach ($batch['batch'] as $event) {
+                if (
+                    $event['event'] === '$feature_flag_called'
+                    && ($event['properties']['$feature_flag'] ?? null) === 'changing-flag'
+                ) {
+                    $events[] = $event;
+                }
+            }
+        }
+
+        $this->assertCount(2, $events, 'expected one event for true and one event for false');
+        $this->assertSame(true, $events[0]['properties']['$feature_flag_response']);
+        $this->assertSame(false, $events[1]['properties']['$feature_flag_response']);
+    }
+
     public function testFeatureFlagCalledFiresPerGroupContext(): void
     {
         $this->makeClient();

--- a/test/FeatureFlagEvaluationsTest.php
+++ b/test/FeatureFlagEvaluationsTest.php
@@ -590,6 +590,7 @@ class FeatureFlagEvaluationsTest extends TestCase
             $this->client->captureFlagCalledIfNeeded(
                 'user-1',
                 'changing-flag',
+                $response,
                 ['$feature_flag' => 'changing-flag', '$feature_flag_response' => $response]
             );
         }

--- a/test/MockedHttpClient.php
+++ b/test/MockedHttpClient.php
@@ -15,8 +15,11 @@ class MockedHttpClient extends \PostHog\HttpClient
     private $flagEndpointEtag;
     private $flagEndpointResponseCode;
 
-    /** @var array|null Queue of responses for sequential calls */
+    /** @var array|null Queue of responses for sequential local-evaluation calls */
     private $flagEndpointResponseQueue;
+
+    /** @var array|null Queue of responses for sequential /flags/ calls */
+    private $flagsEndpointResponseQueue;
 
     /** @var int Response code for /flags/ endpoint (for error simulation) */
     private $flagsEndpointResponseCode;
@@ -62,6 +65,7 @@ class MockedHttpClient extends \PostHog\HttpClient
         $this->flagEndpointEtag = $flagEndpointEtag;
         $this->flagEndpointResponseCode = $flagEndpointResponseCode;
         $this->flagEndpointResponseQueue = null;
+        $this->flagsEndpointResponseQueue = null;
         $this->flagsEndpointResponseCode = $flagsEndpointResponseCode;
         $this->flagsEndpointCurlErrno = $flagsEndpointCurlErrno;
         $this->batchEndpointResponse = $batchEndpointResponse;
@@ -78,6 +82,17 @@ class MockedHttpClient extends \PostHog\HttpClient
     public function setFlagEndpointResponseQueue(array $responses): void
     {
         $this->flagEndpointResponseQueue = $responses;
+    }
+
+    /**
+     * Set a queue of responses for the /flags/ endpoint.
+     * Each call will consume the next response in the queue.
+     *
+     * @param array $responses Array of response arrays or ['response' => array, 'responseCode' => int]
+     */
+    public function setFlagsEndpointResponseQueue(array $responses): void
+    {
+        $this->flagsEndpointResponseQueue = $responses;
     }
 
     // phpcs:ignore Generic.Files.LineLength.TooLong
@@ -124,6 +139,14 @@ class MockedHttpClient extends \PostHog\HttpClient
 
         // Decide endpoint: /flags/?v=2
         if (str_starts_with($path, "/flags/?")) {
+            if ($this->flagsEndpointResponseQueue !== null && !empty($this->flagsEndpointResponseQueue)) {
+                $nextResponse = array_shift($this->flagsEndpointResponseQueue);
+                $response = $nextResponse['response'] ?? $nextResponse;
+                $responseCode = $nextResponse['responseCode'] ?? 200;
+
+                return new HttpResponse(json_encode($response), $responseCode);
+            }
+
             return new HttpResponse(
                 json_encode($this->flagsEndpointResponse),
                 $this->flagsEndpointResponseCode,

--- a/test/MockedHttpClient.php
+++ b/test/MockedHttpClient.php
@@ -15,11 +15,8 @@ class MockedHttpClient extends \PostHog\HttpClient
     private $flagEndpointEtag;
     private $flagEndpointResponseCode;
 
-    /** @var array|null Queue of responses for sequential local-evaluation calls */
+    /** @var array|null Queue of responses for sequential calls */
     private $flagEndpointResponseQueue;
-
-    /** @var array|null Queue of responses for sequential /flags/ calls */
-    private $flagsEndpointResponseQueue;
 
     /** @var int Response code for /flags/ endpoint (for error simulation) */
     private $flagsEndpointResponseCode;
@@ -65,7 +62,6 @@ class MockedHttpClient extends \PostHog\HttpClient
         $this->flagEndpointEtag = $flagEndpointEtag;
         $this->flagEndpointResponseCode = $flagEndpointResponseCode;
         $this->flagEndpointResponseQueue = null;
-        $this->flagsEndpointResponseQueue = null;
         $this->flagsEndpointResponseCode = $flagsEndpointResponseCode;
         $this->flagsEndpointCurlErrno = $flagsEndpointCurlErrno;
         $this->batchEndpointResponse = $batchEndpointResponse;
@@ -82,17 +78,6 @@ class MockedHttpClient extends \PostHog\HttpClient
     public function setFlagEndpointResponseQueue(array $responses): void
     {
         $this->flagEndpointResponseQueue = $responses;
-    }
-
-    /**
-     * Set a queue of responses for the /flags/ endpoint.
-     * Each call will consume the next response in the queue.
-     *
-     * @param array $responses Array of response arrays or ['response' => array, 'responseCode' => int]
-     */
-    public function setFlagsEndpointResponseQueue(array $responses): void
-    {
-        $this->flagsEndpointResponseQueue = $responses;
     }
 
     // phpcs:ignore Generic.Files.LineLength.TooLong
@@ -139,14 +124,6 @@ class MockedHttpClient extends \PostHog\HttpClient
 
         // Decide endpoint: /flags/?v=2
         if (str_starts_with($path, "/flags/?")) {
-            if ($this->flagsEndpointResponseQueue !== null && !empty($this->flagsEndpointResponseQueue)) {
-                $nextResponse = array_shift($this->flagsEndpointResponseQueue);
-                $response = $nextResponse['response'] ?? $nextResponse;
-                $responseCode = $nextResponse['responseCode'] ?? 200;
-
-                return new HttpResponse(json_encode($response), $responseCode);
-            }
-
             return new HttpResponse(
                 json_encode($this->flagsEndpointResponse),
                 $this->flagsEndpointResponseCode,


### PR DESCRIPTION
## :bulb: Motivation and Context

Feature flag called events were deduped only by flag key, distinct ID, and group context. If the same user saw a flag response change, later `$feature_flag_called` events could be suppressed even though the response value was different.

## :green_heart: How did you test it?

- `./vendor/bin/phpunit --no-coverage --filter FeatureFlagEvaluationsTest`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

An implementation agent prepared this draft PR from the dedicated `fix/ff-called-value-dedupe` worktree at a human's request. The change keeps the existing feature flag called-event dedupe mechanism, but adds the evaluated response value to the cache key so changed responses emit distinct tracking events.
