### PR TITLE
feat(flags): add $feature_flag_has_experiment to $feature_flag_called events

### DIFF
--- a/.changeset/flag-called-has-experiment.md
+++ b/.changeset/flag-called-has-experiment.md
@@ -2,4 +2,4 @@
 "posthog-php": minor
 ---
 
-Add a $feature_flag_has_experiment boolean property to every $feature_flag_called event, sourced from the server's has_experiment field and defaulting to false when the server does not report it.
+Add a $feature_flag_has_experiment boolean property to $feature_flag_called events, mirroring the server's has_experiment field. The property is only sent when the server explicitly reports has_experiment and is omitted when unknown (older deployments, missing metadata, missing flags).

--- a/.changeset/flag-called-has-experiment.md
+++ b/.changeset/flag-called-has-experiment.md
@@ -1,0 +1,5 @@
+---
+"posthog-php": minor
+---
+
+Add a $feature_flag_has_experiment boolean property to every $feature_flag_called event, sourced from the server's has_experiment field and defaulting to false when the server does not report it.

--- a/api/public-api.json
+++ b/api/public-api.json
@@ -1579,7 +1579,7 @@
                 "hasExperiment": {
                     "static": false,
                     "readonly": true,
-                    "type": "bool",
+                    "type": "?bool",
                     "default": null,
                     "hasDefault": false
                 },
@@ -1722,11 +1722,11 @@
                         },
                         {
                             "name": "hasExperiment",
-                            "type": "bool",
+                            "type": "?bool",
                             "byReference": false,
                             "variadic": false,
                             "optional": true,
-                            "default": false,
+                            "default": null,
                             "defaultConstant": null,
                             "hasDefault": true
                         }

--- a/api/public-api.json
+++ b/api/public-api.json
@@ -1576,6 +1576,13 @@
                     "default": null,
                     "hasDefault": false
                 },
+                "hasExperiment": {
+                    "static": false,
+                    "readonly": true,
+                    "type": "bool",
+                    "default": null,
+                    "hasDefault": false
+                },
                 "id": {
                     "static": false,
                     "readonly": true,
@@ -1712,6 +1719,16 @@
                             "default": null,
                             "defaultConstant": null,
                             "hasDefault": false
+                        },
+                        {
+                            "name": "hasExperiment",
+                            "type": "bool",
+                            "byReference": false,
+                            "variadic": false,
+                            "optional": true,
+                            "default": false,
+                            "defaultConstant": null,
+                            "hasDefault": true
                         }
                     ]
                 },

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -788,19 +788,23 @@ class Client implements FeatureFlagEvaluationsHost
 
         if ($sendFeatureFlagEvents) {
             // Locally-evaluated flags carry has_experiment in the stored definition;
-            // remotely-evaluated flags carry it in the response metadata. Defaults to
-            // false when the server (older deployment) does not report it.
+            // remotely-evaluated flags carry it in the response metadata. Null when the
+            // server (older deployment) does not report it, in which case the property
+            // is omitted from the event.
             if ($flagWasEvaluatedLocally) {
-                $hasExperiment = (bool) ($localFlagDefinition['has_experiment'] ?? false);
+                $hasExperiment = $localFlagDefinition['has_experiment'] ?? null;
             } else {
-                $hasExperiment = (bool) ($flagDetail['metadata']['has_experiment'] ?? false);
+                $hasExperiment = $flagDetail['metadata']['has_experiment'] ?? null;
             }
 
             $properties = [
                 '$feature_flag' => $key,
                 '$feature_flag_response' => $result,
-                '$feature_flag_has_experiment' => $hasExperiment,
             ];
+
+            if (!is_null($hasExperiment)) {
+                $properties['$feature_flag_has_experiment'] = (bool) $hasExperiment;
+            }
 
             if (!is_null($requestId)) {
                 $properties['$feature_flag_request_id'] = $requestId;
@@ -1046,7 +1050,9 @@ class Client implements FeatureFlagEvaluationsHost
                     version: null,
                     reason: 'Evaluated locally',
                     locallyEvaluated: true,
-                    hasExperiment: (bool) ($flag['has_experiment'] ?? false),
+                    hasExperiment: isset($flag['has_experiment'])
+                        ? (bool) $flag['has_experiment']
+                        : null,
                 );
             }
 
