### PR TITLE
fix: preserve fractional event timestamps in UTC

### DIFF
--- a/.changeset/quiet-clocks-tick.md
+++ b/.changeset/quiet-clocks-tick.md
@@ -1,0 +1,5 @@
+---
+'posthog-php': patch
+---
+
+Preserve fractional seconds in event timestamps.

--- a/.changeset/quiet-clocks-tick.md
+++ b/.changeset/quiet-clocks-tick.md
@@ -2,4 +2,4 @@
 'posthog-php': patch
 ---
 
-Preserve fractional seconds in event timestamps.
+Preserve fractional seconds and emit event timestamps in UTC.

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -2009,49 +2009,55 @@ class Client implements FeatureFlagEvaluationsHost
 
     /**
      * Formats a timestamp by making sure it is set
-     * and converting it to iso8601.
+     * and converting it to ISO 8601 without discarding fractional seconds.
      *
-     * The timestamp can be time in seconds `time()` or `microseconds(true)`.
-     * any other input is considered an error and the method will return a new date.
+     * The timestamp can be time in seconds `time()` or `microtime(true)`.
+     * Any other input is considered an error and the method will return a new date.
      *
-     * Note: php's date() "u" format (for microseconds) has a bug in it
-     * it always shows `.000` for microseconds since `date()` only accepts
-     * ints, so we have to construct the date ourselves if microtime is passed.
-     *
-     * @param $ts
-     * @return false|string
+     * @param mixed $ts
      */
