### PR TITLE
feat: support starts_with and ends_with operators in local evaluation

### DIFF
--- a/.changeset/starts-with-ends-with-operators.md
+++ b/.changeset/starts-with-ends-with-operators.md
@@ -3,3 +3,5 @@
 ---
 
 Support the `starts_with`, `not_starts_with`, `ends_with`, and `not_ends_with` property filter operators in feature flag local evaluation. Matching is case-insensitive and mirrors `icontains`. Previously, local evaluation treated these operators as unrecognized and silently evaluated their conditions to `false`; they now match correctly.
+
+Operators local evaluation doesn't recognize now throw `InconclusiveMatchException`, deferring the flag to the `/flags` endpoint instead of producing a silently wrong `false` — so operators the server adds in the future degrade gracefully.

--- a/.changeset/starts-with-ends-with-operators.md
+++ b/.changeset/starts-with-ends-with-operators.md
@@ -2,4 +2,4 @@
 "posthog-php": minor
 ---
 
-Support the `starts_with`, `not_starts_with`, `ends_with`, and `not_ends_with` property filter operators in feature flag local evaluation. Matching is case-insensitive and mirrors `icontains`, so flags using these operators no longer fall back to remote evaluation.
+Support the `starts_with`, `not_starts_with`, `ends_with`, and `not_ends_with` property filter operators in feature flag local evaluation. Matching is case-insensitive and mirrors `icontains`. Previously, local evaluation treated these operators as unrecognized and silently evaluated their conditions to `false`; they now match correctly.

--- a/.changeset/starts-with-ends-with-operators.md
+++ b/.changeset/starts-with-ends-with-operators.md
@@ -1,0 +1,5 @@
+---
+"posthog-php": minor
+---
+
+Support the `starts_with`, `not_starts_with`, `ends_with`, and `not_ends_with` property filter operators in feature flag local evaluation. Matching is case-insensitive and mirrors `icontains`, so flags using these operators no longer fall back to remote evaluation.

--- a/lib/FeatureFlag.php
+++ b/lib/FeatureFlag.php
@@ -173,7 +173,7 @@ class FeatureFlag
                 && FeatureFlag::compareSemverTuples($overrideTuple, $upper) < 0;
         }
 
