### PR TITLE
fix: make feature flag local tests deterministic

### DIFF
--- a/.changeset/calm-flags-compare.md
+++ b/.changeset/calm-flags-compare.md
@@ -1,0 +1,5 @@
+---
+'posthog-php': patch
+---
+
+Make feature flag local evaluation tests deterministic.

--- a/.changeset/calm-flags-compare.md
+++ b/.changeset/calm-flags-compare.md
@@ -1,5 +1,0 @@
----
-'posthog-php': patch
----
-
-Make feature flag local evaluation tests deterministic.

--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -14,4 +14,4 @@ jobs:
             pr_number: ${{ github.event.pull_request.number }}
             pr_node_id: ${{ github.event.pull_request.node_id }}
             is_draft: ${{ github.event.pull_request.draft }}
-        secrets: inherit
+        secrets: inherit # nosemgrep: yaml.github-actions.security.secrets-inherit.secrets-inherit -- reusable workflow requires inherited secrets

--- a/test/FeatureFlagLocalEvaluationTest.php
+++ b/test/FeatureFlagLocalEvaluationTest.php
@@ -29,7 +29,6 @@ class FeatureFlagLocalEvaluationTest extends TestCase
 
         // This class verifies legacy single-flag local evaluation behavior. Deprecation
         // messages for those methods are asserted in FeatureFlagEvaluationsTest.
