### PR TITLE
fix: fall back when payload compression fails

### DIFF
--- a/.changeset/cold-buckets-gzip.md
+++ b/.changeset/cold-buckets-gzip.md
@@ -1,0 +1,5 @@
+---
+'posthog-php': patch
+---
+
+Fall back to uncompressed batch uploads when local gzip compression fails.

--- a/lib/Consumer/ForkCurl.php
+++ b/lib/Consumer/ForkCurl.php
@@ -62,14 +62,17 @@ class ForkCurl extends QueueConsumer
             $cmd2 = "echo " . $payload . " | gzip > " . $tmpfname;
             exec($cmd2, $output, $exit);
 
-            if (0 != $exit) {
+            if (0 == $exit) {
+                $cmd .= " -H 'Content-Encoding: gzip'";
+                $cmd .= " --data-binary '@" . $tmpfname . "'";
+            } else {
                 $this->handleError($exit, $output);
-                return self::FLUSH_BATCH_NON_RETRYABLE_FAILURE;
+                if (is_file($tmpfname)) {
+                    unlink($tmpfname);
+                }
+                $tmpfname = "";
+                $cmd .= " -d " . $payload;
             }
-
-            $cmd .= " -H 'Content-Encoding: gzip'";
-
-            $cmd .= " --data-binary '@" . $tmpfname . "'";
         } else {
             $cmd .= " -d " . $payload;
         }

--- a/lib/Consumer/LibCurl.php
+++ b/lib/Consumer/LibCurl.php
@@ -81,6 +81,13 @@ class LibCurl extends QueueConsumer
         }
 
         $shouldVerify = $this->options['verify_batch_events_request'] ?? true;
+        $requestOptions = [
+            'shouldVerify' => $shouldVerify,
+        ];
+        if ($this->compress_request) {
+            $requestOptions['compressRequest'] = $isCompressed;
+        }
+
         $response = $this->httpClient->sendRequest(
             '/batch/',
             $payload,
@@ -88,10 +95,7 @@ class LibCurl extends QueueConsumer
                 // Send user agent in the form of {library_name}/{library_version} as per RFC 7231.
                 "User-Agent: {$this->userAgent()}",
             ],
-            [
-                'shouldVerify' => $shouldVerify,
-                'compressRequest' => $isCompressed,
-            ]
+            $requestOptions
         );
 
         if (!$shouldVerify) {

--- a/lib/Consumer/LibCurl.php
+++ b/lib/Consumer/LibCurl.php
@@ -68,11 +68,13 @@ class LibCurl extends QueueConsumer
             return self::FLUSH_BATCH_NON_RETRYABLE_FAILURE;
         }
 
+        $isCompressed = false;
         if ($this->compress_request) {
-            $payload = gzencode($payload);
+            $compressedPayload = gzencode($payload);
 
-            if (false === $payload) {
-                return self::FLUSH_BATCH_NON_RETRYABLE_FAILURE;
+            if (false !== $compressedPayload) {
+                $payload = $compressedPayload;
+                $isCompressed = true;
             }
         }
 
@@ -86,6 +88,7 @@ class LibCurl extends QueueConsumer
             ],
             [
                 'shouldVerify' => $shouldVerify,
+                'compressRequest' => $isCompressed,
             ]
         );
 

--- a/lib/Consumer/LibCurl.php
+++ b/lib/Consumer/LibCurl.php
@@ -75,6 +75,8 @@ class LibCurl extends QueueConsumer
             if (false !== $compressedPayload) {
                 $payload = $compressedPayload;
                 $isCompressed = true;
+            } else {
+                $this->handleError(0, "Failed to gzip batch payload; sending uncompressed.");
             }
         }
 

--- a/lib/Consumer/Socket.php
+++ b/lib/Consumer/Socket.php
@@ -196,15 +196,15 @@ class Socket extends QueueConsumer
         // Send user agent in the form of {library_name}/{library_version} as per RFC 7231.
         $req .= "User-Agent: " . $this->userAgent() . "\r\n";
 
-        // Compress content if compress_request is true
+        // Compress content if compress_request is true. If local compression fails,
+        // keep sending the original uncompressed payload.
         if ($this->compress_request) {
-            $content = gzencode($content);
+            $compressedContent = gzencode($content);
 
-            if (false === $content) {
-                return false;
+            if (false !== $compressedContent) {
+                $content = $compressedContent;
+                $req .= "Content-Encoding: gzip\r\n";
             }
-
-            $req .= "Content-Encoding: gzip\r\n";
         }
 
         $req .= "Content-length: " . strlen($content) . "\r\n";

--- a/lib/Consumer/Socket.php
+++ b/lib/Consumer/Socket.php
@@ -204,6 +204,8 @@ class Socket extends QueueConsumer
             if (false !== $compressedContent) {
                 $content = $compressedContent;
                 $req .= "Content-Encoding: gzip\r\n";
+            } else {
+                $this->handleError(0, "Failed to gzip batch payload; sending uncompressed.");
             }
         }
 

--- a/lib/HttpClient.php
+++ b/lib/HttpClient.php
@@ -98,6 +98,7 @@ class HttpClient
         $shouldRetry = $requestOptions['shouldRetry'] ?? true;
         $shouldVerify = $requestOptions['shouldVerify'] ?? true;
         $includeEtag = $requestOptions['includeEtag'] ?? false;
+        $compressRequest = $requestOptions['compressRequest'] ?? $this->compressRequests;
 
         do {
             // open connection
@@ -109,7 +110,7 @@ class HttpClient
 
             $headers = [];
             $headers[] = 'Content-Type: application/json';
-            if ($this->compressRequests) {
+            if ($compressRequest) {
                 $headers[] = 'Content-Encoding: gzip';
             }
 

--- a/lib/HttpClient.php
+++ b/lib/HttpClient.php
@@ -84,7 +84,8 @@ class HttpClient
      *     shouldRetry?: bool,
      *     shouldVerify?: bool,
      *     includeEtag?: bool,
-     *     timeout?: int
+     *     timeout?: int,
+     *     compressRequest?: bool
      * } $requestOptions
      * @return HttpResponse
      */


### PR DESCRIPTION
## :bulb: Motivation and Context

When `compress_request` is enabled, local gzip failures should not cause the batch to fail or be dropped before the request is sent. The SDK should send the original payload uncompressed instead.

This updates the curl, socket, and forked curl consumers to fall back to the original payload when compression fails, and lets the shared HTTP client omit `Content-Encoding: gzip` for that fallback request.

## :green_heart: How did you test it?

- `composer install --no-interaction --no-progress`
- `./vendor/bin/phpunit --no-coverage test/QueueConsumerTest.php test/ConsumerLibCurlTest.php test/ConsumerSocketTest.php test/ConsumerForkCurlTest.php`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented as part of a cross-SDK consistency pass for client-side compression failure fallback. Kept the change limited to existing compression-enabled batch upload paths.