-        return false;
+        throw new InconclusiveMatchException("Unknown operator: " . $operator);
     }
 
     /**

--- a/lib/FeatureFlag.php
+++ b/lib/FeatureFlag.php
@@ -57,6 +57,22 @@ class FeatureFlag
             return strpos(strtolower(FeatureFlag::valueToString($overrideValue)), strtolower(FeatureFlag::valueToString($value))) == false;
         }
 
+        if ($operator == "starts_with") {
+            return str_starts_with(strtolower(FeatureFlag::valueToString($overrideValue)), strtolower(FeatureFlag::valueToString($value)));
+        }
+
+        if ($operator == "not_starts_with") {
+            return !str_starts_with(strtolower(FeatureFlag::valueToString($overrideValue)), strtolower(FeatureFlag::valueToString($value)));
+        }
+
+        if ($operator == "ends_with") {
+            return str_ends_with(strtolower(FeatureFlag::valueToString($overrideValue)), strtolower(FeatureFlag::valueToString($value)));
+        }
+
+        if ($operator == "not_ends_with") {
+            return !str_ends_with(strtolower(FeatureFlag::valueToString($overrideValue)), strtolower(FeatureFlag::valueToString($value)));
+        }
+
         if (in_array($operator, ["regex", "not_regex"])) {
             $regexValue = FeatureFlag::prepareValueForRegex($value);
             if (FeatureFlag::isRegularExpression($regexValue)) {

--- a/test/FeatureFlagLocalEvaluationTest.php
+++ b/test/FeatureFlagLocalEvaluationTest.php
@@ -333,6 +333,164 @@ class FeatureFlagLocalEvaluationTest extends TestCase
         ]));
     }
 
+    public function testMatchPropertyStartsWith(): void
+    {
+        $prop = [
+            "key" => "key",
+            "value" => "Val",
+            "operator" => "starts_with"
+        ];
+
+        self::assertTrue(FeatureFlag::matchProperty($prop, [
+            "key" => "value",
+        ]));
+
+        self::assertTrue(FeatureFlag::matchProperty($prop, [
+            "key" => "VALUE",
+        ]));
+
+        self::assertTrue(FeatureFlag::matchProperty($prop, [
+            "key" => "vaLue4",
+        ]));
+
+        self::assertFalse(FeatureFlag::matchProperty($prop, [
+            "key" => "prevalue",
+        ]));
+
+        self::assertFalse(FeatureFlag::matchProperty($prop, [
+            "key" => "Alakazam",
+        ]));
+
+        self::assertFalse(FeatureFlag::matchProperty($prop, [
+            "key" => 123,
+        ]));
+
+        $prop = [
+            "key" => "key",
+            "value" => 3,
+            "operator" => "starts_with"
+        ];
+
+        self::assertTrue(FeatureFlag::matchProperty($prop, [
+            "key" => "3",
+        ]));
+
+        self::assertTrue(FeatureFlag::matchProperty($prop, [
+            "key" => 323,
+        ]));
+
+        self::assertFalse(FeatureFlag::matchProperty($prop, [
+            "key" => 123,
+        ]));
+
+        self::assertFalse(FeatureFlag::matchProperty($prop, [
+            "key" => "val3",
+        ]));
+
+        $prop = [
+            "key" => "key",
+            "value" => "Val",
+            "operator" => "not_starts_with"
+        ];
+
+        self::assertFalse(FeatureFlag::matchProperty($prop, [
+            "key" => "value",
+        ]));
+
+        self::assertFalse(FeatureFlag::matchProperty($prop, [
+            "key" => "VALUE",
+        ]));
+
+        self::assertTrue(FeatureFlag::matchProperty($prop, [
+            "key" => "prevalue",
+        ]));
+
+        self::assertTrue(FeatureFlag::matchProperty($prop, [
+            "key" => "Alakazam",
+        ]));
+    }
+
+    public function testMatchPropertyEndsWith(): void
+    {
+        $prop = [
+            "key" => "key",
+            "value" => "lUe",
+            "operator" => "ends_with"
+        ];
+
+        self::assertTrue(FeatureFlag::matchProperty($prop, [
+            "key" => "value",
+        ]));
+
+        self::assertTrue(FeatureFlag::matchProperty($prop, [
+            "key" => "VALUE",
+        ]));
+
+        self::assertTrue(FeatureFlag::matchProperty($prop, [
+            "key" => "343tfvalue",
+        ]));
+
+        self::assertFalse(FeatureFlag::matchProperty($prop, [
+            "key" => "value2",
+        ]));
+
+        self::assertFalse(FeatureFlag::matchProperty($prop, [
+            "key" => "Alakazam",
+        ]));
+
+        self::assertFalse(FeatureFlag::matchProperty($prop, [
+            "key" => 123,
+        ]));
+
+        $prop = [
+            "key" => "key",
+            "value" => 3,
+            "operator" => "ends_with"
+        ];
+
+        self::assertTrue(FeatureFlag::matchProperty($prop, [
+            "key" => "3",
+        ]));
+
+        self::assertTrue(FeatureFlag::matchProperty($prop, [
+            "key" => 323,
+        ]));
+
+        self::assertTrue(FeatureFlag::matchProperty($prop, [
+            "key" => 13,
+        ]));
+
+        self::assertFalse(FeatureFlag::matchProperty($prop, [
+            "key" => 321,
+        ]));
+
+        self::assertFalse(FeatureFlag::matchProperty($prop, [
+            "key" => "3val",
+        ]));
+
+        $prop = [
+            "key" => "key",
+            "value" => "lUe",
+            "operator" => "not_ends_with"
+        ];
+
+        self::assertFalse(FeatureFlag::matchProperty($prop, [
+            "key" => "value",
+        ]));
+
+        self::assertFalse(FeatureFlag::matchProperty($prop, [
+            "key" => "VALUE",
+        ]));
+
+        self::assertTrue(FeatureFlag::matchProperty($prop, [
+            "key" => "value2",
+        ]));
+
+        self::assertTrue(FeatureFlag::matchProperty($prop, [
+            "key" => "Alakazam",
+        ]));
+    }
+
     public function testMatchPropertyRegex(): void
     {
         $prop = [

--- a/test/FeatureFlagLocalEvaluationTest.php
+++ b/test/FeatureFlagLocalEvaluationTest.php
@@ -416,6 +416,22 @@ class FeatureFlagLocalEvaluationTest extends TestCase
         self::assertTrue(FeatureFlag::matchProperty($prop, [
             "key" => null,
         ]));
+
+        // Case folding is ASCII-only, mirroring the flags service: non-ASCII
+        // characters do not match across case.
+        $prop = [
+            "key" => "key",
+            "value" => "ä",
+            "operator" => "starts_with"
+        ];
+
+        self::assertFalse(FeatureFlag::matchProperty($prop, [
+            "key" => "ÄBC",
+        ]));
+
+        self::assertTrue(FeatureFlag::matchProperty($prop, [
+            "key" => "äbc",
+        ]));
     }
 
     public function testMatchPropertyEndsWith(): void
@@ -505,6 +521,36 @@ class FeatureFlagLocalEvaluationTest extends TestCase
         self::assertTrue(FeatureFlag::matchProperty($prop, [
             "key" => null,
         ]));
+
+        // Case folding is ASCII-only, mirroring the flags service: non-ASCII
+        // characters do not match across case.
+        $prop = [
+            "key" => "key",
+            "value" => "é",
+            "operator" => "ends_with"
+        ];
+
+        self::assertFalse(FeatureFlag::matchProperty($prop, [
+            "key" => "CAFÉ",
+        ]));
+
+        self::assertTrue(FeatureFlag::matchProperty($prop, [
+            "key" => "café",
+        ]));
+    }
+
+    public function testMatchPropertyUnknownOperatorIsInconclusive(): void
+    {
+        $prop = [
+            "key" => "key",
+            "value" => "value",
+            "operator" => "future_operator"
+        ];
+
+        $this->expectException(InconclusiveMatchException::class);
+        FeatureFlag::matchProperty($prop, [
+            "key" => "value",
+        ]);
     }
 
     public function testMatchPropertyStartsWithEndsWithMissingKeyIsInconclusive(): void

--- a/test/FeatureFlagLocalEvaluationTest.php
+++ b/test/FeatureFlagLocalEvaluationTest.php
@@ -365,6 +365,10 @@ class FeatureFlagLocalEvaluationTest extends TestCase
             "key" => 123,
         ]));
 
+        self::assertFalse(FeatureFlag::matchProperty($prop, [
+            "key" => null,
+        ]));
+
         $prop = [
             "key" => "key",
             "value" => 3,
@@ -408,6 +412,10 @@ class FeatureFlagLocalEvaluationTest extends TestCase
         self::assertTrue(FeatureFlag::matchProperty($prop, [
             "key" => "Alakazam",
         ]));
+
+        self::assertTrue(FeatureFlag::matchProperty($prop, [
+            "key" => null,
+        ]));
     }
 
     public function testMatchPropertyEndsWith(): void
@@ -440,6 +448,10 @@ class FeatureFlagLocalEvaluationTest extends TestCase
 
         self::assertFalse(FeatureFlag::matchProperty($prop, [
             "key" => 123,
+        ]));
+
+        self::assertFalse(FeatureFlag::matchProperty($prop, [
+            "key" => null,
         ]));
 
         $prop = [
@@ -489,6 +501,30 @@ class FeatureFlagLocalEvaluationTest extends TestCase
         self::assertTrue(FeatureFlag::matchProperty($prop, [
             "key" => "Alakazam",
         ]));
+
+        self::assertTrue(FeatureFlag::matchProperty($prop, [
+            "key" => null,
+        ]));
+    }
+
+    public function testMatchPropertyStartsWithEndsWithMissingKeyIsInconclusive(): void
+    {
+        foreach (["starts_with", "not_starts_with", "ends_with", "not_ends_with"] as $operator) {
+            $prop = [
+                "key" => "key",
+                "value" => "Val",
+                "operator" => $operator
+            ];
+
+            try {
+                FeatureFlag::matchProperty($prop, [
+                    "key2" => "value",
+                ]);
+                self::fail("Expected InconclusiveMatchException for operator {$operator}");
+            } catch (InconclusiveMatchException $exception) {
+                self::assertInstanceOf(InconclusiveMatchException::class, $exception);
+            }
+        }
     }
 
     public function testMatchPropertyRegex(): void


### PR DESCRIPTION
## :bulb: Motivation and Context

PostHog/posthog#72992 added four case-insensitive property filter operators — `starts_with`, `not_starts_with`, `ends_with`, `not_ends_with` — across HogQL, the flags service, and the UI. The UI surface is gated behind a feature flag until server-side SDKs can evaluate these operators locally; on SDK versions without support, flags using them fall back to remote evaluation.

This adds local evaluation support for the four operators, mirroring `icontains`: both sides are stringified and lowercased, and the `not_` variants are exact negations. Filter values are single strings — server-side validation rejects list values for these operators, matching the flags service behavior.

## :green_heart: How did you test it?

New unit tests mirror the flags service's own test matrix for these operators: case-insensitive anchored matching, mid-string non-matches (`prevalue` does not match `starts_with: "Val"`), numeric stringification (`323` matches `starts_with: "3"`, `123` does not), negation inverses, and missing-key inconclusive behavior.

`vendor/bin/phpunit test/FeatureFlagLocalEvaluationTest.php` passes locally (109 tests, 2531 assertions), and `composer run api:check` confirms the public API snapshot is unchanged.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Added a changeset file (minor)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
