### PR TITLE
fix: harden release validation and publishing

### DIFF
--- a/.changeset/calm-wolves-release.md
+++ b/.changeset/calm-wolves-release.md
@@ -1,0 +1,5 @@
+---
+"posthog-php": patch
+---
+
+Fix release validation and publishing safeguards

--- a/.changeset/calm-wolves-release.md
+++ b/.changeset/calm-wolves-release.md
@@ -1,5 +1,0 @@
----
-"posthog-php": patch
----
-
-Fix release validation and publishing safeguards

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Validate composer files
         if: needs.detect-markdown-only.outputs.markdown_only != 'true'
-        run: composer validate --no-check-lock --no-check-version --strict
+        run: composer validate --no-check-version --strict
 
   public-api:
     needs: detect-markdown-only

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,12 @@ jobs:
           cache: true
           install: false
 
+      - name: Set up PHP 8.4
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          php-version: 8.4
+          tools: composer
+
       - name: Apply change intents and update version
         id: candidate
         env:
@@ -104,6 +110,7 @@ jobs:
           fi
 
           ./scripts/bump-version.sh "$new_version"
+          composer update --lock --no-install --no-interaction --no-audit
 
           if [ -z "$(git status --porcelain)" ]; then
             echo "No release candidate changes were generated" >&2
@@ -113,7 +120,7 @@ jobs:
           changed_files=$(git diff --name-only)
           while IFS= read -r file; do
             case "$file" in
-              CHANGELOG.md|composer.json|package.json|lib/PostHog.php|.changeset/*) ;;
+              CHANGELOG.md|composer.json|composer.lock|package.json|lib/PostHog.php|.changeset/*) ;;
               *)
                 echo "Unexpected release candidate change: $file" >&2
                 exit 1
@@ -244,7 +251,7 @@ jobs:
           tools: composer
 
       - name: Validate composer files
-        run: composer validate --no-check-lock --no-check-version --strict
+        run: composer validate --no-check-version --strict
 
       - name: Send failure event to PostHog
         if: ${{ failure() }}
@@ -277,6 +284,9 @@ jobs:
     with:
       slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
       slack_user_group_id: ${{ vars.GROUP_CLIENT_LIBRARIES_SLACK_GROUP_ID }}
+      checkout_repository: false
+      tag_pattern: "[0-9]*"
+      tag_sort: version
     secrets:
       slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
       posthog_project_api_key: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
@@ -353,6 +363,7 @@ jobs:
         with:
           client-id: ${{ secrets.GH_APP_POSTHOG_PHP_RELEASER_APP_ID }}
           private-key: ${{ secrets.GH_APP_POSTHOG_PHP_RELEASER_PRIVATE_KEY }}
+          permission-contents: write
 
       - name: Commit version bump
         id: commit-version-bump
@@ -361,12 +372,20 @@ jobs:
           commit_message: "chore: release ${{ needs.prepare-release-candidate.outputs.new-version }} [version bump] [skip ci]"
           repo: ${{ github.repository }}
           branch: main
-          file_pattern: "CHANGELOG.md composer.json package.json lib/PostHog.php .changeset"
+          file_pattern: "CHANGELOG.md composer.json composer.lock package.json lib/PostHog.php .changeset"
         env:
           GITHUB_TOKEN: ${{ steps.releaser.outputs.token }}
 
+      - name: Require release commit
+        env:
+          COMMIT_SHA: ${{ steps.commit-version-bump.outputs.commit-hash }}
+        run: |
+          if [ -z "$COMMIT_SHA" ]; then
+            echo "Release commit was not created" >&2
+            exit 1
+          fi
+
       - name: Create GitHub release
-        if: steps.commit-version-bump.outputs.commit-hash != ''
         env:
           GH_TOKEN: ${{ steps.releaser.outputs.token }}
           NEW_VERSION: ${{ needs.prepare-release-candidate.outputs.new-version }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -21,7 +21,7 @@ After review, merge the PR to `main`. No GitHub release label is required.
 A push to `main` that includes `.changeset/*.md` changes automatically starts the release workflow. The workflow then:
 
 1. Checks for pending change intents
-2. Uses `pnpm version -r` to determine and apply the version bump, consume the intents, and update `CHANGELOG.md` and `.changeset/ledger.yaml`
+2. Uses `pnpm version -r` to determine and apply the version bump, consume the intents, update `CHANGELOG.md` and `.changeset/ledger.yaml`, and refresh `composer.lock`
 3. Prepares a release candidate patch for the triggering commit in a read-only job without release secrets, after verifying the release bump script hash
 4. Verifies the release candidate in a separate read-only job and fails if the tag or GitHub Release already exists
 5. Notifies the client libraries team in Slack for approval only after candidate preparation and verification both succeed

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c11900659348ffada66c82406a3d8c6c",
+    "content-hash": "4ad7d75a06d730f2933ec1254892145e",
     "packages": [
         {
             "name": "psr/clock",


### PR DESCRIPTION
## :bulb: Motivation and Context

The 4.12.1 release completed successfully but exposed gaps in the release safeguards: the automated version bump left `composer.lock` stale while validation suppressed the mismatch, and a no-op release commit could allow the publish job to finish without creating a GitHub Release. The release also requested the GitHub App's default installation permissions and performed an unnecessary full checkout to build the Slack comparison URL.

This makes the release path fail closed and keeps the committed Composer lock consistent with each released `composer.json`. This PR intentionally does not include a change intent; the updated path can be exercised by a later release.

## :green_heart: How did you test it?

- `composer validate --no-check-version --strict`
- `composer install --dry-run --no-interaction`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/release.yml .github/workflows/php.yml`
- Simulated a release candidate bump from 4.12.1 to 4.12.2 and confirmed `composer update --lock` changed only the lock content hash
- `composer api:check`
- `./vendor/bin/phpunit --bootstrap vendor/autoload.php --configuration phpunit.xml --no-coverage` (441 tests, 3,762 assertions; existing warnings/deprecations remain)
- Independent read-only reviewer pass found no blockers

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm change` to generate a change intent file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent using GitHub CLI, Composer, actionlint, and a read-only reviewer subagent. The chosen approach refreshes only Composer's lock content hash during version bumps, explicitly fails when no release commit is returned, narrows the App token to `contents: write`, and uses the pinned reusable workflow's checkout-free version-tag lookup. A temporary synthetic change intent was used to validate the candidate-generation path, but no release intent is committed in this PR.