@@ -1119,7 +1125,9 @@ class Client implements FeatureFlagEvaluationsHost
                             : null,
                         reason: $flagDetail['reason']['description'] ?? null,
                         locallyEvaluated: false,
-                        hasExperiment: (bool) ($flagDetail['metadata']['has_experiment'] ?? false),
+                        hasExperiment: isset($flagDetail['metadata']['has_experiment'])
+                            ? (bool) $flagDetail['metadata']['has_experiment']
+                            : null,
                     );
                 }
             } catch (HttpException $e) {

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -699,9 +699,11 @@ class Client implements FeatureFlagEvaluationsHost
         $result = null;
         $payload = null;
         $featureFlagError = null;
+        $localFlagDefinition = null;
 
         foreach ($this->featureFlags as $flag) {
             if ($flag["key"] == $key) {
+                $localFlagDefinition = $flag;
                 try {
                     $result = $this->computeFlagLocally(
                         $flag,
@@ -785,9 +787,19 @@ class Client implements FeatureFlagEvaluationsHost
         }
 
         if ($sendFeatureFlagEvents) {
+            // Locally-evaluated flags carry has_experiment in the stored definition;
+            // remotely-evaluated flags carry it in the response metadata. Defaults to
+            // false when the server (older deployment) does not report it.
+            if ($flagWasEvaluatedLocally) {
+                $hasExperiment = (bool) ($localFlagDefinition['has_experiment'] ?? false);
+            } else {
+                $hasExperiment = (bool) ($flagDetail['metadata']['has_experiment'] ?? false);
+            }
+
             $properties = [
                 '$feature_flag' => $key,
                 '$feature_flag_response' => $result,
+                '$feature_flag_has_experiment' => $hasExperiment,
             ];
 
             if (!is_null($requestId)) {
@@ -1034,6 +1046,7 @@ class Client implements FeatureFlagEvaluationsHost
                     version: null,
                     reason: 'Evaluated locally',
                     locallyEvaluated: true,
+                    hasExperiment: (bool) ($flag['has_experiment'] ?? false),
                 );
             }
 
@@ -1106,6 +1119,7 @@ class Client implements FeatureFlagEvaluationsHost
                             : null,
                         reason: $flagDetail['reason']['description'] ?? null,
                         locallyEvaluated: false,
+                        hasExperiment: (bool) ($flagDetail['metadata']['has_experiment'] ?? false),
                     );
                 }
             } catch (HttpException $e) {

--- a/lib/EvaluatedFlagRecord.php
+++ b/lib/EvaluatedFlagRecord.php
@@ -20,6 +20,8 @@ final class EvaluatedFlagRecord
      * @param int|null $version Feature flag version, when provided by the API.
      * @param string|null $reason Evaluation reason, when provided by the API.
      * @param bool $locallyEvaluated Whether the value was computed locally.
+     * @param bool $hasExperiment Server-reported signal for whether the flag is linked to an
+     *     experiment. Defaults to false when the server does not report it (older deployments).
      */
     public function __construct(
         public readonly string $key,
@@ -30,6 +32,7 @@ final class EvaluatedFlagRecord
         public readonly ?int $version,
         public readonly ?string $reason,
         public readonly bool $locallyEvaluated,
+        public readonly bool $hasExperiment = false,
     ) {
     }
 

--- a/lib/EvaluatedFlagRecord.php
+++ b/lib/EvaluatedFlagRecord.php
@@ -20,8 +20,8 @@ final class EvaluatedFlagRecord
      * @param int|null $version Feature flag version, when provided by the API.
      * @param string|null $reason Evaluation reason, when provided by the API.
      * @param bool $locallyEvaluated Whether the value was computed locally.
-     * @param bool $hasExperiment Server-reported signal for whether the flag is linked to an
-     *     experiment. Defaults to false when the server does not report it (older deployments).
+     * @param bool|null $hasExperiment Server-reported signal for whether the flag is linked to an
+     *     experiment. Null when the server does not report it (older deployments).
      */
     public function __construct(
         public readonly string $key,
@@ -32,7 +32,7 @@ final class EvaluatedFlagRecord
         public readonly ?int $version,
         public readonly ?string $reason,
         public readonly bool $locallyEvaluated,
-        public readonly bool $hasExperiment = false,
+        public readonly ?bool $hasExperiment = null,
     ) {
     }
 

--- a/lib/FeatureFlagEvaluations.php
+++ b/lib/FeatureFlagEvaluations.php
@@ -178,12 +178,16 @@ class FeatureFlagEvaluations
             // Missing flags get a null response (not false), matching the legacy single-flag path
             // so consumers can distinguish "flag exists and is disabled" from "flag not found".
             '$feature_flag_response' => $response,
-            // Server-reported signal for whether the flag is linked to an experiment.
-            // Defaults to false when the server does not report it (older deployments).
-            '$feature_flag_has_experiment' => $record?->hasExperiment ?? false,
             // Always set explicitly so consumers don't have to infer "missing key means remote".
             'locally_evaluated' => $record?->locallyEvaluated ?? false,
         ];
+
+        // Server-reported signal for whether the flag is linked to an experiment. Only sent
+        // when the server explicitly reported it; omitted when unknown (older deployments,
+        // missing metadata, missing flags).
+        if ($record?->hasExperiment !== null) {
+            $properties['$feature_flag_has_experiment'] = $record->hasExperiment;
+        }
 
         if ($record !== null) {
             if ($record->id !== null) {

--- a/lib/FeatureFlagEvaluations.php
+++ b/lib/FeatureFlagEvaluations.php
@@ -178,6 +178,9 @@ class FeatureFlagEvaluations
             // Missing flags get a null response (not false), matching the legacy single-flag path
             // so consumers can distinguish "flag exists and is disabled" from "flag not found".
             '$feature_flag_response' => $response,
+            // Server-reported signal for whether the flag is linked to an experiment.
+            // Defaults to false when the server does not report it (older deployments).
+            '$feature_flag_has_experiment' => $record?->hasExperiment ?? false,
             // Always set explicitly so consumers don't have to infer "missing key means remote".
             'locally_evaluated' => $record?->locallyEvaluated ?? false,
         ];

--- a/test/FeatureFlagEvaluationsTest.php
+++ b/test/FeatureFlagEvaluationsTest.php
@@ -364,6 +364,63 @@ class FeatureFlagEvaluationsTest extends TestCase
         $this->assertArrayNotHasKey('$feature_flag_version', $properties);
         $this->assertArrayNotHasKey('$feature_flag_request_id', $properties);
         $this->assertArrayNotHasKey('$feature_flag_evaluated_at', $properties);
+        // Local definition doesn't report has_experiment, so the property defaults to false.
+        $this->assertFalse($properties['$feature_flag_has_experiment']);
+    }
+
+    public function testHasExperimentFromRemoteMetadataPropagatesToEvent(): void
+    {
+        $response = MockedResponses::FLAGS_V2_RESPONSE;
+        $response['flags']['simple-test']['metadata']['has_experiment'] = true;
+        $response['flags']['multivariate-test']['metadata']['has_experiment'] = false;
+        // having_fun's metadata omits has_experiment, covering older deployments.
+        $this->makeClient(flagsEndpointResponse: $response);
+
+        $snapshot = PostHog::evaluateFlags('user-1');
+        $snapshot->isEnabled('simple-test');
+        $snapshot->getFlag('multivariate-test');
+        $snapshot->isEnabled('having_fun');
+        PostHog::flush();
+
+        $batches = $this->batchRequests();
+        $this->assertCount(1, $batches);
+        $hasExperimentByFlag = [];
+        foreach ($batches[0]['batch'] as $event) {
+            $properties = $event['properties'];
+            $hasExperimentByFlag[$properties['$feature_flag']] = $properties['$feature_flag_has_experiment'];
+        }
+
+        $this->assertSame(
+            [
+                'simple-test' => true,
+                'multivariate-test' => false,
+                'having_fun' => false,
+            ],
+            $hasExperimentByFlag
+        );
+    }
+
+    public function testHasExperimentFromLocalDefinitionPropagatesToEvent(): void
+    {
+        $localResponse = MockedResponses::LOCAL_EVALUATION_REQUEST;
+        $localResponse['flags'][0]['has_experiment'] = true;
+        $this->makeClient(
+            personalApiKey: 'test-personal-key',
+            localEvaluationResponse: $localResponse,
+        );
+        $snapshot = PostHog::evaluateFlags(
+            'user-1',
+            personProperties: ['region' => 'USA']
+        );
+
+        $this->assertTrue($snapshot->isEnabled('person-flag'));
+        PostHog::flush();
+
+        $batches = $this->batchRequests();
+        $this->assertCount(1, $batches);
+        $properties = $batches[0]['batch'][0]['properties'];
+        $this->assertTrue($properties['locally_evaluated']);
+        $this->assertTrue($properties['$feature_flag_has_experiment']);
     }
 
     public function testLocalEvaluationSkipsRemoteFlagsRequestWhenAllResolved(): void
@@ -409,6 +466,7 @@ class FeatureFlagEvaluationsTest extends TestCase
         $properties = $batches[0]['batch'][0]['properties'];
         $this->assertNull($properties['$feature_flag_response']);
         $this->assertFalse($properties['locally_evaluated']);
+        $this->assertFalse($properties['$feature_flag_has_experiment']);
     }
 
     public function testRemotePayloadHandlesPreDecodedValue(): void

