### PR TITLE
fix(flags): handle empty evaluation key scopes

### DIFF
--- a/.changeset/empty-scopes-stop.md
+++ b/.changeset/empty-scopes-stop.md
@@ -1,0 +1,5 @@
+---
+'posthog-php': patch
+---
+
+Return an empty feature flag snapshot without evaluation requests when the requested flag key list is empty.

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -1044,9 +1044,10 @@ class Client implements FeatureFlagEvaluationsHost
      * @param bool $disableGeoip Whether to disable GeoIP enrichment during remote evaluation.
      * @param list<string>|null $flagKeys Optional list of flag keys. When provided, only these
      *     flags are evaluated — the underlying /flags request asks the server for just this
-     *     subset, which makes the response smaller and the request cheaper. Use this when you
-     *     only need a handful of flags out of many. Distinct from FeatureFlagEvaluations::only(),
-     *     which scopes which already-evaluated flags get attached to a captured event.
+     *     subset, which makes the response smaller and the request cheaper. An empty list returns
+     *     an empty snapshot without local or remote evaluation. Use this when you only need a
+     *     handful of flags out of many. Distinct from FeatureFlagEvaluations::only(), which scopes
+     *     which already-evaluated flags get attached to a captured event.
      * @return FeatureFlagEvaluations
      */
     public function evaluateFlags(

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -1069,6 +1069,15 @@ class Client implements FeatureFlagEvaluationsHost
             );
         }
 
+        if ($flagKeys === []) {
+            return new FeatureFlagEvaluations(
+                $distinctId,
+                [],
+                $groups,
+                $this,
+            );
+        }
+
         [$personProperties, $groupProperties] = $this->addLocalPersonAndGroupProperties(
             $groups,
             $personProperties,

--- a/test/FeatureFlagEvaluationsTest.php
+++ b/test/FeatureFlagEvaluationsTest.php
@@ -289,6 +289,19 @@ class FeatureFlagEvaluationsTest extends TestCase
         }
     }
 
+    public function testEmptyFlagKeysReturnsEmptySnapshotWithoutEvaluationRequests(): void
+    {
+        $this->makeClient();
+        $callsBefore = count($this->http_client->calls ?? []);
+
+        $snapshot = PostHog::evaluateFlags('user-1', flagKeys: []);
+
+        $this->assertInstanceOf(FeatureFlagEvaluations::class, $snapshot);
+        $this->assertSame([], $snapshot->getKeys());
+        $this->assertCount($callsBefore, $this->http_client->calls ?? []);
+        $this->assertSame(0, $this->flagsRequestCount());
+    }
+
     public function testFlagKeysIsForwardedInRequestBody(): void
     {
         $this->makeClient();


### PR DESCRIPTION
## :bulb: Motivation and Context

The feature flag evaluation scope needs to distinguish between a scope that was not provided and a scope that was explicitly empty. This follows the behavior defined in [sdk-specs PR #47](https://github.com/PostHog/sdk-specs/pull/47).

When the flag key list is omitted or `null`, the SDK continues to evaluate all applicable flags. When the caller provides an empty list, the SDK now returns an empty snapshot without local evaluation or a `/flags` request. When the caller provides a non-empty list, the SDK continues to evaluate and request only those keys.

The change adds an early return for the explicit empty-list case, documents that behavior on `evaluateFlags`, and includes regression coverage that verifies no evaluation request is made.

## :green_heart: How did you test it?

- `vendor/bin/phpunit --no-coverage --display-phpunit-deprecations --filter '/(testEvaluateFlagsReturnsSnapshotAndMakesOneFlagsRequest|testEmptyFlagKeysReturnsEmptySnapshotWithoutEvaluationRequests|testFlagKeysIsForwardedInRequestBody)$/' test/FeatureFlagEvaluationsTest.php` passed 3 tests with 10 assertions. One unrelated existing doc-comment metadata deprecation remains.
- `vendor/bin/phpcs -n lib/Client.php test/FeatureFlagEvaluationsTest.php` passed.
- `php -l lib/Client.php && php -l test/FeatureFlagEvaluationsTest.php` passed.
- `git diff --check origin/main...HEAD` passed.
- `pnpm change status` recognized the patch intent and planned `posthog-php` 4.13.4.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm change` to generate a change intent file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

OpenAI Codex (`gpt-5.6-sol`) through Pi applied the requested PR workflow and ran the Pi autoreview tool. The Pi session is local and does not have a shareable URL. The implementation keeps the omitted and non-empty behavior unchanged and only short-circuits an explicitly empty key list.

