### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    cooldown:
+      default-days: 7
+    directory: "/"
+    schedule:
+      interval: weekly
+    reviewers:
+      - "PostHog/team-client-libraries"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,20 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    cooldown:
-      default-days: 7
+  - package-ecosystem: "composer"
     directory: "/"
     schedule:
-      interval: weekly
-    reviewers:
-      - "PostHog/team-client-libraries"
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## :bulb: Motivation and Context

Add root-level Dependabot coverage for the dependency managers used by this repository: Composer for SDK dependencies, npm for the release-metadata `package.json` and its pnpm package-manager pin, and GitHub Actions.

All three ecosystems run weekly with a seven-day default cooldown. The configuration does not set explicit reviewers; the repository-wide CODEOWNERS rule assigns `PostHog/team-client-libraries` to dependency update changes.

## :green_heart: How did you test it?

- Parsed `.github/dependabot.yml` with Ruby's YAML parser and asserted the exact ecosystem order, complete key set, root directories, weekly intervals, seven-day cooldowns, and absence of `reviewers`.
- Ran `pnpm install --frozen-lockfile` successfully.
- Ran `composer validate --no-check-publish` successfully (with the repository's existing warning about the `version` field).
- Ran `git diff --check` successfully.
- Ran branch autoreview against `origin/main`; it reported no actionable findings.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm change` to generate a change intent file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi's implementation agent and the `autoreview` skill. The configuration is intentionally limited to the three package ecosystems used at the repository root, with duplicated scheduling and cooldown settings and reviewer assignment left to CODEOWNERS.