--- a/test/FeatureFlagEvaluationsTest.php
+++ b/test/FeatureFlagEvaluationsTest.php
@@ -364,8 +364,8 @@ class FeatureFlagEvaluationsTest extends TestCase
         $this->assertArrayNotHasKey('$feature_flag_version', $properties);
         $this->assertArrayNotHasKey('$feature_flag_request_id', $properties);
         $this->assertArrayNotHasKey('$feature_flag_evaluated_at', $properties);
-        // Local definition doesn't report has_experiment, so the property defaults to false.
-        $this->assertFalse($properties['$feature_flag_has_experiment']);
+        // Local definition doesn't report has_experiment, so the property is omitted.
+        $this->assertArrayNotHasKey('$feature_flag_has_experiment', $properties);
     }
 
     public function testHasExperimentFromRemoteMetadataPropagatesToEvent(): void
@@ -384,20 +384,15 @@ class FeatureFlagEvaluationsTest extends TestCase
 
         $batches = $this->batchRequests();
         $this->assertCount(1, $batches);
-        $hasExperimentByFlag = [];
+        $propertiesByFlag = [];
         foreach ($batches[0]['batch'] as $event) {
-            $properties = $event['properties'];
-            $hasExperimentByFlag[$properties['$feature_flag']] = $properties['$feature_flag_has_experiment'];
+            $propertiesByFlag[$event['properties']['$feature_flag']] = $event['properties'];
         }
 
