### PR TITLE
ci: mark release approval Slack message

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,6 +281,16 @@ jobs:
       actions: read
       contents: read
     steps:
+      - name: Notify Slack - Approved
+        if: needs.notify-approval-needed.outputs.slack_ts != ''
+        uses: posthog/.github/.github/actions/slack-thread-reply@cb0979b67dcd585828b61ac45927eef4da8f6287 # main
+        with:
+          slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
+          slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
+          thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
+          message: "✅ Release approved! Publishing release..."
+          emoji_reaction: "white_check_mark"
+
       - name: Checkout approved source revision
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
## :bulb: Motivation and Context

The PHP release workflow sends the shared `notify-approval-needed` Slack message, but unlike the other SDK release workflows it did not mark that Slack thread with a checkmark once the GitHub environment approval was granted.

This adds the same approved Slack reply/reaction step used by the other SDKs after the `Release` environment gate opens.

## :green_heart: How did you test it?

Parsed `.github/workflows/release.yml` successfully as YAML.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A pi coding agent made this surgical workflow update at the user's request. The change mirrors the Slack approval acknowledgement pattern already present in other PostHog SDK release workflows and intentionally avoids adding a changeset because this is CI-only behavior.
