### PR TITLE
fix: stop duplicating distinct_id in flags person properties

### DIFF
--- a/.changeset/quiet-wolves-fix.md
+++ b/.changeset/quiet-wolves-fix.md
@@ -1,0 +1,5 @@
+---
+"posthog-php": patch
+---
+
+Stop duplicating `distinct_id` inside `/flags` person properties.

--- a/.github/workflows/sdk-compliance.yml
+++ b/.github/workflows/sdk-compliance.yml
@@ -14,8 +14,8 @@ on:
 jobs:
   compliance:
     name: PostHog SDK compliance tests
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@68498bcf3ae95ac941476e6ca3d42d6086e1c7fd
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@02c049e529001d02f37a534745678e057d371fb0
     with:
       adapter-dockerfile: "sdk_compliance_adapter/Dockerfile"
       adapter-context: "."
-      test-harness-version: "0.9.0"
+      test-harness-version: "0.10.0"

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -624,7 +624,6 @@ class Client implements FeatureFlagEvaluationsHost
         }
 
         [$personProperties, $groupProperties] = $this->addLocalPersonAndGroupProperties(
-            $distinctId,
             $groups,
             $personProperties,
             $groupProperties
@@ -822,7 +821,6 @@ class Client implements FeatureFlagEvaluationsHost
         }
 
         [$personProperties, $groupProperties] = $this->addLocalPersonAndGroupProperties(
-            $distinctId,
             $groups,
             $personProperties,
             $groupProperties
@@ -906,7 +904,6 @@ class Client implements FeatureFlagEvaluationsHost
         }
 
         [$personProperties, $groupProperties] = $this->addLocalPersonAndGroupProperties(
-            $distinctId,
             $groups,
             $personProperties,
             $groupProperties
@@ -2086,13 +2083,10 @@ class Client implements FeatureFlagEvaluationsHost
     }
 
     private function addLocalPersonAndGroupProperties(
-        string $distinctId,
         array $groups,
         array $personProperties,
         array $groupProperties
     ): array {
-        $allPersonProperties = $personProperties;
-
         $allGroupProperties = [];
         if (count($groups) > 0) {
             foreach ($groups as $groupName => $groupValue) {
@@ -2103,6 +2097,6 @@ class Client implements FeatureFlagEvaluationsHost
             }
         }
 
-        return [$allPersonProperties, $allGroupProperties];
+        return [$personProperties, $allGroupProperties];
     }
 }

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -1183,10 +1183,15 @@ class Client implements FeatureFlagEvaluationsHost
                 $this->groupTypeMapping
             );
         } else {
+            $localPersonProperties = $personProperties;
+            if (!array_key_exists('distinct_id', $localPersonProperties)) {
+                $localPersonProperties['distinct_id'] = $distinctId;
+            }
+
             return FeatureFlag::matchFeatureFlagProperties(
                 $featureFlag,
                 $distinctId,
-                $personProperties,
+                $localPersonProperties,
                 $this->cohorts,
                 $this->featureFlagsByKey,
                 $evaluationCache,

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -2091,10 +2091,7 @@ class Client implements FeatureFlagEvaluationsHost
         array $personProperties,
         array $groupProperties
     ): array {
-        $allPersonProperties = array_merge(
-            ["distinct_id" => $distinctId],
-            $personProperties
-        );
+        $allPersonProperties = $personProperties;
 
         $allGroupProperties = [];
         if (count($groups) > 0) {

--- a/sdk_compliance_adapter/docker-compose.yml
+++ b/sdk_compliance_adapter/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - test-network
 
   test-harness:
-    image: ghcr.io/posthog/sdk-test-harness:0.9.0
+    image: ghcr.io/posthog/sdk-test-harness:0.10.0
     command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081"]
     networks:
       - test-network

--- a/test/FeatureFlagLocalEvaluationTest.php
+++ b/test/FeatureFlagLocalEvaluationTest.php
@@ -1135,6 +1135,47 @@ class FeatureFlagLocalEvaluationTest extends TestCase
         $this->checkEmptyErrorLogs();
     }
 
+    public function testFlagDistinctIdPropertyIsAvailableForLocalEvaluationOnly()
+    {
+        $localEvaluationResponse = MockedResponses::LOCAL_EVALUATION_SIMPLE_REQUEST;
+        $localEvaluationResponse['flags'][0]['key'] = 'distinct-id-flag';
+        $localEvaluationResponse['flags'][0]['filters']['groups'][0]['properties'] = [
+            [
+                'key' => 'distinct_id',
+                'operator' => 'exact',
+                'value' => 'some-distinct-id',
+                'type' => 'person',
+            ],
+        ];
+
+        $this->http_client = new MockedHttpClient(host: "app.posthog.com", flagEndpointResponse: $localEvaluationResponse);
+        $this->client = new Client(
+            self::FAKE_API_KEY,
+            [
+                "debug" => true,
+            ],
+            $this->http_client,
+            "test"
+        );
+        PostHog::init(null, null, $this->client);
+        $this->http_client->calls = array();
+
+        $personProperties = ['region' => 'USA'];
+        $this->assertTrue(PostHog::getFeatureFlag(
+            'distinct-id-flag',
+            'some-distinct-id',
+            [],
+            $personProperties,
+            [],
+            true,
+            false
+        ));
+        $this->assertEquals(['region' => 'USA'], $personProperties);
+        $this->assertEquals(array(), $this->http_client->calls);
+
+        $this->checkEmptyErrorLogs();
+    }
+
     public function testFlagPersonBooleanProperties()
     {
         $this->http_client = new MockedHttpClient(host: "app.posthog.com", flagEndpointResponse: MockedResponses::LOCAL_EVALUATION_BOOLEAN_REQUEST);

--- a/test/FeatureFlagLocalEvaluationTest.php
+++ b/test/FeatureFlagLocalEvaluationTest.php
@@ -1768,7 +1768,7 @@ class FeatureFlagLocalEvaluationTest extends TestCase
             array(
                 0 => array(
                     "path" => "/flags/?v=2",
-                    'payload' => '{"api_key":"random_key","distinct_id":"some-distinct-id","groups":{},"person_properties":{"distinct_id":"some-distinct-id","region":"USA","other":"thing"},"group_properties":{},"geoip_disable":false,"flag_keys_to_evaluate":["beta-feature"]}',
+                    'payload' => '{"api_key":"random_key","distinct_id":"some-distinct-id","groups":{},"person_properties":{"region":"USA","other":"thing"},"group_properties":{},"geoip_disable":false,"flag_keys_to_evaluate":["beta-feature"]}',
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),
                 ),

--- a/test/FeatureFlagTest.php
+++ b/test/FeatureFlagTest.php
@@ -251,7 +251,7 @@ class FeatureFlagTest extends TestCase
                 ),
                 1 => array(
                     "path" => "/flags/?v=2",
-                    "payload" => sprintf('{"api_key":"%s","distinct_id":"user-id","groups":{},"person_properties":{"distinct_id":"user-id"},"group_properties":{},"geoip_disable":false,"flag_keys_to_evaluate":["having_fun"]}', self::FAKE_API_KEY),
+                    "payload" => sprintf('{"api_key":"%s","distinct_id":"user-id","groups":{},"person_properties":{},"group_properties":{},"geoip_disable":false,"flag_keys_to_evaluate":["having_fun"]}', self::FAKE_API_KEY),
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),
                 ),
@@ -271,7 +271,7 @@ class FeatureFlagTest extends TestCase
                 array(
                 0 => array(
                     "path" => "/flags/?v=2",
-                    "payload" => sprintf('{"api_key":"%s","distinct_id":"user-id","groups":{},"person_properties":{"distinct_id":"user-id"},"group_properties":{},"geoip_disable":false,"flag_keys_to_evaluate":["simple-test"]}', self::FAKE_API_KEY),
+                    "payload" => sprintf('{"api_key":"%s","distinct_id":"user-id","groups":{},"person_properties":{},"group_properties":{},"geoip_disable":false,"flag_keys_to_evaluate":["simple-test"]}', self::FAKE_API_KEY),
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                         "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),
                     ),
@@ -294,7 +294,7 @@ class FeatureFlagTest extends TestCase
             [
                 [
                     "path" => "/flags/?v=2",
-                    "payload" => sprintf('{"api_key":"%s","distinct_id":"user-id","groups":{},"person_properties":{"distinct_id":"user-id"},"group_properties":{},"geoip_disable":false,"flag_keys_to_evaluate":["simple-test"]}', self::FAKE_API_KEY),
+                    "payload" => sprintf('{"api_key":"%s","distinct_id":"user-id","groups":{},"person_properties":{},"group_properties":{},"geoip_disable":false,"flag_keys_to_evaluate":["simple-test"]}', self::FAKE_API_KEY),
                     "extraHeaders" => [0 => 'User-Agent: posthog-php/' . PostHog::VERSION],
                     "requestOptions" => ["timeout" => 3000, "shouldRetry" => false],
                 ],
@@ -323,7 +323,7 @@ class FeatureFlagTest extends TestCase
                 1 => array(
                     "path" => "/flags/?v=2",
                     "payload" => sprintf(
-                        '{"api_key":"%s","distinct_id":"user-id","groups":{"company":"id:5"},"person_properties":{"distinct_id":"user-id"},"group_properties":{"company":{"$group_key":"id:5"}},"geoip_disable":false,"flag_keys_to_evaluate":["having_fun"]}',
+                        '{"api_key":"%s","distinct_id":"user-id","groups":{"company":"id:5"},"person_properties":{},"group_properties":{"company":{"$group_key":"id:5"}},"geoip_disable":false,"flag_keys_to_evaluate":["having_fun"]}',
                         self::FAKE_API_KEY
                     ),
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
@@ -351,7 +351,7 @@ class FeatureFlagTest extends TestCase
                 ),
                 1 => array(
                     "path" => "/flags/?v=2",
-                    "payload" => sprintf('{"api_key":"%s","distinct_id":"user-id","groups":{},"person_properties":{"distinct_id":"user-id"},"group_properties":{},"geoip_disable":false,"flag_keys_to_evaluate":["multivariate-test"]}', self::FAKE_API_KEY),
+                    "payload" => sprintf('{"api_key":"%s","distinct_id":"user-id","groups":{},"person_properties":{},"group_properties":{},"geoip_disable":false,"flag_keys_to_evaluate":["multivariate-test"]}', self::FAKE_API_KEY),
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),
                 ),
@@ -371,7 +371,7 @@ class FeatureFlagTest extends TestCase
                 array(
                 0 => array(
                     "path" => "/flags/?v=2",
-                    "payload" => sprintf('{"api_key":"%s","distinct_id":"user-id","groups":{},"person_properties":{"distinct_id":"user-id"},"group_properties":{},"geoip_disable":false,"flag_keys_to_evaluate":["multivariate-test"]}', self::FAKE_API_KEY),
+                    "payload" => sprintf('{"api_key":"%s","distinct_id":"user-id","groups":{},"person_properties":{},"group_properties":{},"geoip_disable":false,"flag_keys_to_evaluate":["multivariate-test"]}', self::FAKE_API_KEY),
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),
                 ),
@@ -420,7 +420,7 @@ class FeatureFlagTest extends TestCase
                 1 => array(
                     "path" => "/flags/?v=2",
                     "payload" => sprintf(
-                        '{"api_key":"%s","distinct_id":"user-id","groups":{"company":"id:5"},"person_properties":{"distinct_id":"user-id"},"group_properties":{"company":{"$group_key":"id:5"}},"geoip_disable":false,"flag_keys_to_evaluate":["multivariate-test"]}',
+                        '{"api_key":"%s","distinct_id":"user-id","groups":{"company":"id:5"},"person_properties":{},"group_properties":{"company":{"$group_key":"id:5"}},"geoip_disable":false,"flag_keys_to_evaluate":["multivariate-test"]}',
                         self::FAKE_API_KEY
                     ),
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -1298,7 +1298,7 @@ class PostHogTest extends TestCase
                 ),
                 1 => array(
                     "path" => "/flags/?v=2",
-                    "payload" => sprintf('{"api_key":"%s","distinct_id":"some_id","groups":{"company":"id:5","instance":"app.posthog.com"},"person_properties":{"distinct_id":"some_id","x1":"y1"},"group_properties":{"company":{"$group_key":"id:5","x":"y"},"instance":{"$group_key":"app.posthog.com"}},"geoip_disable":false,"flag_keys_to_evaluate":["random_key"]}', self::FAKE_API_KEY),
+                    "payload" => sprintf('{"api_key":"%s","distinct_id":"some_id","groups":{"company":"id:5","instance":"app.posthog.com"},"person_properties":{"x1":"y1"},"group_properties":{"company":{"$group_key":"id:5","x":"y"},"instance":{"$group_key":"app.posthog.com"}},"geoip_disable":false,"flag_keys_to_evaluate":["random_key"]}', self::FAKE_API_KEY),
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),
                 ),
@@ -1336,7 +1336,7 @@ class PostHogTest extends TestCase
             array(
                 0 => array(
                     "path" => "/flags/?v=2",
-                    "payload" => sprintf('{"api_key":"%s","distinct_id":"some_id","groups":{"company":"id:5"},"person_properties":{"distinct_id":"some_id"},"group_properties":{"company":{"$group_key":"id:5"}},"geoip_disable":false,"flag_keys_to_evaluate":["random_key"]}', self::FAKE_API_KEY),
+                    "payload" => sprintf('{"api_key":"%s","distinct_id":"some_id","groups":{"company":"id:5"},"person_properties":{},"group_properties":{"company":{"$group_key":"id:5"}},"geoip_disable":false,"flag_keys_to_evaluate":["random_key"]}', self::FAKE_API_KEY),
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),
                 ),
@@ -1352,7 +1352,7 @@ class PostHogTest extends TestCase
             array(
                 0 => array(
                     "path" => "/flags/?v=2",
-                    "payload" => sprintf('{"api_key":"%s","distinct_id":"some_id","groups":{"company":"id:5","instance":"app.posthog.com"},"person_properties":{"distinct_id":"some_id","x1":"y1"},"group_properties":{"company":{"$group_key":"id:5","x":"y"},"instance":{"$group_key":"app.posthog.com"}},"geoip_disable":false,"flag_keys_to_evaluate":["random_key"]}', self::FAKE_API_KEY),
+                    "payload" => sprintf('{"api_key":"%s","distinct_id":"some_id","groups":{"company":"id:5","instance":"app.posthog.com"},"person_properties":{"x1":"y1"},"group_properties":{"company":{"$group_key":"id:5","x":"y"},"instance":{"$group_key":"app.posthog.com"}},"geoip_disable":false,"flag_keys_to_evaluate":["random_key"]}', self::FAKE_API_KEY),
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array("timeout" => 3000, "shouldRetry" => false),
                 ),


### PR DESCRIPTION
## :bulb: Motivation and Context
`/flags` requests already send `distinct_id` at the top level. Automatically copying the same value into `person_properties.distinct_id` sends duplicated identity data and differs from the desired payload shape.

This PR keeps the top-level `distinct_id` and stops automatically injecting it into `person_properties`. Caller-provided person properties are still forwarded.

## :green_heart: How did you test it?

- `vendor/bin/phpunit (tests passed; command exited 1 because PHPUnit reported no coverage driver plus warnings/deprecations)`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This was implemented with pi in dedicated git worktrees. I changed the /flags request construction so SDKs keep the top-level distinct_id while no longer auto-copying it into person_properties; explicit caller-provided person_properties['distinct_id'] values are still preserved where covered.