-        $this->assertSame(
-            [
-                'simple-test' => true,
-                'multivariate-test' => false,
-                'having_fun' => false,
-            ],
-            $hasExperimentByFlag
-        );
+        $this->assertTrue($propertiesByFlag['simple-test']['$feature_flag_has_experiment']);
+        $this->assertFalse($propertiesByFlag['multivariate-test']['$feature_flag_has_experiment']);
+        // Unreported has_experiment omits the property rather than defaulting it.
+        $this->assertArrayNotHasKey('$feature_flag_has_experiment', $propertiesByFlag['having_fun']);
     }
 
     public function testHasExperimentFromLocalDefinitionPropagatesToEvent(): void
@@ -466,7 +461,8 @@ class FeatureFlagEvaluationsTest extends TestCase
         $properties = $batches[0]['batch'][0]['properties'];
         $this->assertNull($properties['$feature_flag_response']);
         $this->assertFalse($properties['locally_evaluated']);
-        $this->assertFalse($properties['$feature_flag_has_experiment']);
+        // Missing flags have no server-reported has_experiment, so the property is omitted.
+        $this->assertArrayNotHasKey('$feature_flag_has_experiment', $properties);
     }
 
     public function testRemotePayloadHandlesPreDecodedValue(): void

--- a/test/FeatureFlagLocalEvaluationTest.php
+++ b/test/FeatureFlagLocalEvaluationTest.php
@@ -1569,7 +1569,7 @@ class FeatureFlagLocalEvaluationTest extends TestCase
                     ),
                     1 => array(
                         "path" => "/batch/",
-                        'payload' => '{"batch":[{"properties":{"$feature_flag":"simple-flag","$feature_flag_response":true,"$feature_flag_has_experiment":false,"$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$is_server":true,"$groups":[]},"distinct_id":"some-distinct-id","event":"$feature_flag_called","$groups":[],"groups":[],"timestamp":"2022-05-01T00:00:00+00:00"}],"api_key":"random_key"}',
+                        'payload' => '{"batch":[{"properties":{"$feature_flag":"simple-flag","$feature_flag_response":true,"$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$is_server":true,"$groups":[]},"distinct_id":"some-distinct-id","event":"$feature_flag_called","$groups":[],"groups":[],"timestamp":"2022-05-01T00:00:00+00:00"}],"api_key":"random_key"}',
                         "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                         "requestOptions" => array('shouldVerify' => true),
                     ),

