### PR TITLE
fix(flags): align local string matching with the flags service

### DIFF
--- a/.changeset/local-flag-case-folding.md
+++ b/.changeset/local-flag-case-folding.md
@@ -2,4 +2,4 @@
 "posthog-php": patch
 ---
 
-Match local feature flag ASCII and Unicode case handling and numeric stringification with the flags service.
+Match local feature flag boolean coercion, JSON stringification, numeric formatting, and string case handling with the flags service.

--- a/.changeset/local-flag-case-folding.md
+++ b/.changeset/local-flag-case-folding.md
@@ -1,0 +1,5 @@
+---
+"posthog-php": patch
+---
+
+Match local feature flag ASCII and Unicode case handling and numeric stringification with the flags service.

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
 		"ext-json": "*",
 		"php": ">=8.2",
 		"symfony/clock": "^6.2|^7.0|^8.0",
-		"symfony/polyfill-mbstring": "^1.31"
+		"symfony/polyfill-mbstring": "^1.31",
+		"symfony/polyfill-iconv": "^1.31"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^11.0",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
 	"require": {
 		"ext-json": "*",
 		"php": ">=8.2",
-		"symfony/clock": "^6.2|^7.0|^8.0"
+		"symfony/clock": "^6.2|^7.0|^8.0",
+		"symfony/polyfill-mbstring": "^1.31"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^11.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fcbecc0a26b21917b79a5a17199e10e5",
+    "content-hash": "e62591693e048b106dd0dfa5150bd102",
     "packages": [
         {
             "name": "psr/clock",
@@ -131,6 +131,90 @@
                 }
             ],
             "time": "2026-03-24T13:12:05+00:00"
+        },
+        {
+            "name": "symfony/polyfill-iconv",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-iconv.git",
+                "reference": "2c5729fd241b4b22f6e4b436bc3354a4f262df57"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/2c5729fd241b4b22f6e4b436bc3354a4f262df57",
+                "reference": "2c5729fd241b4b22f6e4b436bc3354a4f262df57",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-iconv": "*"
+            },
+            "suggest": {
+                "ext-iconv": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Iconv\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Iconv extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "iconv",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-iconv/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d5821b77f51196ecaf707d618b7bba7c",
+    "content-hash": "fcbecc0a26b21917b79a5a17199e10e5",
     "packages": [
         {
             "name": "psr/clock",
@@ -131,6 +131,91 @@
                 }
             ],
             "time": "2026-03-24T13:12:05+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.38.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-27T06:59:30+00:00"
         },
         {
             "name": "symfony/polyfill-php83",

--- a/lib/FeatureFlag.php
+++ b/lib/FeatureFlag.php
@@ -571,7 +571,14 @@ class FeatureFlag
 
     private static function unicodeLowercase($value)
     {
-        return mb_convert_case($value, MB_CASE_LOWER_SIMPLE, "UTF-8");
+        // Rust's full, context-independent lowercase expands U+0130, while PHP's
+        // simple mode does not. Expand it before applying simple lowercase.
+        $value = str_replace("\u{0130}", "i\u{0307}", $value);
+
+        // The polyfill does not define MB_CASE_LOWER_SIMPLE, but its regular
+        // lowercase mapping is context-independent and therefore equivalent here.
+        $mode = defined('MB_CASE_LOWER_SIMPLE') ? MB_CASE_LOWER_SIMPLE : MB_CASE_LOWER;
+        return mb_convert_case($value, $mode, "UTF-8");
     }
 
     private static function valueToString($value)

--- a/lib/FeatureFlag.php
+++ b/lib/FeatureFlag.php
@@ -580,7 +580,11 @@ class FeatureFlag
             return $value ? "true" : "false";
         }
         if (is_float($value)) {
-            return json_encode($value, JSON_PRESERVE_ZERO_FRACTION | JSON_THROW_ON_ERROR);
+            if (!is_finite($value)) {
+                return strval($value);
+            }
+            $encoded = json_encode($value, JSON_PRESERVE_ZERO_FRACTION | JSON_THROW_ON_ERROR);
+            return preg_replace('/\.0(e[+-]?\d+)$/', '$1', $encoded);
         }
         return strval($value);
     }

