### PR TITLE
fix: validate batch payloads before transport processing

### DIFF
--- a/.changeset/fuzzy-laws-allow.md
+++ b/.changeset/fuzzy-laws-allow.md
@@ -1,0 +1,5 @@
+---
+"posthog-php": patch
+---
+
+Apply batch payload size checks consistently before transport processing

--- a/lib/Consumer/ForkCurl.php
+++ b/lib/Consumer/ForkCurl.php
@@ -42,8 +42,10 @@ class ForkCurl extends QueueConsumer
      */
     public function flushBatch($messages)
     {
-        $body = $this->payload($messages);
-        $payload = json_encode($body);
+        $payload = $this->encodeBatchPayload($messages);
+        if (false === $payload) {
+            return self::FLUSH_BATCH_NON_RETRYABLE_FAILURE;
+        }
 
         // Escape for shell usage.
         $payload = escapeshellarg($payload);
@@ -78,15 +80,6 @@ class ForkCurl extends QueueConsumer
         }
 
         $cmd .= " '" . $url . "'";
-
-        if (strlen($payload) >= self::MAX_BATCH_PAYLOAD_SIZE) {
-            if ($this->debug()) {
-                $msg = "Message size is larger than " . self::MAX_BATCH_PAYLOAD_SIZE_HUMAN;
-                error_log("[PostHog][" . $this->type . "] " . $msg);
-            }
-
-            return self::FLUSH_BATCH_NON_RETRYABLE_FAILURE;
-        }
 
         // Send user agent in the form of {library_name}/{library_version} as per RFC 7231.
         $cmd .= " -H 'User-Agent: " . $this->userAgent() . "'";

--- a/lib/Consumer/ForkCurl.php
+++ b/lib/Consumer/ForkCurl.php
@@ -47,8 +47,17 @@ class ForkCurl extends QueueConsumer
             return self::FLUSH_BATCH_NON_RETRYABLE_FAILURE;
         }
 
-        // Escape for shell usage.
-        $payload = escapeshellarg($payload);
+        // Escape for shell usage and reject payloads that expand beyond the
+        // configured safety limit before creating compression temporary files.
+        try {
+            $payload = escapeshellarg($payload);
+        } catch (\ValueError $error) {
+            $this->handleError($error->getCode(), $error->getMessage());
+            return self::FLUSH_BATCH_NON_RETRYABLE_FAILURE;
+        }
+        if ($this->payloadExceedsSizeLimit($payload)) {
+            return self::FLUSH_BATCH_NON_RETRYABLE_FAILURE;
+        }
 
         $protocol = $this->ssl() ? "https://" : "http://";
 