--- a/test/FeatureFlagLocalEvaluationTest.php
+++ b/test/FeatureFlagLocalEvaluationTest.php
@@ -1569,13 +1569,38 @@ class FeatureFlagLocalEvaluationTest extends TestCase
                     ),
                     1 => array(
                         "path" => "/batch/",
-                        'payload' => '{"batch":[{"properties":{"$feature_flag":"simple-flag","$feature_flag_response":true,"$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$is_server":true,"$groups":[]},"distinct_id":"some-distinct-id","event":"$feature_flag_called","$groups":[],"groups":[],"timestamp":"2022-05-01T00:00:00+00:00"}],"api_key":"random_key"}',
+                        'payload' => '{"batch":[{"properties":{"$feature_flag":"simple-flag","$feature_flag_response":true,"$feature_flag_has_experiment":false,"$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$is_server":true,"$groups":[]},"distinct_id":"some-distinct-id","event":"$feature_flag_called","$groups":[],"groups":[],"timestamp":"2022-05-01T00:00:00+00:00"}],"api_key":"random_key"}',
                         "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                         "requestOptions" => array('shouldVerify' => true),
                     ),
                 )
             );
         });
+    }
+
+    public function testFeatureFlagCalledEventIncludesHasExperimentFromLocalDefinition()
+    {
+        $localResponse = MockedResponses::LOCAL_EVALUATION_SIMPLE_REQUEST;
+        $localResponse['flags'][0]['has_experiment'] = true;
+
+        $this->http_client = new MockedHttpClient(host: "app.posthog.com", flagEndpointResponse: $localResponse);
+        $this->client = new Client(
+            self::FAKE_API_KEY,
+            [
+                "debug" => true,
+            ],
+            $this->http_client,
+            "test"
+        );
+        PostHog::init(null, null, $this->client);
+
+        $this->assertTrue(PostHog::getFeatureFlag('simple-flag', 'some-distinct-id'));
+        PostHog::flush();
+
+        $payload = json_decode($this->http_client->calls[1]['payload'], true);
+        $properties = $payload['batch'][0]['properties'];
+        $this->assertSame('simple-flag', $properties['$feature_flag']);
+        $this->assertTrue($properties['$feature_flag_has_experiment']);
     }
 
     public function testFeatureFlagsDontFallbackToDecideWhenOnlyLocalEvaluationIsTrue()

--- a/test/FeatureFlagTest.php
+++ b/test/FeatureFlagTest.php
@@ -379,7 +379,7 @@ class FeatureFlagTest extends TestCase
                     ),
                 1 => array(
                     "path" => "/batch/",
-                    "payload" => '{"batch":[{"properties":{"$feature_flag":"simple-test","$feature_flag_response":true,"$feature_flag_request_id":"98487c8a-287a-4451-a085-299cd76228dd","$feature_flag_id":6,"$feature_flag_version":1,"$feature_flag_reason":"Matched condition set 1","$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$is_server":true,"$groups":[]},"distinct_id":"user-id","event":"$feature_flag_called","$groups":[],"groups":[],"timestamp":"2022-05-01T00:00:00+00:00"}],"api_key":"random_key"}',
+                    "payload" => '{"batch":[{"properties":{"$feature_flag":"simple-test","$feature_flag_response":true,"$feature_flag_has_experiment":false,"$feature_flag_request_id":"98487c8a-287a-4451-a085-299cd76228dd","$feature_flag_id":6,"$feature_flag_version":1,"$feature_flag_reason":"Matched condition set 1","$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$is_server":true,"$groups":[]},"distinct_id":"user-id","event":"$feature_flag_called","$groups":[],"groups":[],"timestamp":"2022-05-01T00:00:00+00:00"}],"api_key":"random_key"}',
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array('shouldVerify' => true),
                     ),
