### PR TITLE
fix: standardize event buffer defaults

### DIFF
--- a/.changeset/standardize-event-buffer-defaults.md
+++ b/.changeset/standardize-event-buffer-defaults.md
@@ -2,4 +2,4 @@
 "posthog-php": patch
 ---
 
-Fix the default event queue capacity at 10,000 events while retaining the existing 100-event batch size and 5-second opportunistic flush interval.
+Fix the default event queue capacity at 10,000 events.

--- a/.changeset/standardize-event-buffer-defaults.md
+++ b/.changeset/standardize-event-buffer-defaults.md
@@ -1,0 +1,5 @@
+---
+"posthog-php": patch
+---
+
+Fix the default event queue capacity at 10,000 events while retaining the existing 100-event batch size and 5-second opportunistic flush interval.

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -164,9 +164,11 @@ class Client implements FeatureFlagEvaluationsHost
      * Time-based options use milliseconds unless the option name says otherwise:
      * `timeout` defaults to 10000ms, `feature_flag_request_timeout_ms` defaults to 3000ms,
      * and `maximum_backoff_duration` defaults to 10000ms for retry backoff. Retry backoff starts
-     * at 100ms and doubles until capped by `maximum_backoff_duration`. `flush_interval_seconds`
-     * defaults to 5 seconds. For the socket consumer, `timeout` is passed to pfsockopen() and is
-     * in seconds.
+     * at 100ms and doubles until capped by `maximum_backoff_duration`. `max_queue_size` defaults
+     * to 10000 events, `batch_size` defaults to 100 events, and `flush_interval_seconds` defaults
+     * to 5 seconds. The interval is checked when another event is enqueued because PHP has no
+     * portable in-process background timer. For the socket consumer, `timeout` is passed to
+     * pfsockopen() and is in seconds.
      *
      * Feature flag requests to `/flags/?v=2` retry transient curl/network errors and HTTP 502/504.
      * `feature_flag_request_max_retries` defaults to 1; set it to 0 to disable these retries.

--- a/lib/PostHog.php
+++ b/lib/PostHog.php
@@ -27,9 +27,11 @@ class PostHog
      * Time-based options use milliseconds unless the option name says otherwise:
      * `timeout` defaults to 10000ms, `feature_flag_request_timeout_ms` defaults to 3000ms,
      * and `maximum_backoff_duration` defaults to 10000ms for retry backoff. Retry backoff starts
-     * at 100ms and doubles until capped by `maximum_backoff_duration`. `flush_interval_seconds`
-     * defaults to 5 seconds. For the socket consumer, `timeout` is passed to pfsockopen() and is
-     * in seconds.
+     * at 100ms and doubles until capped by `maximum_backoff_duration`. `max_queue_size` defaults
+     * to 10000 events, `batch_size` defaults to 100 events, and `flush_interval_seconds` defaults
+     * to 5 seconds. The interval is checked when another event is enqueued because PHP has no
+     * portable in-process background timer. For the socket consumer, `timeout` is passed to
+     * pfsockopen() and is in seconds.
      *
      * Feature flag requests to `/flags/?v=2` retry transient curl/network errors and HTTP 502/504.
      * `feature_flag_request_max_retries` defaults to 1; set it to 0 to disable these retries.

--- a/lib/QueueConsumer.php
+++ b/lib/QueueConsumer.php
@@ -27,7 +27,7 @@ abstract class QueueConsumer extends Consumer
     protected $type = "QueueConsumer";
 
     protected $queue;
-    protected $max_queue_size = 1000;
+    protected $max_queue_size = 10000;
     protected $batch_size = 100;
     protected $flush_interval = 5.0;
     protected $flush_after = null;
@@ -163,7 +163,7 @@ abstract class QueueConsumer extends Consumer
     {
         $count = count($this->queue);
 
-        if ($count > $this->max_queue_size) {
+        if ($count >= $this->max_queue_size) {
             return false;
         }
 

--- a/test/QueueConsumerTest.php
+++ b/test/QueueConsumerTest.php
@@ -10,6 +10,22 @@ use PostHog\QueueConsumer;
 
 class QueueConsumerTest extends TestCase
 {
+    public function testDefaultQueueAcceptsTenThousandItemsAndRejectsTheNext(): void
+    {
+        $consumer = new QueueConsumerTestConsumer(
+            [],
+            ['batch_size' => 20_000, 'flush_interval_seconds' => 3600]
+        );
+
+        for ($i = 0; $i < 10_000; ++$i) {
+            $consumer->enqueue($i);
+        }
+
+        $this->assertCount(10_000, $consumer->queuedItems());
+        $this->assertFalse($consumer->enqueue('overflow'));
+        $this->assertCount(10_000, $consumer->queuedItems());
+    }
+
     public function testRetryableFlushFailureKeepsBatchQueued(): void
     {
         $first = $this->message('first');


### PR DESCRIPTION
## :bulb: Motivation and Context

The PHP SDK already uses a 100-event `batch_size` as both its flush threshold and maximum batch size, plus a 5-second flush interval. This change raises the remaining 1,000-event queue default to 10,000 and fixes its boundary check so the configured capacity is an exact maximum rather than allowing one extra event.

These defaults align with the Python, Ruby, and Rails server-side SDKs, as summarized in the [server-side SDK event buffer defaults comparison](https://gist.github.com/dustinbyrne/53aae4565ccae67586b9d8d9a1017033). Related changes: [Node.js SDK](https://github.com/PostHog/posthog-js/pull/4164), [Java server SDK](https://github.com/PostHog/posthog-android/pull/626), and [.NET SDK](https://github.com/PostHog/posthog-dotnet/pull/262).

PHP does not have a portable in-process background timer across FPM, Apache, CLI, and other runtimes. The existing 5-second interval therefore remains opportunistic: it is checked on the next enqueue, while explicit flushes and shutdown still drain pending events. Adding a true timer would require runtime-specific event-loop, signal, or worker integrations and is intentionally out of scope.

## :green_heart: How did you test it?

- `./vendor/bin/phpunit --no-coverage --colors=never test/QueueConsumerTest.php` (9 passed, 27 assertions)
- `./vendor/bin/phpunit --no-coverage --colors=never --bootstrap vendor/autoload.php --configuration phpunit.xml` (432 passed, 3,734 assertions; existing warnings/deprecations reported)
- `./vendor/bin/phpcs -n --standard=phpcs.xml --extensions=php lib/Client.php lib/PostHog.php lib/QueueConsumer.php test/QueueConsumerTest.php`
- `composer run api:check`

Coverage was disabled locally because no Xdebug/PCOV coverage driver is installed; CI will run the coverage-enabled suite.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent and a read-only Pi scout as part of a human-directed server-side SDK standardization. The scout confirmed that PHP's 100-event batch size already serves both the threshold and maximum, and that a portable autonomous timer is not viable in the base SDK. The implementation is limited to the queue default and exact-capacity fix, focused behavioral coverage, synchronized public PHPDoc, and a patch changeset.
