### PR TITLE
feat: canonical bottom-up stack frame order for error tracking

### DIFF
--- a/.changeset/canonical-frame-order.md
+++ b/.changeset/canonical-frame-order.md
@@ -1,0 +1,5 @@
+---
+"posthog-php": minor
+---
+
+Emit error tracking stack frames in the canonical bottom-up order: `stacktrace.frames[0]` is now the outermost/entry-point call and the last frame is the crash site. This aligns the PHP SDK with the cross-SDK stack frame ordering standard.

--- a/lib/ExceptionPayloadBuilder.php
+++ b/lib/ExceptionPayloadBuilder.php
@@ -153,8 +153,9 @@ class ExceptionPayloadBuilder
             && !self::isDeclarationLineForFirstFrame($exception, $trace[0])
         ) {
             // Many PHP exceptions report the throw site in getFile()/getLine() but omit it
-            // from getTrace()[0]. Prepending a synthetic top frame keeps the first frame aligned
-            // with the highlighted source location in PostHog.
+            // from getTrace()[0]. Prepending a synthetic frame at the innermost end keeps the
+            // crash site aligned with the highlighted source location in PostHog (it becomes the
+            // last frame once buildStacktrace reverses the trace into canonical bottom-up order).
             array_unshift($trace, array_filter([
                 'file'     => $exception->getFile(),
                 'line'     => $exception->getLine(),
@@ -231,6 +232,11 @@ class ExceptionPayloadBuilder
         }
 
         $frames = array_values(array_filter($frames));
+
+        // PHP traces are innermost-first (crash site at index 0). PostHog's canonical wire order is
+        // bottom-up: frames[0] is the outermost/entry-point call and the last frame is the crash
+        // site. Slicing before reversing keeps the maxFrames most-relevant (crash-site) frames.
+        $frames = array_reverse($frames);
 
         return [
             'type'   => 'raw',

--- a/test/ExceptionCaptureTest.php
+++ b/test/ExceptionCaptureTest.php
@@ -241,12 +241,16 @@ PHP, 255, false);
                 $event['properties']['$exception_list'][0]['mechanism']
             );
             $this->assertSame('ErrorException', $event['properties']['$exception_list'][0]['type']);
-            $this->assertSame('trigger_error', $frames[0]['function']);
-            $this->assertSame(__FILE__, $frames[0]['abs_path']);
-            $this->assertSame($triggerLine, $frames[0]['lineno']);
-            $this->assertSame(__CLASS__ . '->triggerWarningHelper', $frames[1]['function']);
-            $this->assertSame(__FILE__, $frames[1]['abs_path']);
-            $this->assertSame($callSiteLine, $frames[1]['lineno']);
+            // Canonical bottom-up order: the crash site (trigger_error) is the last frame and its
+            // caller sits just before it.
+            $crashFrame = $frames[count($frames) - 1];
+            $callerFrame = $frames[count($frames) - 2];
+            $this->assertSame('trigger_error', $crashFrame['function']);
+            $this->assertSame(__FILE__, $crashFrame['abs_path']);
+            $this->assertSame($triggerLine, $crashFrame['lineno']);
+            $this->assertSame(__CLASS__ . '->triggerWarningHelper', $callerFrame['function']);
+            $this->assertSame(__FILE__, $callerFrame['abs_path']);
+            $this->assertSame($callSiteLine, $callerFrame['lineno']);
             $this->assertFalse($this->framesContainFunction($frames, ExceptionCapture::class . '::handleError'));
         } finally {
             error_reporting($previousReporting);

--- a/test/ExceptionPayloadBuilderTest.php
+++ b/test/ExceptionPayloadBuilderTest.php
@@ -153,8 +153,9 @@ class ExceptionPayloadBuilderTest extends TestCase
         [$exception, $throwLine] = $this->throwHelperWithKnownLine();
         $result = ExceptionPayloadBuilder::buildExceptionList($exception);
 
+        // Canonical bottom-up order: the crash site (most recent frame) is the last frame.
         $frames = $result[0]['stacktrace']['frames'];
-        $frame = $frames[0];
+        $frame = $frames[count($frames) - 1];
 
         $this->assertEquals(__FILE__, $frame['abs_path']);
         $this->assertEquals($throwLine, $frame['lineno']);
@@ -165,9 +166,10 @@ class ExceptionPayloadBuilderTest extends TestCase
         [$exception, $throwLine, $callerLine] = $this->nestedThrowHelperWithKnownLines();
         $result = ExceptionPayloadBuilder::buildExceptionList($exception);
 
+        // Canonical bottom-up order: the innermost (crash) frame is last, its caller sits just before it.
         $frames = array_values($result[0]['stacktrace']['frames']);
-        $innermostFrame = $frames[0];
-        $callerFrame = $frames[1];
+        $innermostFrame = $frames[count($frames) - 1];
+        $callerFrame = $frames[count($frames) - 2];
 
         $this->assertEquals(__FILE__, $innermostFrame['abs_path']);
         $this->assertEquals($throwLine, $innermostFrame['lineno']);
@@ -181,15 +183,18 @@ class ExceptionPayloadBuilderTest extends TestCase
         [$exception, $arraySumLine, $callerLine] = $this->internalErrorHelperWithKnownLines();
         $result = ExceptionPayloadBuilder::buildExceptionList($exception);
 
+        // Canonical bottom-up order: the internal function (crash site) is last, its caller before it.
         $frames = array_values($result[0]['stacktrace']['frames']);
+        $crashFrame = $frames[count($frames) - 1];
+        $callerFrame = $frames[count($frames) - 2];
 
-        $this->assertEquals('array_sum', $frames[0]['function']);
-        $this->assertEquals(__FILE__, $frames[0]['abs_path']);
-        $this->assertEquals($arraySumLine, $frames[0]['lineno']);
-        $this->assertEquals(__CLASS__ . '->internalErrorLeaf', $frames[1]['function']);
-        $this->assertEquals(__FILE__, $frames[1]['abs_path']);
-        $this->assertEquals($callerLine, $frames[1]['lineno']);
-        $this->assertNotEquals($frames[0], $frames[1]);
+        $this->assertEquals('array_sum', $crashFrame['function']);
+        $this->assertEquals(__FILE__, $crashFrame['abs_path']);
+        $this->assertEquals($arraySumLine, $crashFrame['lineno']);
+        $this->assertEquals(__CLASS__ . '->internalErrorLeaf', $callerFrame['function']);
+        $this->assertEquals(__FILE__, $callerFrame['abs_path']);
+        $this->assertEquals($callerLine, $callerFrame['lineno']);
+        $this->assertNotEquals($crashFrame, $callerFrame);
     }
 
     public function testStrictTypeErrorUsesCallsiteBeforeDeclaration(): void
@@ -226,12 +231,14 @@ PHP;
             $this->assertInstanceOf(\Throwable::class, $exception);
 
             $result = ExceptionPayloadBuilder::buildExceptionList($exception);
+            // Canonical bottom-up order: the real callsite (crash site) is the last frame.
             $frames = array_values($result[0]['stacktrace']['frames']);
+            $crashFrame = $frames[count($frames) - 1];
 
-            $this->assertSame($scriptPath, $frames[0]['abs_path']);
-            $this->assertSame('requiresIntForTrace', $frames[0]['function']);
-            $this->assertSame($callLine, $frames[0]['lineno']);
-            $this->assertNotSame($declarationLine, $frames[0]['lineno']);
+            $this->assertSame($scriptPath, $crashFrame['abs_path']);
+            $this->assertSame('requiresIntForTrace', $crashFrame['function']);
+            $this->assertSame($callLine, $crashFrame['lineno']);
+            $this->assertNotSame($declarationLine, $crashFrame['lineno']);
         } finally {
             unlink($scriptPath);
         }
