### PR TITLE
feat(flags): minimize $feature_flag_called events for non-experiment flags

### DIFF
--- a/.changeset/minimal-flag-called-events.md
+++ b/.changeset/minimal-flag-called-events.md
@@ -1,0 +1,5 @@
+---
+"posthog-php": minor
+---
+
+Send minimal $feature_flag_called events when the server enables the minimal_flag_called_events gate and the flag is not linked to an experiment. Minimal events keep only an allowlisted set of flag evaluation properties; experiment-linked flags, ungated projects, and responses without the signal keep the full event shape. The gate is read from the top-level minimalFlagCalledEvents field of /flags responses and the top-level minimal_flag_called_events field of the local-evaluation flag definitions payload, and persists through external flag definition caches.

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -24,6 +24,10 @@ class Client implements FeatureFlagEvaluationsHost
      * server-controlled minimal_flag_called_events gate is on and the flag reports
      * has_experiment=false, every property outside this list is stripped — including request
      * context properties and SDK consumer metadata.
+     *
+     * Keep in sync with the $feature_flag_* properties built in doGetFeatureFlagResult() and
+     * FeatureFlagEvaluations::recordAccess(). A new flag-eval property added there but omitted
+     * here is silently stripped from minimized events.
      */
     private const MINIMAL_FLAG_CALLED_EVENT_PROPERTIES = [
         '$feature_flag',
@@ -454,6 +458,9 @@ class Client implements FeatureFlagEvaluationsHost
         unset($message["send_feature_flags"]);
 
         if ($this->shouldSendMinimalFlagCalledEvent($message)) {
+            // Runs after message() enrichment (above) so consumer metadata added there, e.g.
+            // $lib_consumer, is also stripped. This also means before_send (below) sees the
+            // already-minimized properties for gated events, not the full envelope.
             $message["properties"] = array_intersect_key(
                 $message["properties"],
                 array_flip(self::MINIMAL_FLAG_CALLED_EVENT_PROPERTIES)
@@ -470,6 +477,10 @@ class Client implements FeatureFlagEvaluationsHost
 
     /**
      * Run the configured before_send callback for a fully enriched capture event.
+     *
+     * For a gated, non-experiment $feature_flag_called event, properties have already been
+     * reduced to the minimal allowlist (see capture()) by the time the callback runs, so
+     * before_send sees the minimized shape rather than the full envelope for those events.
      *
      * @param array<string, mixed> $message
      * @return array<string, mixed>|null
@@ -1581,7 +1592,7 @@ class Client implements FeatureFlagEvaluationsHost
         $this->featureFlags = $data['flags'];
         $this->groupTypeMapping = $data['group_type_mapping'];
         $this->cohorts = $data['cohorts'];
-        $this->minimalFlagCalledEvents = ($data['minimal_flag_called_events'] ?? null) === true;
+        $this->minimalFlagCalledEvents = $data['minimal_flag_called_events'];
 
         // Build flags by key dictionary for dependency resolution
         $this->featureFlagsByKey = [];

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -18,6 +18,32 @@ use Throwable;
 class Client implements FeatureFlagEvaluationsHost
 {
     private const SIZE_LIMIT = 50_000;
+
+    /**
+     * Allowlist of event properties kept when a $feature_flag_called event is minimized. When the
+     * server-controlled minimal_flag_called_events gate is on and the flag reports
+     * has_experiment=false, every property outside this list is stripped — including request
+     * context properties and SDK consumer metadata.
+     */
+    private const MINIMAL_FLAG_CALLED_EVENT_PROPERTIES = [
+        '$feature_flag',
+        '$feature_flag_response',
+        '$feature_flag_has_experiment',
+        '$feature_flag_id',
+        '$feature_flag_version',
+        '$feature_flag_reason',
+        '$feature_flag_request_id',
+        '$feature_flag_evaluated_at',
+        '$feature_flag_error',
+        'locally_evaluated',
+        '$groups',
+        '$process_person_profile',
+        '$session_id',
+        '$lib',
+        '$lib_version',
+        '$is_server',
+    ];
+
     private const CONSUMERS = [
         "socket" => Socket::class,
         "file" => File::class,
@@ -120,6 +146,15 @@ class Client implements FeatureFlagEvaluationsHost
      * @var bool Whether flag definitions have been loaded successfully at least once.
      */
     private $flagDefinitionsLoaded;
+
+    /**
+     * Server-controlled gate for minimal $feature_flag_called events, read from the top-level
+     * minimalFlagCalledEvents field of /flags responses and the minimal_flag_called_events field
+     * of the flag definitions payload. Absence of the field means off.
+     *
+     * @var bool
+     */
+    private $minimalFlagCalledEvents;
 
     /**
      * @var FlagDefinitionCacheProvider|null External shared cache provider for flag definitions.
@@ -255,6 +290,7 @@ class Client implements FeatureFlagEvaluationsHost
         $this->distinctIdsFeatureFlagsReported = new SizeLimitedHash(self::SIZE_LIMIT);
         $this->flagsEtag = null;
         $this->flagDefinitionsLoaded = false;
+        $this->minimalFlagCalledEvents = false;
 
         if ($this->enabled) {
             ExceptionCapture::configure($this, $options['error_tracking'] ?? []);
@@ -417,6 +453,13 @@ class Client implements FeatureFlagEvaluationsHost
 
         unset($message["send_feature_flags"]);
 
+        if ($this->shouldSendMinimalFlagCalledEvent($message)) {
+            $message["properties"] = array_intersect_key(
+                $message["properties"],
+                array_flip(self::MINIMAL_FLAG_CALLED_EVENT_PROPERTIES)
+            );
+        }
+
         $message = $this->applyBeforeSend($message);
         if ($message === null) {
             return false;
@@ -460,6 +503,22 @@ class Client implements FeatureFlagEvaluationsHost
         }
 
         return $result;
+    }
+
+    /**
+     * Whether a $feature_flag_called event should be reduced to the minimal property allowlist.
+     * Requires the server-controlled gate plus an explicit has_experiment=false signal for the
+     * flag. Any missing signal keeps the full legacy shape; experiment-linked flags always send
+     * the full envelope because experiment exposure analysis reads it.
+     *
+     * @param array<string, mixed> $message
+     * @return bool
+     */
+    private function shouldSendMinimalFlagCalledEvent(array $message): bool
+    {
+        return $this->minimalFlagCalledEvents
+            && ($message['event'] ?? null) === '$feature_flag_called'
+            && ($message['properties']['$feature_flag_has_experiment'] ?? null) === false;
     }
 
     /**
@@ -1470,6 +1529,7 @@ class Client implements FeatureFlagEvaluationsHost
                 ? $data['group_type_mapping']
                 : [],
             'cohorts' => isset($data['cohorts']) && is_array($data['cohorts']) ? $data['cohorts'] : [],
+            'minimal_flag_called_events' => ($data['minimal_flag_called_events'] ?? null) === true,
         ];
     }
 
@@ -1506,6 +1566,7 @@ class Client implements FeatureFlagEvaluationsHost
             'flags' => $data['flags'],
             'group_type_mapping' => $groupTypeMapping,
             'cohorts' => $data['cohorts'],
+            'minimal_flag_called_events' => ($data['minimal_flag_called_events'] ?? null) === true,
         ];
     }
 
@@ -1520,6 +1581,7 @@ class Client implements FeatureFlagEvaluationsHost
         $this->featureFlags = $data['flags'];
         $this->groupTypeMapping = $data['group_type_mapping'];
         $this->cohorts = $data['cohorts'];
+        $this->minimalFlagCalledEvents = ($data['minimal_flag_called_events'] ?? null) === true;
 
         // Build flags by key dictionary for dependency resolution
         $this->featureFlagsByKey = [];
@@ -1801,7 +1863,11 @@ class Client implements FeatureFlagEvaluationsHost
             );
         }
 
-        return $this->normalizeFeatureFlags($httpResponse->getResponse());
+        $response = $this->normalizeFeatureFlags($httpResponse->getResponse());
+        // Only gated projects receive the field on v2 responses, so absence means off.
+        $this->minimalFlagCalledEvents = ($response['minimalFlagCalledEvents'] ?? null) === true;
+
+        return $response;
     }
 
     /**

--- a/test/FeatureFlagEvaluationsTest.php
+++ b/test/FeatureFlagEvaluationsTest.php
@@ -418,6 +418,43 @@ class FeatureFlagEvaluationsTest extends TestCase
         $this->assertTrue($properties['$feature_flag_has_experiment']);
     }
 
+    public function testMinimalFlagCalledEventKeepsLocallyEvaluatedUnderGate(): void
+    {
+        $localResponse = MockedResponses::LOCAL_EVALUATION_REQUEST;
+        $localResponse['minimal_flag_called_events'] = true;
+        $localResponse['flags'][0]['has_experiment'] = false;
+        $this->makeClient(
+            personalApiKey: 'test-personal-key',
+            localEvaluationResponse: $localResponse,
+        );
+        $snapshot = PostHog::evaluateFlags(
+            'user-1',
+            personProperties: ['region' => 'USA']
+        );
+
+        $this->assertTrue($snapshot->isEnabled('person-flag'));
+        PostHog::flush();
+
+        $batches = $this->batchRequests();
+        $this->assertCount(1, $batches);
+        $properties = $batches[0]['batch'][0]['properties'];
+        ksort($properties);
+        $expected = [
+            '$feature_flag' => 'person-flag',
+            '$feature_flag_response' => true,
+            '$feature_flag_has_experiment' => false,
+            '$feature_flag_id' => 1,
+            '$feature_flag_reason' => 'Evaluated locally',
+            '$groups' => [],
+            '$lib' => 'posthog-php',
+            '$lib_version' => PostHog::VERSION,
+            '$is_server' => true,
+            'locally_evaluated' => true,
+        ];
+        ksort($expected);
+        $this->assertSame($expected, $properties);
+    }
+
     public function testLocalEvaluationSkipsRemoteFlagsRequestWhenAllResolved(): void
     {
         // When local definitions cover every flag and they all evaluate without inconclusive

--- a/test/FeatureFlagLocalEvaluationTest.php
+++ b/test/FeatureFlagLocalEvaluationTest.php
@@ -1603,6 +1603,67 @@ class FeatureFlagLocalEvaluationTest extends TestCase
         $this->assertTrue($properties['$feature_flag_has_experiment']);
     }
 
+    public function testMinimalFlagCalledEventFromLocalEvaluationGate()
+    {
+        $localResponse = MockedResponses::LOCAL_EVALUATION_SIMPLE_REQUEST;
+        $localResponse['minimal_flag_called_events'] = true;
+        $localResponse['flags'][0]['has_experiment'] = false;
+
+        $this->http_client = new MockedHttpClient(host: "app.posthog.com", flagEndpointResponse: $localResponse);
+        $this->client = new Client(
+            self::FAKE_API_KEY,
+            [
+                "debug" => true,
+            ],
+            $this->http_client,
+            "test"
+        );
+        PostHog::init(null, null, $this->client);
+
+        $this->assertTrue(PostHog::getFeatureFlag('simple-flag', 'some-distinct-id'));
+        PostHog::flush();
+
+        $payload = json_decode($this->http_client->calls[1]['payload'], true);
+        $properties = $payload['batch'][0]['properties'];
+        ksort($properties);
+        $expected = [
+            '$feature_flag' => 'simple-flag',
+            '$feature_flag_response' => true,
+            '$feature_flag_has_experiment' => false,
+            '$groups' => [],
+            '$lib' => 'posthog-php',
+            '$lib_version' => PostHog::VERSION,
+            '$is_server' => true,
+        ];
+        ksort($expected);
+        $this->assertSame($expected, $properties);
+    }
+
+    public function testLocalEvaluationGateWithoutHasExperimentKeepsFullEvent()
+    {
+        $localResponse = MockedResponses::LOCAL_EVALUATION_SIMPLE_REQUEST;
+        $localResponse['minimal_flag_called_events'] = true;
+
+        $this->http_client = new MockedHttpClient(host: "app.posthog.com", flagEndpointResponse: $localResponse);
+        $this->client = new Client(
+            self::FAKE_API_KEY,
+            [
+                "debug" => true,
+            ],
+            $this->http_client,
+            "test"
+        );
+        PostHog::init(null, null, $this->client);
+
+        $this->assertTrue(PostHog::getFeatureFlag('simple-flag', 'some-distinct-id'));
+        PostHog::flush();
+
+        $payload = json_decode($this->http_client->calls[1]['payload'], true);
+        $properties = $payload['batch'][0]['properties'];
+        // Without an explicit has_experiment=false signal the full shape is kept.
+        $this->assertSame('LibCurl', $properties['$lib_consumer']);
+    }
+
     public function testFeatureFlagsDontFallbackToDecideWhenOnlyLocalEvaluationIsTrue()
     {
         $this->http_client = new MockedHttpClient(host: "app.posthog.com", flagEndpointResponse: MockedResponses::FALLBACK_TO_FLAGS_REQUEST);

--- a/test/FeatureFlagTest.php
+++ b/test/FeatureFlagTest.php
@@ -523,6 +523,70 @@ class FeatureFlagTest extends TestCase
         }
     }
 
+    public function testMinimalFlagCalledEventKeepsOnlyAllowlistedProperties()
+    {
+        $response = MockedResponses::FLAGS_V2_RESPONSE;
+        $response['minimalFlagCalledEvents'] = true;
+        $response['flags']['simple-test']['metadata']['has_experiment'] = false;
+        $this->setUp($response, personalApiKey: null);
+
+        $this->assertTrue(PostHog::isFeatureEnabled('simple-test', 'user-id'));
+        PostHog::flush();
+
+        $payload = json_decode($this->http_client->calls[1]['payload'], true);
+        $properties = $payload['batch'][0]['properties'];
+        ksort($properties);
+        $expected = [
+            '$feature_flag' => 'simple-test',
+            '$feature_flag_response' => true,
+            '$feature_flag_has_experiment' => false,
+            '$feature_flag_request_id' => '98487c8a-287a-4451-a085-299cd76228dd',
+            '$feature_flag_id' => 6,
+            '$feature_flag_version' => 1,
+            '$feature_flag_reason' => 'Matched condition set 1',
+            '$groups' => [],
+            '$lib' => 'posthog-php',
+            '$lib_version' => PostHog::VERSION,
+            '$is_server' => true,
+        ];
+        ksort($expected);
+        $this->assertSame($expected, $properties);
+    }
+
+    public static function fullFlagCalledEventCases(): array
+    {
+        // Minimization requires both the server gate and an explicit has_experiment=false
+        // signal; any missing signal falls back to the full legacy event shape.
+        return [
+            'gated but experiment-linked' => [true, true],
+            'gated but has_experiment unreported' => [true, null],
+            'ungated with has_experiment false' => [false, false],
+        ];
+    }
+
+    /**
+     * @dataProvider fullFlagCalledEventCases
+     */
+    public function testFlagCalledEventStaysFullWithoutBothMinimalSignals(bool $gated, ?bool $hasExperiment)
+    {
+        $response = MockedResponses::FLAGS_V2_RESPONSE;
+        if ($gated) {
+            $response['minimalFlagCalledEvents'] = true;
+        }
+        if ($hasExperiment !== null) {
+            $response['flags']['simple-test']['metadata']['has_experiment'] = $hasExperiment;
+        }
+        $this->setUp($response, personalApiKey: null);
+
+        $this->assertTrue(PostHog::isFeatureEnabled('simple-test', 'user-id'));
+        PostHog::flush();
+
+        $payload = json_decode($this->http_client->calls[1]['payload'], true);
+        $properties = $payload['batch'][0]['properties'];
+        // Full events keep the consumer metadata that minimal events strip.
+        $this->assertSame('LibCurl', $properties['$lib_consumer']);
+    }
+
     /**
      * @dataProvider decideResponseCases
      */

--- a/test/FlagDefinitionCacheProviderTest.php
+++ b/test/FlagDefinitionCacheProviderTest.php
@@ -287,6 +287,36 @@ class FlagDefinitionCacheProviderTest extends TestCase
         $this->assertSame([], $httpClient->calls ?? []);
     }
 
+    public function testMinimalFlagCalledGatePersistsThroughProviderCache(): void
+    {
+        // Simulates a restart: a fresh client reads definitions (including the
+        // minimal_flag_called_events gate) from the shared cache instead of the API and still
+        // minimizes $feature_flag_called events.
+        $provider = new MockFlagDefinitionCacheProvider();
+        $provider->shouldFetch = false;
+        $data = $this->sampleFlagDefinitionData();
+        $data['flags'][0]['has_experiment'] = false;
+        $data['minimal_flag_called_events'] = true;
+        $provider->cachedData = $data;
+        $httpClient = new MockedHttpClient(host: "app.posthog.com");
+
+        $client = $this->createClient($provider, $httpClient);
+        $this->assertTrue($client->getFeatureFlag('beta-ui', 'user-1'));
+        $client->flush();
+
+        $batchCall = null;
+        foreach ($httpClient->calls as $call) {
+            if (str_starts_with($call['path'], '/batch/')) {
+                $batchCall = $call;
+            }
+        }
+        $this->assertNotNull($batchCall);
+        $properties = json_decode($batchCall['payload'], true)['batch'][0]['properties'];
+        $this->assertFalse($properties['$feature_flag_has_experiment']);
+        $this->assertTrue($properties['$is_server']);
+        $this->assertArrayNotHasKey('$lib_consumer', $properties);
+    }
+
     public function testInvalidProviderOptionThrows(): void
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
## :bulb: Motivation and Context

`$feature_flag_called` events carry the full enriched properties dict (request context, super properties, custom event properties, system context) on every flag call, even for flags not linked to an experiment. This PR trims those events to a strict allowlist iff the server-controlled gate is on (`minimalFlagCalledEvents` in the v2 `/flags` response, or `minimal_flag_called_events` in the local-evaluation payload) and the flag's `has_experiment` is exactly `false`. Any missing signal — gate absent, legacy response shape, `has_experiment` unknown — sends the full legacy shape unchanged, and experiment-linked flags always send the full envelope since experiment exposure analysis reads it.

Server-gated because rolling this out unconditionally could break existing insights; announcement/comms come before enablement. The goal is to establish `$feature_flag_called` as a special system event.

Implementation:

- Single enforcement point in `Client::capture()`: the allowlist is applied via `array_intersect_key()` after all property enrichment (request context merge, SDK metadata, `$groups`) and before `before_send`, so both event-building paths (`getFeatureFlag()`/`isFeatureEnabled()` and the `evaluateFlags()` snapshot) funnel through it.
- The gate is wired from both sources — read from every parsed v2 `/flags` response and from the `/flags/definitions` payload — stored alongside the cached flag definitions, and round-trips through `FlagDefinitionCacheProvider` so it survives process restarts on shared caches.

Part of a cross-SDK rollout; reference implementation and fuller context: PostHog/posthog-python#748

## :green_heart: How did you test it?

- `vendor/bin/phpunit --bootstrap vendor/autoload.php --configuration phpunit.xml` (CI-equivalent invocation): 441 tests, 3,762 assertions, 0 failures.
- `vendor/bin/phpcs` on touched files: 0 errors; warning baseline unchanged from the branch base (no new warnings introduced).
- `php scripts/check-public-api.php`: public API snapshot up to date (only private members added).

New tests cover: gate on/off from both sources (v2 `/flags` response and local-evaluation payload), the `has_experiment` matrix (false → minimal; true / unreported / ungated → full), exact-allowlist assertions on the minimal shape (the whole properties array is compared, not just spot checks), `locally_evaluated` preserved on the snapshot path, and a cache round-trip restart simulation asserting the gate persists through an external flag definition cache.

A minor changeset is included.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*