### PR TITLE
fix(flags): align presence operator semantics

### DIFF
--- a/.changeset/present-properties-match.md
+++ b/.changeset/present-properties-match.md
@@ -1,0 +1,5 @@
+---
+"posthog-php": patch
+---
+
+Align local `is_set` and `is_not_set` evaluation with partial property context.

--- a/.changeset/present-properties-match.md
+++ b/.changeset/present-properties-match.md
@@ -2,4 +2,4 @@
 "posthog-php": patch
 ---
 
-Align local `is_set` and `is_not_set` evaluation with partial property context.
+Return false for the `is_not_set` operator during local evaluation when the property key is present.

--- a/lib/FeatureFlag.php
+++ b/lib/FeatureFlag.php
@@ -32,7 +32,7 @@ class FeatureFlag
         }
 
         if ($operator == "is_not_set") {
-            throw new InconclusiveMatchException("can't match properties with operator is_not_set");
+            return false;
         }
 
         $overrideValue = $propertyValues[$key];

--- a/test/FeatureFlagLocalEvaluationTest.php
+++ b/test/FeatureFlagLocalEvaluationTest.php
@@ -248,34 +248,55 @@ class FeatureFlagLocalEvaluationTest extends TestCase
         ]);
     }
 
-    public function testMatchPropertyIsSet(): void
+    /**
+     * @dataProvider presentPresenceOperatorValuesProvider
+     */
+    public function testMatchPropertyPresenceOperatorsTreatPresentValuesAsSet($value): void
     {
-        $prop = [
-            "key" => "key",
-            "value" => "is_set",
-            "operator" => "is_set"
+        foreach (["is_set" => true, "is_not_set" => false] as $operator => $expected) {
+            $prop = [
+                "key" => "key",
+                "value" => $operator,
+                "operator" => $operator,
+            ];
+
+            self::assertSame($expected, FeatureFlag::matchProperty($prop, [
+                "key" => $value,
+            ]));
+        }
+    }
+
+    public static function presentPresenceOperatorValuesProvider(): array
+    {
+        return [
+            'null' => [null],
+            'false' => [false],
+            'zero' => [0],
+            'empty string' => [''],
+            'empty array' => [[]],
+            // stdClass is PHP's JSON-object host equivalent and keeps it distinct from [] (an empty array).
+            'empty object' => [new \stdClass()],
         ];
+    }
 
-        self::assertTrue(FeatureFlag::matchProperty($prop, [
-            "key" => "value",
-        ]));
+    public function testMatchPropertyPresenceOperatorsAreInconclusiveForOmittedKey(): void
+    {
+        foreach (["is_set", "is_not_set"] as $operator) {
+            $prop = [
+                "key" => "key",
+                "value" => $operator,
+                "operator" => $operator,
+            ];
 
-        self::assertTrue(FeatureFlag::matchProperty($prop, [
-            "key" => "value2",
-        ]));
-
-        self::assertTrue(FeatureFlag::matchProperty($prop, [
-            "key" => "",
-        ]));
-
-        self::assertTrue(FeatureFlag::matchProperty($prop, [
-            "key" => null,
-        ]));
-
-        self::expectException(InconclusiveMatchException::class);
-        FeatureFlag::matchProperty($prop, [
-            "key2" => "value",
-        ]);
+            try {
+                FeatureFlag::matchProperty($prop, [
+                    "key2" => "value",
+                ]);
+                self::fail("Expected InconclusiveMatchException for operator {$operator}");
+            } catch (InconclusiveMatchException $exception) {
+                self::assertInstanceOf(InconclusiveMatchException::class, $exception);
+            }
+        }
     }
 
     public function testMatchPropertyContains(): void


### PR DESCRIPTION
## :bulb: Motivation and Context

[sdk-specs PR #49](https://github.com/PostHog/sdk-specs/pull/49) defines `is_not_set` using partial property context. The PHP local evaluator returned an inconclusive exception even when the caller supplied the property key.

This change returns false for `is_not_set` whenever the key is present, including null and other falsey values. An omitted key remains inconclusive.

## :green_heart: How did you test it?

- `php -l lib/FeatureFlag.php`
- `php -l test/FeatureFlagLocalEvaluationTest.php`
- Direct smoke checks for present and omitted property behavior
- `git diff --check`
- Autoreview completed on commit `6ef03b9` with no actionable findings.

PHPUnit was not run locally because vendor dependencies were unavailable. CI will run the complete test suite.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm change` to generate a change intent file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi coding agent worker subagents implemented the focused matcher change and regression tests. The bundled autoreview tool reviewed the final committed diff against `origin/main`.
