### PR TITLE
ci: skip feature flags workflow for Dependabot

### DIFF
--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
     call-flags-project:
-        uses: PostHog/.github/.github/workflows/flags-project-board.yml@d8b55d05dc5150f05c24542a6397ff3ecfbfb56d
+        uses: PostHog/.github/.github/workflows/flags-project-board.yml@c220af5fc29f2818f91ac8e4906ca71a3da880ff
         with:
             pr_number: ${{ github.event.pull_request.number }}
             pr_node_id: ${{ github.event.pull_request.node_id }}


### PR DESCRIPTION
## :bulb: Motivation and Context

Dependabot pull requests fail the Feature Flags project workflow because GitHub withholds organization Actions secrets from Dependabot runs. The pinned reusable workflow still tries to create a GitHub App token with those unavailable secrets.

This updates the shared workflow pin to a revision that skips the project-board job for Dependabot pull requests. Regular pull requests continue to update the Feature Flags project board.

## :green_heart: How did you test it?

- Parsed the changed workflow as YAML.
- Ran `git diff --check`.
- Confirmed the pinned reusable workflow checks `github.actor != 'dependabot[bot]'`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm change` to generate a change intent file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi and GitHub CLI were used to inspect the failing workflow, compare its behavior with other PostHog SDK repositories, and update the pinned shared workflow. The shared workflow's existing Dependabot guard was reused instead of exposing project-board credentials to Dependabot.