@@ -479,13 +479,44 @@ class FeatureFlagTest extends TestCase
                 ),
                 1 => array(
                     "path" => "/batch/",
-                    "payload" => '{"batch":[{"properties":{"$feature_flag":"multivariate-test","$feature_flag_response":"variant-value","$feature_flag_request_id":"98487c8a-287a-4451-a085-299cd76228dd","$feature_flag_id":7,"$feature_flag_version":3,"$feature_flag_reason":"Matched condition set 2","$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$is_server":true,"$groups":[]},"distinct_id":"user-id","event":"$feature_flag_called","$groups":[],"groups":[],"timestamp":"2022-05-01T00:00:00+00:00"}],"api_key":"random_key"}',
+                    "payload" => '{"batch":[{"properties":{"$feature_flag":"multivariate-test","$feature_flag_response":"variant-value","$feature_flag_has_experiment":false,"$feature_flag_request_id":"98487c8a-287a-4451-a085-299cd76228dd","$feature_flag_id":7,"$feature_flag_version":3,"$feature_flag_reason":"Matched condition set 2","$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$is_server":true,"$groups":[]},"distinct_id":"user-id","event":"$feature_flag_called","$groups":[],"groups":[],"timestamp":"2022-05-01T00:00:00+00:00"}],"api_key":"random_key"}',
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array('shouldVerify' => true),
                 ),
                 )
             );
         });
+    }
+
+    public static function hasExperimentCases(): array
+    {
+        return [
+            'reported true' => [true, true],
+            'reported false' => [false, false],
+            'absent' => [null, false],
+        ];
+    }
+
+    /**
+     * @dataProvider hasExperimentCases
+     */
+    public function testFeatureFlagCalledEventIncludesHasExperimentFromRemoteMetadata(
+        ?bool $reported,
+        bool $expected
+    ) {
+        $response = MockedResponses::FLAGS_V2_RESPONSE;
+        if ($reported !== null) {
+            $response['flags']['simple-test']['metadata']['has_experiment'] = $reported;
+        }
+        $this->setUp($response, personalApiKey: null);
+
+        $this->assertTrue(PostHog::isFeatureEnabled('simple-test', 'user-id'));
+        PostHog::flush();
+
+        $payload = json_decode($this->http_client->calls[1]['payload'], true);
+        $properties = $payload['batch'][0]['properties'];
+        $this->assertSame('simple-test', $properties['$feature_flag']);
+        $this->assertSame($expected, $properties['$feature_flag_has_experiment']);
     }
 
     /**

--- a/test/FeatureFlagTest.php
+++ b/test/FeatureFlagTest.php
@@ -379,7 +379,7 @@ class FeatureFlagTest extends TestCase
                     ),
                 1 => array(
                     "path" => "/batch/",
-                    "payload" => '{"batch":[{"properties":{"$feature_flag":"simple-test","$feature_flag_response":true,"$feature_flag_has_experiment":false,"$feature_flag_request_id":"98487c8a-287a-4451-a085-299cd76228dd","$feature_flag_id":6,"$feature_flag_version":1,"$feature_flag_reason":"Matched condition set 1","$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$is_server":true,"$groups":[]},"distinct_id":"user-id","event":"$feature_flag_called","$groups":[],"groups":[],"timestamp":"2022-05-01T00:00:00+00:00"}],"api_key":"random_key"}',
+                    "payload" => '{"batch":[{"properties":{"$feature_flag":"simple-test","$feature_flag_response":true,"$feature_flag_request_id":"98487c8a-287a-4451-a085-299cd76228dd","$feature_flag_id":6,"$feature_flag_version":1,"$feature_flag_reason":"Matched condition set 1","$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$is_server":true,"$groups":[]},"distinct_id":"user-id","event":"$feature_flag_called","$groups":[],"groups":[],"timestamp":"2022-05-01T00:00:00+00:00"}],"api_key":"random_key"}',
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array('shouldVerify' => true),
                     ),
@@ -479,7 +479,7 @@ class FeatureFlagTest extends TestCase
                 ),
                 1 => array(
                     "path" => "/batch/",
-                    "payload" => '{"batch":[{"properties":{"$feature_flag":"multivariate-test","$feature_flag_response":"variant-value","$feature_flag_has_experiment":false,"$feature_flag_request_id":"98487c8a-287a-4451-a085-299cd76228dd","$feature_flag_id":7,"$feature_flag_version":3,"$feature_flag_reason":"Matched condition set 2","$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$is_server":true,"$groups":[]},"distinct_id":"user-id","event":"$feature_flag_called","$groups":[],"groups":[],"timestamp":"2022-05-01T00:00:00+00:00"}],"api_key":"random_key"}',
+                    "payload" => '{"batch":[{"properties":{"$feature_flag":"multivariate-test","$feature_flag_response":"variant-value","$feature_flag_request_id":"98487c8a-287a-4451-a085-299cd76228dd","$feature_flag_id":7,"$feature_flag_version":3,"$feature_flag_reason":"Matched condition set 2","$lib":"posthog-php","$lib_version":"' . PostHog::VERSION . '","$lib_consumer":"LibCurl","$is_server":true,"$groups":[]},"distinct_id":"user-id","event":"$feature_flag_called","$groups":[],"groups":[],"timestamp":"2022-05-01T00:00:00+00:00"}],"api_key":"random_key"}',
                     "extraHeaders" => array(0 => 'User-Agent: posthog-php/' . PostHog::VERSION),
                     "requestOptions" => array('shouldVerify' => true),
                 ),
@@ -490,20 +490,20 @@ class FeatureFlagTest extends TestCase
 
     public static function hasExperimentCases(): array
     {
+        // The event property mirrors the server's has_experiment field exactly and is
+        // omitted when the server does not report it (older deployments).
         return [
-            'reported true' => [true, true],
-            'reported false' => [false, false],
-            'absent' => [null, false],
+            'reported true' => [true],
+            'reported false' => [false],
+            'absent' => [null],
         ];
     }
 
     /**
      * @dataProvider hasExperimentCases
      */