-        $previous = null;
         $previous = set_error_handler(
             function (int $errno, string $errstr) use (&$previous) {
                 if ($errno === E_USER_DEPRECATED && $this->isLegacyFeatureFlagDeprecation($errstr)) {

--- a/test/FeatureFlagLocalEvaluationTest.php
+++ b/test/FeatureFlagLocalEvaluationTest.php
@@ -27,9 +27,39 @@ class FeatureFlagLocalEvaluationTest extends TestCase
     {
         date_default_timezone_set("UTC");
 
+        // This class verifies legacy single-flag local evaluation behavior. Deprecation
+        // messages for those methods are asserted in FeatureFlagEvaluationsTest.
+        $previous = null;
+        $previous = set_error_handler(
+            function (int $errno, string $errstr) use (&$previous) {
+                if ($errno === E_USER_DEPRECATED && $this->isLegacyFeatureFlagDeprecation($errstr)) {
+                    return true;
+                }
+
+                if ($previous !== null) {
+                    return $previous($errno, $errstr);
+                }
+
+                return false;
+            },
+            E_USER_DEPRECATED
+        );
+
         // Reset the errorMessages array before each test
         global $errorMessages;
         $errorMessages = [];
+    }
+
+    public function tearDown(): void
+    {
+        restore_error_handler();
+    }
+
+    private function isLegacyFeatureFlagDeprecation(string $message): bool
+    {
+        return str_contains($message, 'Client::getFeatureFlag() is deprecated')
+            || str_contains($message, 'Client::isFeatureEnabled() is deprecated')
+            || str_contains($message, 'Client::getFeatureFlagPayload() is deprecated');
     }
 
     public function checkEmptyErrorLogs(): void
@@ -38,22 +68,51 @@ class FeatureFlagLocalEvaluationTest extends TestCase
         $this->assertTrue(empty($errorMessages), "Error logs are not empty: " . implode("\n", $errorMessages));
     }
 
-    private function assertAndStripBatchUuid(int $callIndex): void
+    private function assertHttpCallsEqual(array $expectedCalls): void
     {
-        $payload = json_decode($this->http_client->calls[$callIndex]['payload'], true);
-        $this->assertIsArray($payload);
-        $this->assertArrayHasKey('batch', $payload);
+        $this->assertEquals(
+            $this->normalizeHttpCalls($expectedCalls, false),
+            $this->normalizeHttpCalls($this->http_client->calls ?? [], true)
+        );
+    }
 
-        foreach ($payload['batch'] as $index => $event) {
-            $this->assertArrayHasKey('uuid', $event);
-            $this->assertMatchesRegularExpression(
-                '/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i',
-                $event['uuid']
-            );
-            unset($payload['batch'][$index]['uuid']);
+    private function normalizeHttpCalls(array $calls, bool $assertBatchUuids): array
+    {
+        foreach ($calls as $callIndex => $call) {
+            if (!isset($call['payload']) || !is_string($call['payload'])) {
+                continue;
+            }
+
+            $payload = json_decode($call['payload'], true);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                continue;
+            }
+
+            if (isset($payload['batch']) && is_array($payload['batch'])) {
+                foreach ($payload['batch'] as $eventIndex => $event) {
+                    if (!is_array($event)) {
+                        continue;
+                    }
+
+                    if (!array_key_exists('uuid', $event)) {
+                        if ($assertBatchUuids) {
+                            $this->fail('Expected batch event to include a UUID');
+                        }
+                        continue;
+                    }
+
+                    $this->assertMatchesRegularExpression(
+                        '/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i',
+                        $event['uuid']
+                    );
+                    unset($payload['batch'][$eventIndex]['uuid']);
+                }
+            }
+
+            $calls[$callIndex]['payload'] = $payload;
         }
 
-        $this->http_client->calls[$callIndex]['payload'] = json_encode($payload);
+        return $calls;
     }
 
     public function testMatchPropertyEquals(): void
@@ -1460,9 +1519,7 @@ class FeatureFlagLocalEvaluationTest extends TestCase
 
             PostHog::flush();
 
-            $this->assertAndStripBatchUuid(1);
-            $this->assertEquals(
-                $this->http_client->calls,
+            $this->assertHttpCallsEqual(
                 array(
                     0 => array(
                         "path" => "/flags/definitions?send_cohorts&token=random_key",
@@ -1708,8 +1765,7 @@ class FeatureFlagLocalEvaluationTest extends TestCase
         );
         # since 'other' is negated, we return False. Since 'nation' is not present, we can't tell whether the flag should be true or false, so go to decide
         $this->assertEquals($feature_flag_match, 'decide-fallback-value');
-        $this->assertEquals(
-            $this->http_client->calls,
+        $this->assertHttpCallsEqual(
             array(
                 0 => array(
                     "path" => "/flags/?v=2",


### PR DESCRIPTION
## :bulb: Motivation and Context

Feature flag local evaluation assertions were brittle in CI because they compared raw JSON payload strings. Generated UUIDs and payload serialization details can differ by environment, making failures appear in PHP 8.2/8.3/8.4 even when behavior is correct.

Semgrep also flagged the existing `secrets: inherit` usage in the feature flags project board workflow. This mirrors PostHog/posthog-js#4034: the reusable workflow currently requires inherited secrets, so the finding is suppressed inline with context.

## :green_heart: How did you test it?

- `./vendor/bin/phpcs --standard=phpcs.xml test/FeatureFlagLocalEvaluationTest.php`
- `./vendor/bin/phpunit --bootstrap vendor/autoload.php --configuration phpunit.xml --filter FeatureFlagLocalEvaluationTest --no-coverage`
- `./vendor/bin/phpunit --bootstrap vendor/autoload.php --configuration phpunit.xml --no-coverage`
- `docker run ... semgrep --config /rules/.semgrep/rules/ --config p/owasp-top-ten --config p/security-audit --config p/trailofbits --config p/github-actions ... --error --metrics=off .github/`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The pi coding agent made the feature flag local evaluation test assertions deterministic by normalizing JSON payloads before comparing mocked HTTP calls, validating generated batch UUIDs without comparing their random values, and suppressing expected legacy feature-flag deprecations inside this legacy behavior test class. Deprecation-specific behavior remains covered by the dedicated deprecation tests.

After CI reported the same Semgrep `secrets: inherit` finding handled in PostHog/posthog-js#4034, the agent applied the same inline `nosemgrep` suppression to the feature flags project board workflow because the called reusable workflow requires inherited secrets today.