@@ -249,6 +256,59 @@ PHP;
         $this->assertCount(2, $frames);
         $this->assertArrayHasKey('context_line', $frames[0]);
         $this->assertArrayHasKey('context_line', $frames[1]);
+    }
+
+    public function testStacktraceFramesUseCanonicalBottomUpOrder(): void
+    {
+        // Regression guard for the canonical wire order. PHP's getTrace() is innermost-first
+        // (crash site at index 0); PostHog expects bottom-up frames where frames[0] is the
+        // outermost/entry-point call and the last frame is the crash site.
+        $exception = $this->orderedNestedThrowHelper();
+        $result = ExceptionPayloadBuilder::buildExceptionList($exception);
+
+        $frames = array_values($result[0]['stacktrace']['frames']);
+        $this->assertGreaterThanOrEqual(3, count($frames), 'nested throw should yield multiple frames');
+
+        $functions = array_map(static fn(array $frame) => $frame['function'] ?? null, $frames);
+
+        // The three helpers unwind inward: leaf (crash) is called by middle, called by the entry
+        // point. Canonical order therefore reads entry -> middle -> leaf from first to last.
+        $entryIndex  = array_search(__CLASS__ . '->orderedNestedThrowHelper', $functions, true);
+        $middleIndex = array_search(__CLASS__ . '->orderedThrowMiddle', $functions, true);
+        $leafIndex   = array_search(__CLASS__ . '->orderedThrowLeaf', $functions, true);
+
+        $this->assertNotFalse($entryIndex);
+        $this->assertNotFalse($middleIndex);
+        $this->assertNotFalse($leafIndex);
+        $this->assertTrue(
+            $entryIndex < $middleIndex && $middleIndex < $leafIndex,
+            'frames must read bottom-up: entry point first, crash site last'
+        );
+
+        // The very last frame is the crash site: it carries the throw location (file + line) and
+        // is the synthetic throw-site frame appended for the leaf.
+        $crashFrame = $frames[count($frames) - 1];
+        $this->assertSame(__FILE__, $crashFrame['abs_path']);
+        $this->assertSame($exception->getLine(), $crashFrame['lineno']);
+    }
+
+    private function orderedNestedThrowHelper(): \RuntimeException
+    {
+        try {
+            $this->orderedThrowMiddle();
+        } catch (\RuntimeException $e) {
+            return $e;
+        }
+    }
+
+    private function orderedThrowMiddle(): void
+    {
+        $this->orderedThrowLeaf();
+    }
+
+    private function orderedThrowLeaf(): never
+    {
+        throw new \RuntimeException('canonical order leaf');
     }
 
     private function throwHelper(): \RuntimeException