--- a/lib/Consumer/LibCurl.php
+++ b/lib/Consumer/LibCurl.php
@@ -56,15 +56,8 @@ class LibCurl extends QueueConsumer
      */
     public function flushBatch($messages)
     {
-        $body = $this->payload($messages);
-        $payload = json_encode($body);
-
-        if (strlen($payload) >= self::MAX_BATCH_PAYLOAD_SIZE) {
-            if ($this->debug()) {
-                $msg = "Message size is larger than " . self::MAX_BATCH_PAYLOAD_SIZE_HUMAN;
-                error_log("[PostHog][" . $this->type . "] " . $msg);
-            }
-
+        $payload = $this->encodeBatchPayload($messages);
+        if (false === $payload) {
             return self::FLUSH_BATCH_NON_RETRYABLE_FAILURE;
         }
 

--- a/lib/Consumer/Socket.php
+++ b/lib/Consumer/Socket.php
@@ -47,19 +47,18 @@ class Socket extends QueueConsumer
      */
     public function flushBatch($batch)
     {
+        $payload = $this->encodeBatchPayload($batch);
+        if (false === $payload) {
+            return self::FLUSH_BATCH_NON_RETRYABLE_FAILURE;
+        }
+
         $socket = $this->createSocket();
 
         if (!$socket) {
             return self::FLUSH_BATCH_NON_RETRYABLE_FAILURE;
         }
 
-        $payload = $this->payload($batch);
-        $payload = json_encode($payload);
-
         $body = $this->createBody($this->host, $payload);
-        if (false === $body) {
-            return self::FLUSH_BATCH_NON_RETRYABLE_FAILURE;
-        }
 
         return $this->makeRequest($socket, $body)
             ? true
@@ -212,15 +211,6 @@ class Socket extends QueueConsumer
         $req .= "Content-length: " . strlen($content) . "\r\n";
         $req .= "\r\n";
         $req .= $content;
-
-        if (strlen($req) >= self::MAX_BATCH_PAYLOAD_SIZE) {
-            if ($this->debug()) {
-                $msg = "Message size is larger than " . self::MAX_BATCH_PAYLOAD_SIZE_HUMAN;
-                error_log("[PostHog][" . $this->type . "] " . $msg);
-            }
-
-            return false;
-        }
 
         return $req;
     }

--- a/lib/QueueConsumer.php
+++ b/lib/QueueConsumer.php
@@ -199,6 +199,35 @@ abstract class QueueConsumer extends Consumer
     }
 
     /**
+     * Encode a batch and enforce the transport-independent payload size limit.
+     *
+     * The limit applies to the raw JSON body, before transport-specific escaping,
+     * compression, or HTTP framing.
+     *
+     * @param array<int, array<string, mixed>> $batch Batch of messages to encode.
+     * @return string|false Encoded payload, or false when it cannot be sent.
+     */
+    protected function encodeBatchPayload($batch)
+    {
+        $payload = json_encode($this->payload($batch));
+        if (false === $payload) {
+            $this->handleError(json_last_error(), "Failed to encode batch payload: " . json_last_error_msg());
+            return false;
+        }
+
+        if (strlen($payload) >= self::MAX_BATCH_PAYLOAD_SIZE) {
+            if ($this->debug()) {
+                $msg = "Message size is larger than " . self::MAX_BATCH_PAYLOAD_SIZE_HUMAN;
+                error_log("[PostHog][" . $this->type . "] " . $msg);
+            }
+
+            return false;
+        }
+
+        return $payload;
+    }
+
+    /**
      * Given a batch of messages the method returns
      * a valid payload.
      *

--- a/lib/QueueConsumer.php
+++ b/lib/QueueConsumer.php
@@ -215,16 +215,31 @@ abstract class QueueConsumer extends Consumer
             return false;
         }
 
-        if (strlen($payload) >= self::MAX_BATCH_PAYLOAD_SIZE) {
-            if ($this->debug()) {
-                $msg = "Message size is larger than " . self::MAX_BATCH_PAYLOAD_SIZE_HUMAN;
-                error_log("[PostHog][" . $this->type . "] " . $msg);
-            }
-
+        if ($this->payloadExceedsSizeLimit($payload)) {
             return false;
         }
 
         return $payload;
+    }
+
+    /**
+     * Check a raw or transport-encoded payload against the batch size limit.
+     *
+     * @param string $payload Payload representation to measure.
+     * @return bool Whether the payload reaches or exceeds the limit.
+     */
+    protected function payloadExceedsSizeLimit($payload)
+    {
+        if (strlen($payload) < self::MAX_BATCH_PAYLOAD_SIZE) {
+            return false;
+        }
+
+        if ($this->debug()) {
+            $msg = "Message size is larger than " . self::MAX_BATCH_PAYLOAD_SIZE_HUMAN;
+            error_log("[PostHog][" . $this->type . "] " . $msg);
+        }
+
+        return true;
     }
 
     /**

--- a/test/QueueConsumerTest.php
+++ b/test/QueueConsumerTest.php
@@ -70,12 +70,13 @@ class QueueConsumerTest extends TestCase
         $this->assertNull($httpClient->calls);
     }
 
-    public function testForkCurlRejectsOversizedCompressedPayloadWithoutLeakingTempFile(): void
+    public function testForkCurlRejectsExpandedShellPayloadWithoutLeakingTempFile(): void
     {
         $before = glob('/tmp/forkcurl_*') ?: [];
         $consumer = new ForkCurl('test-key', ['compress_request' => true]);
 
-        $result = $consumer->flushBatch([['event' => str_repeat('x', 1024 * 1024)]]);
+        // The raw JSON is below 1 MiB, but shell escaping expands each apostrophe.
+        $result = $consumer->flushBatch([['event' => str_repeat("'", 300_000)]]);
 
         $after = glob('/tmp/forkcurl_*') ?: [];
         $created = array_values(array_diff($after, $before));

--- a/test/QueueConsumerTest.php
+++ b/test/QueueConsumerTest.php
@@ -74,18 +74,26 @@ class QueueConsumerTest extends TestCase
     {
         $before = glob('/tmp/forkcurl_*') ?: [];
         $consumer = new ForkCurl('test-key', ['compress_request' => true]);
+        $marker = bin2hex(random_bytes(16));
 
         // The raw JSON is below 1 MiB, but shell escaping expands each apostrophe.
-        $result = $consumer->flushBatch([['event' => str_repeat("'", 300_000)]]);
+        $result = $consumer->flushBatch([['event' => $marker . str_repeat("'", 300_000)]]);
 
         $after = glob('/tmp/forkcurl_*') ?: [];
-        $created = array_values(array_diff($after, $before));
-        foreach ($created as $file) {
+        $createdByTest = array_values(array_filter(
+            array_diff($after, $before),
+            static function ($file) use ($marker): bool {
+                $compressed = @file_get_contents($file);
+                $payload = false !== $compressed ? @gzdecode($compressed) : false;
+                return false !== $payload && str_contains($payload, $marker);
+            }
+        ));
+        foreach ($createdByTest as $file) {
             @unlink($file);
         }
 
         $this->assertSame('non_retryable_failure', $result);
-        $this->assertSame([], $created);
+        $this->assertSame([], $createdByTest);
     }
 
     public function testSocketRejectsOversizedPayloadBeforeOpeningConnection(): void

--- a/test/QueueConsumerTest.php
+++ b/test/QueueConsumerTest.php
@@ -4,6 +4,7 @@ namespace PostHog\Test;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use PostHog\Consumer\ForkCurl;
 use PostHog\Consumer\LibCurl;
 use PostHog\Consumer\Socket;
 use PostHog\QueueConsumer;
@@ -24,6 +25,88 @@ class QueueConsumerTest extends TestCase
         $this->assertCount(10_000, $consumer->queuedItems());
         $this->assertFalse($consumer->enqueue('overflow'));
         $this->assertCount(10_000, $consumer->queuedItems());
+    }
+
+    public function testBatchPayloadSizeLimitAppliesToRawJson(): void
+    {
+        $consumer = new QueueConsumerTestConsumer([]);
+
+        $emptyPayload = $consumer->encodedBatchPayload([['event' => '']]);
+        $this->assertIsString($emptyPayload);
+
+        $remainingBytes = (1024 * 1024) - strlen($emptyPayload);
+        $belowLimit = [['event' => str_repeat('x', $remainingBytes - 1)]];
+        $atLimit = [['event' => str_repeat('x', $remainingBytes)]];
+
+        $this->assertIsString($consumer->encodedBatchPayload($belowLimit));
+        $this->assertFalse($consumer->encodedBatchPayload($atLimit));
+    }
+
+    public function testBatchPayloadEncodingFailureIsNotSendable(): void
+    {
+        $error = null;
+        $consumer = new QueueConsumerTestConsumer(
+            [],
+            [
+                'error_handler' => static function ($code, $message) use (&$error): void {
+                    $error = [$code, $message];
+                },
+            ]
+        );
+
+        $this->assertFalse($consumer->encodedBatchPayload([['event' => "\xB1\x31"]]));
+        $this->assertSame(JSON_ERROR_UTF8, $error[0]);
+        $this->assertStringContainsString('Failed to encode batch payload', $error[1]);
+    }
+
+    public function testLibCurlRejectsOversizedPayloadBeforeSendingRequest(): void
+    {
+        $httpClient = new MockedHttpClient('app.posthog.com');
+        $consumer = new LibCurl('test-key', ['compress_request' => true], $httpClient);
+
+        $result = $consumer->flushBatch([['event' => str_repeat('x', 1024 * 1024)]]);
+
+        $this->assertSame('non_retryable_failure', $result);
+        $this->assertNull($httpClient->calls);
+    }
+
+    public function testForkCurlRejectsOversizedCompressedPayloadWithoutLeakingTempFile(): void
+    {
+        $before = glob('/tmp/forkcurl_*') ?: [];
+        $consumer = new ForkCurl('test-key', ['compress_request' => true]);
+
+        $result = $consumer->flushBatch([['event' => str_repeat('x', 1024 * 1024)]]);
+
+        $after = glob('/tmp/forkcurl_*') ?: [];
+        $created = array_values(array_diff($after, $before));
+        foreach ($created as $file) {
+            @unlink($file);
+        }
+
+        $this->assertSame('non_retryable_failure', $result);
+        $this->assertSame([], $created);
+    }
+
+    public function testSocketRejectsOversizedPayloadBeforeOpeningConnection(): void
+    {
+        $networkAttempted = false;
+        $consumer = new Socket(
+            'test-key',
+            [
+                'compress_request' => true,
+                'host' => 'invalid.invalid',
+                'ssl' => false,
+                'timeout' => 0.01,
+                'error_handler' => static function () use (&$networkAttempted): void {
+                    $networkAttempted = true;
+                },
+            ]
+        );
+
+        $result = $consumer->flushBatch([['event' => str_repeat('x', 1024 * 1024)]]);
+
+        $this->assertSame('non_retryable_failure', $result);
+        $this->assertFalse($networkAttempted);
     }
 
     public function testRetryableFlushFailureKeepsBatchQueued(): void

--- a/test/QueueConsumerTestConsumer.php
+++ b/test/QueueConsumerTestConsumer.php
@@ -36,6 +36,11 @@ class QueueConsumerTestConsumer extends QueueConsumer
         return $this->queue;
     }
 
+    public function encodedBatchPayload(array $batch)
+    {
+        return $this->encodeBatchPayload($batch);
+    }
+
     public function flushBatch($batch)
     {
         $this->flushedBatches[] = $batch;


### PR DESCRIPTION
## :bulb: Motivation and Context

The queued consumers duplicated JSON encoding and payload-size checks. Each transport measured a different representation, so the same batch could be accepted or rejected depending on the selected consumer. ForkCurl also created a compressed temporary file before rejecting an oversized payload, which could leave the file behind.

This change applies the 1 MiB limit to the raw JSON batch for every queued transport. ForkCurl keeps an additional check after shell escaping because escaping can expand an otherwise valid payload beyond the command argument limit.

## :green_heart: How did you test it?

- Ran the full PHPUnit suite: 469 tests and 3868 assertions passed.
- Ran PHPCS on the changed PHP files.
- Ran `composer api:check`.
- Added tests for the exact payload-size boundary, JSON encoding failures, transport side effects, and ForkCurl temporary-file cleanup.
- Tagged the ForkCurl test payload with a unique marker so cleanup cannot remove files created by concurrent processes.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm change` to generate a change intent file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi and a Slopo duplication report were used to identify and implement this change. The shared code only handles JSON encoding and the raw payload limit. Compression, request delivery, and retry behavior remain transport-specific. Autoreview found that ForkCurl still needed its shell-escaped payload guard, so the guard was restored before temporary-file creation. Greptile later identified that the leak test could remove another process's temporary file, so cleanup now identifies only files containing a unique test marker. The final autoreview completed without actionable findings.
