### PR TITLE
chore: group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,15 +6,24 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      composer-dependencies:
+        patterns: ["*"]
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      release-tooling:
+        patterns: ["*"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      github-actions:
+        patterns: ["*"]


### PR DESCRIPTION
## :bulb: Motivation and Context
Dependabot currently opens separate pull requests for each matching update in every configured package ecosystem. Grouping these updates reduces repository maintenance while keeping the existing weekly schedule and cooldown settings.

## :green_heart: How did you test it?

Parsed `.github/dependabot.yml` as YAML and verified that Composer, npm, and GitHub Actions each define the requested wildcard group.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm change` to generate a change intent file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented the requested repository administration change. The diff adds one wildcard Dependabot group to each existing ecosystem and does not change SDK code, dependencies, schedules, or cooldown settings. Autoreview was skipped because the diff is limited to `.github` repository administration.