-    private function formatTime($ts)
+    private function formatTime($ts): string
     {
-        // time()
         if (null == $ts || !$ts) {
-            $ts = Clock::get()->now()->getTimestamp();
+            return $this->formatDateTime(Clock::get()->now());
         }
+
         if (false !== filter_var($ts, FILTER_VALIDATE_INT)) {
             return date("c", (int)$ts);
         }
 
-        // anything else try to strtotime the date.
+        // Anything else try to parse as a date string.
         if (false === filter_var($ts, FILTER_VALIDATE_FLOAT)) {
             if (is_string($ts)) {
-                return date("c", strtotime($ts));
+                try {
+                    return $this->formatDateTime(new \DateTimeImmutable($ts));
+                } catch (\Exception) {
+                    return date("c", strtotime($ts));
+                }
             }
 
-            return date("c", Clock::get()->now()->getTimestamp());
+            return $this->formatDateTime(Clock::get()->now());
         }
 
-        // fix for floatval casting in send.php
-        $parts = explode(".", (string)$ts);
-        if (!isset($parts[1])) {
-            return date("c", (int)$parts[0]);
+        // date() only accepts integer timestamps, so use DateTimeImmutable for microtime(true).
+        $date = \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', (float)$ts));
+        if (false === $date) {
+            return date("c", (int)$ts);
         }
 
-        // microtime(true)
-        $sec = (int)$parts[0];
-        $usec = (int)$parts[1];
-        $fmt = sprintf("Y-m-d\\TH:i:s%sP", $usec);
+        return $this->formatDateTime($date);
+    }
 
-        return date($fmt, (int)$sec);
+    /**
+     * Format in the configured timezone, including microseconds when present.
+     */
+    private function formatDateTime(\DateTimeInterface $date): string
+    {
+        $date = \DateTimeImmutable::createFromInterface($date)
+            ->setTimezone(new \DateTimeZone(date_default_timezone_get()));
+        $format = '000000' === $date->format('u') ? 'Y-m-d\\TH:i:sP' : 'Y-m-d\\TH:i:s.uP';
+
+        return $date->format($format);
     }
 
     /**

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -2032,7 +2032,7 @@ class Client implements FeatureFlagEvaluationsHost
                 try {
                     return $this->formatDateTime(new \DateTimeImmutable($ts));
                 } catch (\Exception) {
-                    return $this->formatUnixTimestamp((int)strtotime($ts));
+                    return $this->formatDateTime(Clock::get()->now());
                 }
             }
 

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -2023,7 +2023,7 @@ class Client implements FeatureFlagEvaluationsHost
         }
 
         if (false !== filter_var($ts, FILTER_VALIDATE_INT)) {
-            return date("c", (int)$ts);
+            return $this->formatUnixTimestamp((int)$ts);
         }
 
         // Anything else try to parse as a date string.
@@ -2032,7 +2032,7 @@ class Client implements FeatureFlagEvaluationsHost
                 try {
                     return $this->formatDateTime(new \DateTimeImmutable($ts));
                 } catch (\Exception) {
-                    return date("c", strtotime($ts));
+                    return $this->formatUnixTimestamp((int)strtotime($ts));
                 }
             }
 
@@ -2042,19 +2042,27 @@ class Client implements FeatureFlagEvaluationsHost
         // date() only accepts integer timestamps, so use DateTimeImmutable for microtime(true).
         $date = \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', (float)$ts));
         if (false === $date) {
-            return date("c", (int)$ts);
+            return $this->formatUnixTimestamp((int)$ts);
         }
 
         return $this->formatDateTime($date);
     }
 
     /**
-     * Format in the configured timezone, including microseconds when present.
+     * Format a Unix timestamp in UTC.
+     */
+    private function formatUnixTimestamp(int $timestamp): string
+    {
+        return $this->formatDateTime((new \DateTimeImmutable())->setTimestamp($timestamp));
+    }
+
+    /**
+     * Format in UTC, including microseconds when present.
      */
     private function formatDateTime(\DateTimeInterface $date): string
     {
         $date = \DateTimeImmutable::createFromInterface($date)
-            ->setTimezone(new \DateTimeZone(date_default_timezone_get()));
+            ->setTimezone(new \DateTimeZone('UTC'));
         $format = '000000' === $date->format('u') ? 'Y-m-d\\TH:i:sP' : 'Y-m-d\\TH:i:s.uP';
 
         return $date->format($format);

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -61,10 +61,15 @@ class PostHogTest extends TestCase
 
     private function firstBatchEvent(): array
     {
+        return $this->firstBatchEvents()[0];
+    }
+
+    private function firstBatchEvents(): array
+    {
         foreach ($this->http_client->calls as $call) {
             if (($call["path"] ?? null) === "/batch/") {
                 $decoded = json_decode($call["payload"], true);
-                return $decoded["batch"][0];
+                return $decoded["batch"];
             }
         }
 
@@ -1446,6 +1451,54 @@ class PostHogTest extends TestCase
         self::assertTrue(PostHog::flush());
 
         self::assertSame('2024-01-01T00:00:00.654321+00:00', $this->firstBatchEvent()['timestamp']);
+    }
+
+    public function testTimestampsAreFormattedInUtc(): void
+    {
+        date_default_timezone_set('America/Los_Angeles');
+
+        try {
+            $this->executeAtFrozenDateTime(
+                new \DateTimeImmutable('2024-01-01T00:00:00.123456-08:00'),
+                function (): void {
+                    self::assertTrue(
+                        PostHog::capture(
+                            array(
+                                "distinctId" => "user-id",
+                                "event" => "default-timestamp",
+                            )
+                        )
+                    );
+                    self::assertTrue(
+                        PostHog::capture(
+                            array(
+                                "distinctId" => "user-id",
+                                "event" => "integer-timestamp",
+                                "timestamp" => 1704067200,
+                            )
+                        )
+                    );
+                    self::assertTrue(
+                        PostHog::capture(
+                            array(
+                                "distinctId" => "user-id",
+                                "event" => "iso-timestamp",
+                                "timestamp" => '2024-01-01T02:00:00.654321+02:00',
+                            )
+                        )
+                    );
+                    self::assertTrue(PostHog::flush());
+                }
+            );
+        } finally {
+            date_default_timezone_set('UTC');
+            Clock::set(new NativeClock());
+        }
+
+        $events = $this->firstBatchEvents();
+        self::assertSame('2024-01-01T08:00:00.123456+00:00', $events[0]['timestamp']);
+        self::assertSame('2024-01-01T00:00:00+00:00', $events[1]['timestamp']);
+        self::assertSame('2024-01-01T00:00:00.654321+00:00', $events[2]['timestamp']);
     }
 
     public function testTimestamps(): void

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -1396,6 +1396,58 @@ class PostHogTest extends TestCase
         $this->assertTrue($result);
     }
 
+    public function testDefaultTimestampPreservesMicroseconds(): void
+    {
+        $this->executeAtFrozenDateTime(
+            new \DateTimeImmutable('2024-01-01T00:00:00.123456+00:00'),
+            function (): void {
+                self::assertTrue(
+                    PostHog::capture(
+                        array(
+                            "distinctId" => "user-id",
+                            "event" => "default-timestamp",
+                        )
+                    )
+                );
+                self::assertTrue(PostHog::flush());
+            }
+        );
+
+        self::assertSame('2024-01-01T00:00:00.123456+00:00', $this->firstBatchEvent()['timestamp']);
+    }
+
+    public function testMicrotimeTimestampPreservesMicroseconds(): void
+    {
+        self::assertTrue(
+            PostHog::capture(
+                array(
+                    "distinctId" => "user-id",
+                    "event" => "microtime-timestamp",
+                    "timestamp" => 1704067200.123456,
+                )
+            )
+        );
+        self::assertTrue(PostHog::flush());
+
+        self::assertSame('2024-01-01T00:00:00.123456+00:00', $this->firstBatchEvent()['timestamp']);
+    }
+
+    public function testIsoTimestampPreservesMicroseconds(): void
+    {
+        self::assertTrue(
+            PostHog::capture(
+                array(
+                    "distinctId" => "user-id",
+                    "event" => "iso-timestamp",
+                    "timestamp" => '2024-01-01T02:00:00.654321+02:00',
+                )
+            )
+        );
+        self::assertTrue(PostHog::flush());
+
+        self::assertSame('2024-01-01T00:00:00.654321+00:00', $this->firstBatchEvent()['timestamp']);
+    }
+
     public function testTimestamps(): void
     {
         self::assertTrue(

--- a/test/PostHogTest.php
+++ b/test/PostHogTest.php
@@ -1453,6 +1453,27 @@ class PostHogTest extends TestCase
         self::assertSame('2024-01-01T00:00:00.654321+00:00', $this->firstBatchEvent()['timestamp']);
     }
 
+    public function testInvalidTimestampFallsBackToCurrentTime(): void
+    {
+        $this->executeAtFrozenDateTime(
+            new \DateTimeImmutable('2024-01-01T00:00:00.123456+00:00'),
+            function (): void {
+                self::assertTrue(
+                    PostHog::capture(
+                        array(
+                            "distinctId" => "user-id",
+                            "event" => "invalid-timestamp",
+                            "timestamp" => "not-a-date",
+                        )
+                    )
+                );
+                self::assertTrue(PostHog::flush());
+            }
+        );
+
+        self::assertSame('2024-01-01T00:00:00.123456+00:00', $this->firstBatchEvent()['timestamp']);
+    }
+
     public function testTimestampsAreFormattedInUtc(): void
     {
         date_default_timezone_set('America/Los_Angeles');


### PR DESCRIPTION
## :bulb: Motivation and Context

The PHP SDK formats generated event timestamps with second-level precision. Events captured within the same second therefore receive identical timestamps and can appear out of order. The existing fractional timestamp paths also drop fractions from ISO strings and produce an invalid value for `microtime(true)`.

The SDK also formats timestamps in PHP's configured timezone. Malformed timestamp strings fall through to the Unix epoch. These behaviors can make closely spaced events ambiguous in ordered analysis such as funnels.

## :green_heart: How did you test it?

- Ran `./vendor/bin/phpunit test` - 450 tests passed with 3,823 assertions.
- Ran focused tests for generated, `microtime(true)`, ISO, whole-second, non-UTC, and malformed timestamps.
- Ran PHPCS on the changed PHP files. It reported no errors.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm change` to generate a change intent file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi coding agent implemented and tested the fix in a dedicated worktree. Pi autoreview checked commit `ae98eee` against `origin/main` and reported no actionable findings. The formatter now preserves fractional seconds, emits every timestamp in UTC, and uses the current time instead of the Unix epoch when a timestamp string cannot be parsed.