### PR DESCRIPTION
## Problem

PHP's `Throwable::getTrace()` is innermost-first: the crash site sits at index 0 and the entry point is last. The PHP SDK currently serializes `$exception_list[].stacktrace.frames` in that raw order, so `frames[0]` is the crash site. The cross-SDK stack frame ordering standard (PostHog/sdk-specs#11) defines the canonical wire order as bottom-up: `frames[0]` is the outermost/entry-point call and the **last** frame is the crash site.

Spec: https://github.com/PostHog/sdk-specs/pull/11

## Change

`ExceptionPayloadBuilder::buildStacktrace()` now reverses the built frames after truncating to `max_frames`. Slicing before reversing keeps the most-relevant crash-site frames (the ones PHP puts first) and then orders them bottom-up, so the crash site — including the synthetic throw-site frame prepended for exceptions that omit their throw location from `getTrace()` — ends up last.

Both frame-producing paths flow through `buildStacktrace()`, so this covers thrown exceptions (`getTrace()`) and the PHP error/warning handler path (`debug_backtrace()`). The `$exception_list` chain order is unchanged (still outermost-first via the `getPrevious()` walk). Source context fields (`context_line`/`pre_context`/`post_context`) stay attached to their frames and remain in canonical file order.

## Tests

- Updated the existing frame-order assertions in `ExceptionPayloadBuilderTest` and `ExceptionCaptureTest` to expect the crash site at the last frame instead of the first.
- Added `testStacktraceFramesUseCanonicalBottomUpOrder` as an explicit regression guard: a nested throw must serialize entry point first and crash site (the synthetic throw-site frame) last.
- Scoped suite green: `vendor/bin/phpunit test/ExceptionPayloadBuilderTest.php test/ExceptionCaptureTest.php` — 42 tests, 208 assertions. Full suite also green.

## Coordination

This is a **breaking wire-order change** for the stack frame ordering. Merge and release only after the pipeline normalization gate (cymbal) is live, so the backend can normalize old vs new ordering. The changeset is intentionally a **minor** bump (not major) so the pipeline can gate on `$lib_version` to distinguish SDK versions emitting the old order from those emitting canonical order.