--- a/lib/FeatureFlag.php
+++ b/lib/FeatureFlag.php
@@ -104,7 +104,8 @@ class FeatureFlag
                     return FeatureFlag::compare($overrideValue, $parsedValue, $operator, "numeric");
                 }
             } else {
-                return FeatureFlag::compare(FeatureFlag::valueToString($overrideValue), FeatureFlag::valueToString($value), $operator);
+                // Preserve the existing fallback for non-numeric comparison values.
+                return FeatureFlag::compare(strval($overrideValue), strval($value), $operator);
             }
         }
 
@@ -557,8 +558,12 @@ class FeatureFlag
 
     private static function computeExactMatch($value, $overrideValue)
     {
+        if (FeatureFlag::isTruthyOrFalsyPropertyValue($value)) {
+            return FeatureFlag::isTruthyPropertyValue($value) === FeatureFlag::isTruthyPropertyValue($overrideValue);
+        }
+
         $overrideString = FeatureFlag::unicodeLowercase(FeatureFlag::valueToString($overrideValue));
-        if (is_array($value)) {
+        if (is_array($value) && array_is_list($value)) {
             foreach ($value as $candidate) {
                 if (FeatureFlag::unicodeLowercase(FeatureFlag::valueToString($candidate)) === $overrideString) {
                     return true;
@@ -569,31 +574,190 @@ class FeatureFlag
         return FeatureFlag::unicodeLowercase(FeatureFlag::valueToString($value)) === $overrideString;
     }
 
+    private static function isTruthyOrFalsyPropertyValue($value)
+    {
+        if (is_bool($value)) {
+            return true;
+        }
+        if (is_string($value)) {
+            return in_array(strtolower($value), ["true", "false"], true);
+        }
+        if (is_array($value) && array_is_list($value)) {
+            foreach ($value as $candidate) {
+                if (!FeatureFlag::isTruthyOrFalsyPropertyValue($candidate)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private static function isTruthyPropertyValue($value)
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+        if (is_string($value)) {
+            return strtolower($value) === "true";
+        }
+        if (is_array($value) && array_is_list($value)) {
+            foreach ($value as $candidate) {
+                if (!FeatureFlag::isTruthyPropertyValue($candidate)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
     private static function unicodeLowercase($value)
     {
-        // Rust's full, context-independent lowercase expands U+0130, while PHP's
-        // simple mode does not. Expand it before applying simple lowercase.
-        $value = str_replace("\u{0130}", "i\u{0307}", $value);
-
-        // The polyfill does not define MB_CASE_LOWER_SIMPLE, but its regular
-        // lowercase mapping is context-independent and therefore equivalent here.
         $mode = defined('MB_CASE_LOWER_SIMPLE') ? MB_CASE_LOWER_SIMPLE : MB_CASE_LOWER;
+        $characters = preg_split('//u', $value, -1, PREG_SPLIT_NO_EMPTY);
+        if ($characters === false) {
+            return mb_convert_case($value, $mode, "UTF-8");
+        }
+
+        foreach ($characters as $index => $character) {
+            if ($character !== "Σ") {
+                continue;
+            }
+
+            // PHP 8.2+'s PCRE2 supports the Cased and Case_Ignorable
+            // derived properties used by Unicode's Final_Sigma rule.
+            $precededByCased = false;
+            for ($before = $index - 1; $before >= 0; $before--) {
+                if (preg_match('/^\p{Case_Ignorable}$/u', $characters[$before])) {
+                    continue;
+                }
+                $precededByCased = preg_match('/^\p{Cased}$/u', $characters[$before]) === 1;
+                break;
+            }
+
+            $followedByCased = false;
+            for ($after = $index + 1; $after < count($characters); $after++) {
+                if (preg_match('/^\p{Case_Ignorable}$/u', $characters[$after])) {
+                    continue;
+                }
+                $followedByCased = preg_match('/^\p{Cased}$/u', $characters[$after]) === 1;
+                break;
+            }
+
+            $characters[$index] = $precededByCased && !$followedByCased ? "ς" : "σ";
+        }
+
+        // U+0130 is the unconditional multi-code-point lowercase mapping that
+        // PHP's simple mode omits.
+        $value = str_replace("\u{0130}", "i\u{0307}", implode('', $characters));
         return mb_convert_case($value, $mode, "UTF-8");
     }
 
     private static function valueToString($value)
     {
+        if (is_string($value)) {
+            return $value;
+        }
         if (is_bool($value)) {
             return $value ? "true" : "false";
         }
+        if (is_null($value)) {
+            return "null";
+        }
         if (is_float($value)) {
-            if (!is_finite($value)) {
-                return strval($value);
-            }
-            $encoded = json_encode($value, JSON_PRESERVE_ZERO_FRACTION | JSON_THROW_ON_ERROR);
-            return preg_replace('/\.0(e[+-]?\d+)$/', '$1', $encoded);
+            return FeatureFlag::floatToString($value);
+        }
+        if (is_array($value) || is_object($value)) {
+            return FeatureFlag::jsonValueToString($value);
         }
         return strval($value);
+    }
+
+    private static function jsonValueToString($value)
+    {
+        $jsonFlags = JSON_UNESCAPED_LINE_TERMINATORS
+            | JSON_UNESCAPED_SLASHES
+            | JSON_UNESCAPED_UNICODE
+            | JSON_THROW_ON_ERROR;
+
+        if (is_string($value)) {
+            return json_encode($value, $jsonFlags);
+        }
+        if (is_bool($value)) {
+            return $value ? "true" : "false";
+        }
+        if (is_null($value)) {
+            return "null";
+        }
+        if (is_float($value)) {
+            return FeatureFlag::floatToString($value);
+        }
+        if (is_int($value)) {
+            return strval($value);
+        }
+        if ($value instanceof \JsonSerializable) {
+            return FeatureFlag::jsonValueToString($value->jsonSerialize());
+        }
+        if (is_object($value)) {
+            $value = get_object_vars($value);
+            $isList = false;
+        } else {
+            $isList = array_is_list($value);
+        }
+
+        if ($isList) {
+            $items = array_map(fn($item) => FeatureFlag::jsonValueToString($item), $value);
+            return '[' . implode(',', $items) . ']';
+        }
+
+        ksort($value, SORT_STRING);
+        $items = [];
+        foreach ($value as $key => $item) {
+            $encodedKey = json_encode(strval($key), $jsonFlags);
+            $items[] = $encodedKey . ':' . FeatureFlag::jsonValueToString($item);
+        }
+        return '{' . implode(',', $items) . '}';
+    }
+
+    private static function floatToString($value)
+    {
+        if (!is_finite($value)) {
+            return strval($value);
+        }
+
+        $encoded = json_encode($value, JSON_PRESERVE_ZERO_FRACTION | JSON_THROW_ON_ERROR);
+        if ($value == 0.0) {
+            return str_starts_with($encoded, '-') ? "-0.0" : "0.0";
+        }
+
+        preg_match('/^(-?)(\d+)(?:\.(\d+))?(?:e([+-]?\d+))?$/i', $encoded, $parts);
+        $sign = $parts[1];
+        $integer = $parts[2];
+        $fraction = $parts[3] ?? '';
+        $encodedExponent = intval($parts[4] ?? 0);
+        $digits = $integer . $fraction;
+        $firstNonZero = strspn($digits, '0');
+        $digits = rtrim(substr($digits, $firstNonZero), '0');
+        $decimalPosition = strlen($integer) + $encodedExponent;
+        $exponent = $decimalPosition - $firstNonZero - 1;
+
+        if ($exponent >= 16 || $exponent <= -6) {
+            $mantissa = $digits[0];
+            if (strlen($digits) > 1) {
+                $mantissa .= '.' . substr($digits, 1);
+            }
+            return $sign . $mantissa . 'e' . ($exponent >= 0 ? '+' : '') . $exponent;
+        }
+
+        $position = $exponent + 1;
+        if ($position <= 0) {
+            return $sign . '0.' . str_repeat('0', -$position) . $digits;
+        }
+        if ($position >= strlen($digits)) {
+            return $sign . $digits . str_repeat('0', $position - strlen($digits)) . '.0';
+        }
+        return $sign . substr($digits, 0, $position) . '.' . substr($digits, $position);
     }
 
     private static function compare($lhs, $rhs, $operator, $type = "string")

--- a/lib/FeatureFlag.php
+++ b/lib/FeatureFlag.php
@@ -54,7 +54,7 @@ class FeatureFlag
         }
 
         if ($operator == "not_icontains") {
-            return strpos(strtolower(FeatureFlag::valueToString($overrideValue)), strtolower(FeatureFlag::valueToString($value))) == false;
+            return strpos(strtolower(FeatureFlag::valueToString($overrideValue)), strtolower(FeatureFlag::valueToString($value))) === false;
         }
 
         if ($operator == "starts_with") {
@@ -557,19 +557,32 @@ class FeatureFlag
 
     private static function computeExactMatch($value, $overrideValue)
     {
+        $overrideString = FeatureFlag::unicodeLowercase(FeatureFlag::valueToString($overrideValue));
         if (is_array($value)) {
-            return in_array(strtolower(FeatureFlag::valueToString($overrideValue)), array_map('strtolower', array_map(fn($val) => FeatureFlag::valueToString($val), $value)));
+            foreach ($value as $candidate) {
+                if (FeatureFlag::unicodeLowercase(FeatureFlag::valueToString($candidate)) === $overrideString) {
+                    return true;
+                }
+            }
+            return false;
         }
-        return strtolower(FeatureFlag::valueToString($value)) == strtolower(FeatureFlag::valueToString($overrideValue));
+        return FeatureFlag::unicodeLowercase(FeatureFlag::valueToString($value)) === $overrideString;
+    }
+
+    private static function unicodeLowercase($value)
+    {
+        return mb_strtolower($value, "UTF-8");
     }
 
     private static function valueToString($value)
     {
         if (is_bool($value)) {
             return $value ? "true" : "false";
-        } else {
-            return strval($value);
         }
+        if (is_float($value)) {
+            return json_encode($value, JSON_PRESERVE_ZERO_FRACTION | JSON_THROW_ON_ERROR);
+        }
+        return strval($value);
     }
 
     private static function compare($lhs, $rhs, $operator, $type = "string")

--- a/lib/FeatureFlag.php
+++ b/lib/FeatureFlag.php
@@ -571,7 +571,7 @@ class FeatureFlag
 
     private static function unicodeLowercase($value)
     {
-        return mb_strtolower($value, "UTF-8");
+        return mb_convert_case($value, MB_CASE_LOWER_SIMPLE, "UTF-8");
     }
 
     private static function valueToString($value)

--- a/test/FeatureFlagLocalEvaluationTest.php
+++ b/test/FeatureFlagLocalEvaluationTest.php
@@ -258,6 +258,10 @@ class FeatureFlagLocalEvaluationTest extends TestCase
 
         self::assertTrue(FeatureFlag::matchProperty($exact, ["key" => "ä"]));
 
+        $exact["value"] = "İ";
+        self::assertTrue(FeatureFlag::matchProperty($exact, ["key" => "i\u{0307}"]));
+        self::assertFalse(FeatureFlag::matchProperty($exact, ["key" => "i"]));
+
         $exact["value"] = ["FREE", "Ä"];
         self::assertTrue(FeatureFlag::matchProperty($exact, ["key" => "ä"]));
 

--- a/test/FeatureFlagLocalEvaluationTest.php
+++ b/test/FeatureFlagLocalEvaluationTest.php
@@ -269,7 +269,7 @@ class FeatureFlagLocalEvaluationTest extends TestCase
         $isNot["operator"] = "is_not";
         self::assertFalse(FeatureFlag::matchProperty($isNot, ["key" => "ä"]));
 
-        foreach ([["ß", "ss"], ["Σ", "ς"], ["ΟΣ", "ος"]] as [$filter, $property]) {
+        foreach ([["ß", "ss"], ["Σ", "ς"]] as [$filter, $property]) {
             $exact["value"] = $filter;
             self::assertFalse(FeatureFlag::matchProperty($exact, ["key" => $property]));
 
@@ -277,8 +277,53 @@ class FeatureFlagLocalEvaluationTest extends TestCase
             self::assertTrue(FeatureFlag::matchProperty($isNot, ["key" => $property]));
         }
 
-        $exact["value"] = "ΟΣ";
-        self::assertTrue(FeatureFlag::matchProperty($exact, ["key" => "οσ"]));
+        foreach ([["ΟΣ", "ος"], ["ΟΔΟΣ", "οδος"], ["ΠΑΡΑΓΓΕΛΙΕΣ", "παραγγελιες"]] as [$filter, $property]) {
+            $exact["value"] = $filter;
+            self::assertTrue(FeatureFlag::matchProperty($exact, ["key" => $property]));
+
+            $isNot["value"] = $filter;
+            self::assertFalse(FeatureFlag::matchProperty($isNot, ["key" => $property]));
+        }
+
+        foreach ([["ΟΣ", "οσ"], ["ΟΔΟΣ", "οδοσ"], ["ΠΑΡΑΓΓΕΛΙΕΣ", "παραγγελιεσ"]] as [$filter, $property]) {
+            $exact["value"] = $filter;
+            self::assertFalse(FeatureFlag::matchProperty($exact, ["key" => $property]));
+
+            $isNot["value"] = $filter;
+            self::assertTrue(FeatureFlag::matchProperty($isNot, ["key" => $property]));
+        }
+
+        $exact["value"] = "invalid-\xFF";
+        self::assertTrue(FeatureFlag::matchProperty($exact, ["key" => "invalid-\xFF"]));
+    }
+
+    public function testMatchPropertyExactUsesBackendBooleanCoercion(): void
+    {
+        $cases = [
+            [false, "banana", true],
+            ["false", 0, true],
+            [false, ["a" => true], true],
+            [true, ["a" => true], false],
+            [false, new \stdClass(), true],
+            [["false"], null, true],
+            [["true", "false"], "true", false],
+            [["true", "false"], "pro", true],
+            [[], true, true],
+            [[], "true", true],
+            [[], [], true],
+            [[], [true], true],
+            [[], false, false],
+            [[], "banana", false],
+            [["FREE", "PRO"], "pro", true],
+        ];
+
+        foreach ($cases as [$filter, $property, $expected]) {
+            $exact = ["key" => "key", "value" => $filter, "operator" => "exact"];
+            self::assertSame($expected, FeatureFlag::matchProperty($exact, ["key" => $property]));
+
+            $exact["operator"] = "is_not";
+            self::assertSame(!$expected, FeatureFlag::matchProperty($exact, ["key" => $property]));
+        }
     }
 
     public function testMatchPropertyStringificationPreservesIntegralFloats(): void
@@ -305,6 +350,41 @@ class FeatureFlagLocalEvaluationTest extends TestCase
             $exact["value"] = $filter;
             self::assertTrue(FeatureFlag::matchProperty($exact, ["key" => $property]));
         }
+    }
+
+    public function testMatchPropertyStringificationMatchesBackendJson(): void
+    {
+        $cases = [
+            ["[1,2]", [1, 2]],
+            ['{"a":2,"b":1}', ["b" => 1, "a" => 2]],
+            ['{"outer":{"a":2,"b":1}}', ["outer" => ["b" => 1, "a" => 2]]],
+            ["1e-7", 1.0e-7],
+            ["1e-6", 1.0e-6],
+            ["1.2e-6", 1.2e-6],
+            ["1e+16", 1.0e16],
+            ["0.00001", 1.0e-5],
+            ["0.000099", 9.9e-5],
+        ];
+
+        foreach ($cases as [$filter, $property]) {
+            $exact = ["key" => "key", "value" => $filter, "operator" => "exact"];
+            self::assertTrue(FeatureFlag::matchProperty($exact, ["key" => $property]));
+
+            $exact["operator"] = "is_not";
+            self::assertFalse(FeatureFlag::matchProperty($exact, ["key" => $property]));
+        }
+
+        $exact = ["key" => "key", "value" => "Array", "operator" => "exact"];
+        self::assertFalse(FeatureFlag::matchProperty($exact, ["key" => [1, 2]]));
+
+        $jsonSerializable = new class implements \JsonSerializable {
+            public function jsonSerialize(): mixed
+            {
+                return ["b" => 1, "a" => 2];
+            }
+        };
+        $exact["value"] = '{"a":2,"b":1}';
+        self::assertTrue(FeatureFlag::matchProperty($exact, ["key" => $jsonSerializable]));
     }
 
     /**
@@ -1254,7 +1334,7 @@ class FeatureFlagLocalEvaluationTest extends TestCase
             "operator" => "is_not"
         ];
 
-        self::assertTrue(FeatureFlag::matchProperty($prop_a, [
+        self::assertFalse(FeatureFlag::matchProperty($prop_a, [
             "key" => null,
         ]));
         self::assertFalse(FeatureFlag::matchProperty($prop_a, [

--- a/test/FeatureFlagLocalEvaluationTest.php
+++ b/test/FeatureFlagLocalEvaluationTest.php
@@ -248,6 +248,53 @@ class FeatureFlagLocalEvaluationTest extends TestCase
         ]);
     }
 
+    public function testMatchPropertyExactUsesUnicodeLowercase(): void
+    {
+        $exact = [
+            "key" => "key",
+            "value" => "Ä",
+            "operator" => "exact",
+        ];
+
+        self::assertTrue(FeatureFlag::matchProperty($exact, ["key" => "ä"]));
+
+        $exact["value"] = ["FREE", "Ä"];
+        self::assertTrue(FeatureFlag::matchProperty($exact, ["key" => "ä"]));
+
+        $isNot = $exact;
+        $isNot["operator"] = "is_not";
+        self::assertFalse(FeatureFlag::matchProperty($isNot, ["key" => "ä"]));
+
+        foreach ([["ß", "ss"], ["Σ", "ς"]] as [$filter, $property]) {
+            $exact["value"] = $filter;
+            self::assertFalse(FeatureFlag::matchProperty($exact, ["key" => $property]));
+
+            $isNot["value"] = $filter;
+            self::assertTrue(FeatureFlag::matchProperty($isNot, ["key" => $property]));
+        }
+    }
+
+    public function testMatchPropertyStringificationPreservesIntegralFloats(): void
+    {
+        $exact = [
+            "key" => "key",
+            "value" => "323.0",
+            "operator" => "exact",
+        ];
+
+        self::assertTrue(FeatureFlag::matchProperty($exact, ["key" => 323.0]));
+        self::assertFalse(FeatureFlag::matchProperty($exact, ["key" => 323]));
+
+        $endsWith = [
+            "key" => "key",
+            "value" => "3",
+            "operator" => "ends_with",
+        ];
+
+        self::assertFalse(FeatureFlag::matchProperty($endsWith, ["key" => 323.0]));
+        self::assertTrue(FeatureFlag::matchProperty($endsWith, ["key" => 323]));
+    }
+
     /**
      * @dataProvider presentPresenceOperatorValuesProvider
      */
@@ -352,6 +399,24 @@ class FeatureFlagLocalEvaluationTest extends TestCase
         self::assertFalse(FeatureFlag::matchProperty($prop, [
             "key" => "three",
         ]));
+
+        // Case folding is ASCII-only, mirroring the flags service.
+        $prop["value"] = "ä";
+        self::assertFalse(FeatureFlag::matchProperty($prop, ["key" => "ÄBC"]));
+        self::assertTrue(FeatureFlag::matchProperty($prop, ["key" => "äbc"]));
+    }
+
+    public function testMatchPropertyNotContainsNegatesMatchAtOffsetZero(): void
+    {
+        $prop = [
+            "key" => "key",
+            "value" => "VALUE",
+            "operator" => "not_icontains",
+        ];
+
+        self::assertFalse(FeatureFlag::matchProperty($prop, ["key" => "value suffix"]));
+        self::assertFalse(FeatureFlag::matchProperty($prop, ["key" => "prefix value suffix"]));
+        self::assertTrue(FeatureFlag::matchProperty($prop, ["key" => "different"]));
     }
 
     public function testMatchPropertyStartsWith(): void

--- a/test/FeatureFlagLocalEvaluationTest.php
+++ b/test/FeatureFlagLocalEvaluationTest.php
@@ -293,6 +293,11 @@ class FeatureFlagLocalEvaluationTest extends TestCase
 
         self::assertFalse(FeatureFlag::matchProperty($endsWith, ["key" => 323.0]));
         self::assertTrue(FeatureFlag::matchProperty($endsWith, ["key" => 323]));
+
+        foreach ([["1e+20", 1.0e20], ["-1e-7", -1.0e-7], ["INF", INF], ["NAN", NAN]] as [$filter, $property]) {
+            $exact["value"] = $filter;
+            self::assertTrue(FeatureFlag::matchProperty($exact, ["key" => $property]));
+        }
     }
 
     /**

--- a/test/FeatureFlagLocalEvaluationTest.php
+++ b/test/FeatureFlagLocalEvaluationTest.php
@@ -265,13 +265,16 @@ class FeatureFlagLocalEvaluationTest extends TestCase
         $isNot["operator"] = "is_not";
         self::assertFalse(FeatureFlag::matchProperty($isNot, ["key" => "ä"]));
 
-        foreach ([["ß", "ss"], ["Σ", "ς"]] as [$filter, $property]) {
+        foreach ([["ß", "ss"], ["Σ", "ς"], ["ΟΣ", "ος"]] as [$filter, $property]) {
             $exact["value"] = $filter;
             self::assertFalse(FeatureFlag::matchProperty($exact, ["key" => $property]));
 
             $isNot["value"] = $filter;
             self::assertTrue(FeatureFlag::matchProperty($isNot, ["key" => $property]));
         }
+
+        $exact["value"] = "ΟΣ";
+        self::assertTrue(FeatureFlag::matchProperty($exact, ["key" => "οσ"]));
     }
 
     public function testMatchPropertyStringificationPreservesIntegralFloats(): void


### PR DESCRIPTION
## :bulb: Motivation and Context

Local feature flag evaluation did not match the released `/flags` service for exact comparisons, Unicode lowercase, or JSON value stringification.

This fixes PostHog/posthog#78019 by:

- reproducing the released backend's boolean-like filter gate before ordinary array membership, including its current empty-array behavior
- applying ordinary ANY membership only to arrays that are not entirely boolean-like
- keeping `is_not` as the direct complement of `exact`
- serializing arrays and objects as compact JSON with recursively sorted object keys
- formatting finite PHP floats with the same cutovers and exponent spelling as `serde_json` for the same IEEE-754 value
- applying full Unicode lowercase for final sigma and dotted-I expansion on PHP 8.2+, with and without native mbstring/iconv
- keeping `icontains`, prefix, and suffix operators on the existing ASCII-only lowercase path
- using strict `strpos` comparison for `not_icontains`
- retaining `symfony/polyfill-mbstring` and `symfony/polyfill-iconv` for installations without the native extensions

The SDK intentionally follows the currently released backend. [PostHog/posthog#90694](https://github.com/PostHog/posthog/pull/90694) is a separate draft proposing more intuitive boolean and empty-array semantics. This SDK can follow that behavior if the backend proposal is accepted later.

A patch changeset is included for `posthog-php`.

## :green_heart: How did you test it?

- Added red-green regressions for boolean coercion, boolean arrays, empty arrays, recursively sorted JSON, float cutovers, final sigma, dotted I, malformed UTF-8, and `JsonSerializable`
- `vendor/bin/phpunit --no-coverage` - 481 tests and 3,966 assertions passed
- `vendor/bin/phpcs --warning-severity=0` - no errors
- `composer validate --no-check-publish` - valid, with the existing package version warning
- `composer api:check` - public API snapshot is up to date
- `composer audit` - no security advisories
- A 1,000-value same-bit float comparison matched `serde_json` output
- Disposable PHP 8.2, 8.3, and 8.4 containers passed the behavior matrix
- An Alpine PHP 8.3 container passed with native mbstring and iconv both absent

PHPUnit reported existing warnings and deprecations, but no test failures.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Added a patch changeset for `posthog-php`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi using the address-pr-comments, check-pr, autoreview, and karpathy-guidelines skills. Autoreview found malformed UTF-8 and `JsonSerializable` gaps, which were reproduced and fixed before push. A claim that PHP PCRE2 lacked the Final_Sigma Unicode properties was rejected after PHP 8.2, 8.3, 8.4, and Alpine runtime validation confirmed support.
