### PR TITLE
chore: move release workflow note to changeset

### DIFF
--- a/.changeset/harden-automated-release-workflow.md
+++ b/.changeset/harden-automated-release-workflow.md
@@ -1,0 +1,5 @@
+---
+"posthog-php": patch
+---
+
+Harden the automated release workflow.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### Patch Changes
 
 - b1a5645: Retry capture delivery on transient HTTP errors and respect Retry-After responses.
-- a6da214: Harden the automated release workflow.
 
 ## 4.8.6
 


### PR DESCRIPTION
## :bulb: Motivation and Context

The 4.8.7 changelog included the automated release workflow hardening note directly. This moves that unreleased release-process change back into a changeset so it can be picked up by the next release.

## :green_heart: How did you test it?

- Ran `git diff --check`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This PR was prepared with pi. The change removes the release workflow hardening note from the already-published 4.8.7 changelog section and adds it as a new changeset entry for a future patch release.