-    public function testFeatureFlagCalledEventIncludesHasExperimentFromRemoteMetadata(
-        ?bool $reported,
-        bool $expected
-    ) {
+    public function testFeatureFlagCalledEventIncludesHasExperimentFromRemoteMetadata(?bool $reported)
+    {
         $response = MockedResponses::FLAGS_V2_RESPONSE;
         if ($reported !== null) {
             $response['flags']['simple-test']['metadata']['has_experiment'] = $reported;
@@ -516,7 +516,11 @@ class FeatureFlagTest extends TestCase
         $payload = json_decode($this->http_client->calls[1]['payload'], true);
         $properties = $payload['batch'][0]['properties'];
         $this->assertSame('simple-test', $properties['$feature_flag']);
-        $this->assertSame($expected, $properties['$feature_flag_has_experiment']);
+        if ($reported === null) {
+            $this->assertArrayNotHasKey('$feature_flag_has_experiment', $properties);
+        } else {
+            $this->assertSame($reported, $properties['$feature_flag_has_experiment']);
+        }
     }
 
     /**


### PR DESCRIPTION
## :bulb: Motivation and Context

Part of a cross-SDK effort to shrink `$feature_flag_called` events. This first phase adds a `$feature_flag_has_experiment` boolean property to every `$feature_flag_called` event, reflecting the server's `has_experiment` signal: `metadata.has_experiment` in the `/flags?v=2` response and `has_experiment` on `/api/feature_flag/local_evaluation` flag definitions. When the server does not report the field (older deployments, bootstrapped flags), the property is omitted, so it is tri-state: `true`, `false`, or absent (unknown).

This lets ingestion distinguish experiment-linked flag events (which need the full property set for exposure analysis) from the rest, and lets us measure the split before a later phase strips the expensive properties (`$feature/<key>`, `$feature_flag_payload`, per-event system metadata) from non-experiment flag events. This PR intentionally minimizes nothing: no properties are removed, no config options are added, and dedupe behavior is unchanged.

## Changes

- `Client.php`: single-flag path sources `has_experiment` from the matched local definition when evaluated locally, otherwise from `metadata.has_experiment` in the `/flags?v=2` response; `evaluateFlags()` threads it into `EvaluatedFlagRecord` for both local and remote records.
- `FeatureFlagEvaluations::recordAccess()` adds the property to every event, including missing-flag accesses omit the property.
- Public API snapshot regenerated (`composer api:update`); minor changeset.

## :green_heart: How did you test it?

phpunit: 431 tests / 3,729 assertions, all green. New data-provider tests cover reported-true / reported-false / absent on the remote single-flag path; local-definition and snapshot-path tests added; existing exact-payload assertions updated. `phpcs` matches baseline; `composer api:check` passes.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

