### PR TITLE
test: release with new changeset management

### DIFF
--- a/.changeset/funny-mugs-march.md
+++ b/.changeset/funny-mugs-march.md
@@ -1,0 +1,5 @@
+---
+"posthog-php": patch
+---
+
+test: release with new changeset management


### PR DESCRIPTION
## :bulb: Motivation and Context

Validate the new pnpm-native changeset management and release workflow end to end with a patch release intent for `posthog-php`.

## :green_heart: How did you test it?

- Ran `pnpm change status` and confirmed it detects `.changeset/funny-mugs-march.md` and plans the `4.12.0` → `4.12.1` patch release.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm change` to generate a change intent file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Used the Pi coding agent with shell and file tools to move the supplied change intent into a dedicated PR worktree, validate it with `pnpm change status`, and prepare the draft PR. The existing patch bump and release summary were preserved unchanged.
