### PR TITLE
feat: add before send callback

### DIFF
--- a/.changeset/bright-owls-filter.md
+++ b/.changeset/bright-owls-filter.md
@@ -1,0 +1,5 @@
+---
+"posthog-php": minor
+---
+
+Add a before_send callback for modifying or dropping fully enriched events.

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -172,6 +172,7 @@ class Client implements FeatureFlagEvaluationsHost
      *     flush_interval_seconds?: int|float,
      *     compress_request?: bool|string,
      *     error_handler?: callable,
+     *     before_send?: callable(array<string, mixed>): (array<string, mixed>|null),
      *     filename?: string,
      *     is_server?: bool,
      *     flag_definition_cache_provider?: FlagDefinitionCacheProvider,
@@ -394,7 +395,49 @@ class Client implements FeatureFlagEvaluationsHost
 
         unset($message["send_feature_flags"]);
 
+        $message = $this->applyBeforeSend($message);
+        if ($message === null) {
+            return false;
+        }
+
         return $this->consumer->capture($message);
+    }
+
+    /**
+     * Run the configured before_send callback for a fully enriched capture event.
+     *
+     * @param array<string, mixed> $message
+     * @return array<string, mixed>|null
+     */
+    private function applyBeforeSend(array $message): ?array
+    {
+        $beforeSend = $this->options['before_send'] ?? null;
+        if ($beforeSend === null) {
+            return $message;
+        }
+
+        if (!is_callable($beforeSend)) {
+            error_log('[PostHog][Client] before_send is not callable; dropping event');
+            return null;
+        }
+
+        try {
+            $result = $beforeSend($message);
+        } catch (Throwable $e) {
+            error_log('[PostHog][Client] before_send callback threw; dropping event: ' . $e->getMessage());
+            return null;
+        }
+
+        if ($result === null) {
+            return null;
+        }
+
+        if (!is_array($result)) {
+            error_log('[PostHog][Client] before_send must return an array or null; dropping event');
+            return null;
+        }
+
+        return $result;
     }
 
     /**

--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -49,6 +49,7 @@ class PostHog
      *     flush_interval_seconds?: int|float,
      *     compress_request?: bool|string,
      *     error_handler?: callable,
+     *     before_send?: callable(array<string, mixed>): (array<string, mixed>|null),
      *     filename?: string,
      *     flag_definition_cache_provider?: FlagDefinitionCacheProvider,
      *     error_tracking?: array{

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -487,6 +487,63 @@ class PostHogTest extends TestCase
         $this->assertSame('/batch/', $httpClient->calls[0]['path']);
     }
 
+    public function testBeforeSendCanModifyFullyEnrichedEvent(): void
+    {
+        $httpClient = new MockedHttpClient("app.posthog.com");
+        $sawFullyEnrichedEvent = false;
+        $client = new Client(
+            self::FAKE_API_KEY,
+            [
+                "batch_size" => 1,
+                "before_send" => function (array $event) use (&$sawFullyEnrichedEvent): array {
+                    $sawFullyEnrichedEvent = isset(
+                        $event['properties']['$lib'],
+                        $event['properties']['$lib_version'],
+                        $event['properties']['$lib_consumer'],
+                        $event['properties']['$is_server']
+                    );
+                    unset($event['properties']['secret']);
+                    $event['properties']['before_send'] = true;
+
+                    return $event;
+                },
+            ],
+            $httpClient,
+            null,
+            false
+        );
+
+        $this->assertTrue($client->capture([
+            "distinctId" => "john",
+            "event" => "Module PHP Event",
+            "properties" => ["secret" => "remove"],
+        ]));
+
+        $this->assertTrue($sawFullyEnrichedEvent);
+        $payload = json_decode($httpClient->calls[0]['payload'], true);
+        $properties = $payload['batch'][0]['properties'];
+        $this->assertTrue($properties['before_send']);
+        $this->assertArrayNotHasKey('secret', $properties);
+    }
+
+    public function testBeforeSendCanDropEvent(): void
+    {
+        $httpClient = new MockedHttpClient("app.posthog.com");
+        $client = new Client(
+            self::FAKE_API_KEY,
+            ["batch_size" => 1, "before_send" => static fn(array $event): ?array => null],
+            $httpClient,
+            null,
+            false
+        );
+
+        $this->assertFalse($client->capture([
+            "distinctId" => "john",
+            "event" => "Module PHP Event",
+        ]));
+        $this->assertSame([], $httpClient->calls ?? []);
+    }
+
 
     /**
      * @dataProvider facadeNoOpBeforeInitCases


### PR DESCRIPTION
## :bulb: Motivation and Context

Customers need a configuration hook to inspect, modify, or drop events before upload, matching the before-send behavior available in other PostHog SDKs.

This adds a `before_send` client option. It receives the fully enriched event array after SDK metadata, server attribution, groups, timestamps, and feature flag properties have been applied. Returning `null` drops the event.

## :green_heart: How did you test it?

- `./vendor/bin/phpunit --no-coverage --filter 'BeforeSend|BatchSizeOne' test/PostHogTest.php`
- `composer api:check`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the pi coding agent. The callback runs immediately before queueing the fully enriched capture payload; callbacks that return `null`, return a non-array, or throw will drop only that event.
