### PR TITLE
fix(flags): honor versioned local property matching

### DIFF
--- a/.changeset/versioned-property-matching.md
+++ b/.changeset/versioned-property-matching.md
@@ -1,0 +1,5 @@
+---
+posthog-php: patch
+---
+
+Honor the definitions snapshot's `property_matching_version` during local feature flag evaluation, including group, cohort, and flag dependency conditions. Version 2 uses explicit boolean matching; missing or other versions retain legacy matching. Preserve the selector across external definition caches and reloads.

--- a/api/public-api.json
+++ b/api/public-api.json
@@ -2136,6 +2136,16 @@
                             "default": null,
                             "defaultConstant": null,
                             "hasDefault": false
+                        },
+                        {
+                            "name": "propertyMatchingVersion",
+                            "type": null,
+                            "byReference": false,
+                            "variadic": false,
+                            "optional": true,
+                            "default": 1,
+                            "defaultConstant": null,
+                            "hasDefault": true
                         }
                     ]
                 },
@@ -2202,6 +2212,16 @@
                             "variadic": false,
                             "optional": true,
                             "default": null,
+                            "defaultConstant": null,
+                            "hasDefault": true
+                        },
+                        {
+                            "name": "propertyMatchingVersion",
+                            "type": null,
+                            "byReference": false,
+                            "variadic": false,
+                            "optional": true,
+                            "default": 1,
                             "defaultConstant": null,
                             "hasDefault": true
                         }
@@ -2302,6 +2322,16 @@
                             "default": [],
                             "defaultConstant": null,
                             "hasDefault": true
+                        },
+                        {
+                            "name": "propertyMatchingVersion",
+                            "type": null,
+                            "byReference": false,
+                            "variadic": false,
+                            "optional": true,
+                            "default": 1,
+                            "defaultConstant": null,
+                            "hasDefault": true
                         }
                     ]
                 },
@@ -2330,6 +2360,16 @@
                             "default": null,
                             "defaultConstant": null,
                             "hasDefault": false
+                        },
+                        {
+                            "name": "propertyMatchingVersion",
+                            "type": null,
+                            "byReference": false,
+                            "variadic": false,
+                            "optional": true,
+                            "default": 1,
+                            "defaultConstant": null,
+                            "hasDefault": true
                         }
                     ]
                 },
@@ -2396,6 +2436,16 @@
                             "variadic": false,
                             "optional": true,
                             "default": null,
+                            "defaultConstant": null,
+                            "hasDefault": true
+                        },
+                        {
+                            "name": "propertyMatchingVersion",
+                            "type": null,
+                            "byReference": false,
+                            "variadic": false,
+                            "optional": true,
+                            "default": 1,
                             "defaultConstant": null,
                             "hasDefault": true
                         }

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -136,6 +136,9 @@ class Client implements FeatureFlagEvaluationsHost
      */
     public $featureFlagsByKey;
 
+    /** @var mixed Matching selector from the current definition set; missing defaults to legacy. */
+    private $propertyMatchingVersion = 1;
+
     /**
      * @var SizeLimitedHash
      */
@@ -783,12 +786,14 @@ class Client implements FeatureFlagEvaluationsHost
         $featureFlagError = null;
         $localFlagDefinition = null;
 
-        foreach ($this->featureFlags as $flag) {
+        $definitionSnapshot = $this->flagDefinitionSnapshot();
+        foreach ($definitionSnapshot['flags'] as $flag) {
             if ($flag["key"] == $key) {
                 $localFlagDefinition = $flag;
                 try {
                     $result = $this->computeFlagLocally(
                         $flag,
+                        $definitionSnapshot,
                         $distinctId,
                         $groups,
                         $personProperties,
@@ -994,11 +999,13 @@ class Client implements FeatureFlagEvaluationsHost
         $response = [];
         $fallbackToFlags = false;
 
-        if (count($this->featureFlags) > 0) {
-            foreach ($this->featureFlags as $flag) {
+        $definitionSnapshot = $this->flagDefinitionSnapshot();
+        if (count($definitionSnapshot['flags']) > 0) {
+            foreach ($definitionSnapshot['flags'] as $flag) {
                 try {
                     $response[$flag['key']] = $this->computeFlagLocally(
                         $flag,
+                        $definitionSnapshot,
                         $distinctId,
                         $groups,
                         $personProperties,
@@ -1095,10 +1102,11 @@ class Client implements FeatureFlagEvaluationsHost
         // Local pass: try to resolve any flag we can without going to the server. Track whether
         // any flag was inconclusive (which forces a remote round trip) so we can skip /flags
         // entirely when local evaluation covered everything we know about.
-        $hasLocalDefinitions = count($this->featureFlags) > 0;
+        $definitionSnapshot = $this->flagDefinitionSnapshot();
+        $hasLocalDefinitions = count($definitionSnapshot['flags']) > 0;
         if ($hasLocalDefinitions) {
             $localKeys = [];
-            foreach ($this->featureFlags as $flag) {
+            foreach ($definitionSnapshot['flags'] as $flag) {
                 $key = $flag['key'] ?? null;
                 if (!is_string($key) || $key === '') {
                     continue;
@@ -1112,6 +1120,7 @@ class Client implements FeatureFlagEvaluationsHost
                 try {
                     $value = $this->computeFlagLocally(
                         $flag,
+                        $definitionSnapshot,
                         $distinctId,
                         $groups,
                         $personProperties,
@@ -1320,8 +1329,26 @@ class Client implements FeatureFlagEvaluationsHost
         error_log("[PostHog][Client] " . $message);
     }
 
+    /**
+     * Capture one definition context for an entire local evaluation, including dependencies.
+     * PHP arrays are copy-on-write, so a reentrant reload cannot change this snapshot.
+     *
+     * @return array<string, mixed>
+     */
+    private function flagDefinitionSnapshot(): array
+    {
+        return [
+            'flags' => $this->featureFlags,
+            'flags_by_key' => $this->featureFlagsByKey,
+            'group_type_mapping' => $this->groupTypeMapping,
+            'cohorts' => $this->cohorts,
+            'property_matching_version' => $this->propertyMatchingVersion,
+        ];
+    }
+
     private function computeFlagLocally(
         array $featureFlag,
+        array $definitionSnapshot,
         string $distinctId,
         array $groups = array(),
         array $personProperties = array(),
@@ -1342,7 +1369,7 @@ class Client implements FeatureFlagEvaluationsHost
         $aggregationGroupTypeIndex = $flagFilters["aggregation_group_type_index"] ?? null;
 
         if (!is_null($aggregationGroupTypeIndex)) {
-            $groupName = $this->groupTypeMapping[strval($aggregationGroupTypeIndex)] ?? null;
+            $groupName = $definitionSnapshot['group_type_mapping'][strval($aggregationGroupTypeIndex)] ?? null;
 
             if (is_null($groupName)) {
                 throw new InconclusiveMatchException("Flag has unknown group type index");
@@ -1357,12 +1384,13 @@ class Client implements FeatureFlagEvaluationsHost
                 $featureFlag,
                 $groups[$groupName],
                 $focusedGroupProperties,
-                $this->cohorts,
-                $this->featureFlagsByKey,
+                $definitionSnapshot['cohorts'],
+                $definitionSnapshot['flags_by_key'],
                 $evaluationCache,
                 $groups,
                 $groupProperties,
-                $this->groupTypeMapping
+                $definitionSnapshot['group_type_mapping'],
+                $definitionSnapshot['property_matching_version']
             );
         } else {
             $localPersonProperties = $personProperties;
@@ -1374,12 +1402,13 @@ class Client implements FeatureFlagEvaluationsHost
                 $featureFlag,
                 $distinctId,
                 $localPersonProperties,
-                $this->cohorts,
-                $this->featureFlagsByKey,
+                $definitionSnapshot['cohorts'],
+                $definitionSnapshot['flags_by_key'],
                 $evaluationCache,
                 $groups,
                 $groupProperties,
-                $this->groupTypeMapping
+                $definitionSnapshot['group_type_mapping'],
+                $definitionSnapshot['property_matching_version']
             );
         }
     }
@@ -1561,6 +1590,7 @@ class Client implements FeatureFlagEvaluationsHost
                 : [],
             'cohorts' => isset($data['cohorts']) && is_array($data['cohorts']) ? $data['cohorts'] : [],
             'minimal_flag_called_events' => ($data['minimal_flag_called_events'] ?? null) === true,
+            'property_matching_version' => $data['property_matching_version'] ?? 1,
         ];
     }
 
@@ -1598,6 +1628,7 @@ class Client implements FeatureFlagEvaluationsHost
             'group_type_mapping' => $groupTypeMapping,
             'cohorts' => $data['cohorts'],
             'minimal_flag_called_events' => ($data['minimal_flag_called_events'] ?? null) === true,
+            'property_matching_version' => $data['property_matching_version'] ?? 1,
         ];
     }
 
@@ -1612,6 +1643,7 @@ class Client implements FeatureFlagEvaluationsHost
         $this->featureFlags = $data['flags'];
         $this->groupTypeMapping = $data['group_type_mapping'];
         $this->cohorts = $data['cohorts'];
+        $this->propertyMatchingVersion = $data['property_matching_version'];
         $this->minimalFlagCalledEvents = $data['minimal_flag_called_events'];
 
         // Build flags by key dictionary for dependency resolution

--- a/lib/FeatureFlag.php
+++ b/lib/FeatureFlag.php
@@ -18,10 +18,11 @@ class FeatureFlag
      *
      * @param array<string, mixed> $property Feature flag property filter.
      * @param array<string, mixed> $propertyValues Available property values keyed by property name.
+     * @param mixed $propertyMatchingVersion Definition snapshot selector; only 2 enables explicit matching.
      * @return bool Whether the property matches.
      * @throws InconclusiveMatchException When the property cannot be evaluated locally.
      */
-    public static function matchProperty($property, $propertyValues)
+    public static function matchProperty($property, $propertyValues, $propertyMatchingVersion = 1)
     {
         $key = $property["key"];
         $operator = $property["operator"] ?? "exact";
@@ -38,11 +39,11 @@ class FeatureFlag
         $overrideValue = $propertyValues[$key];
 
         if ($operator == "exact") {
-            return FeatureFlag::computeExactMatch($value, $overrideValue);
+            return FeatureFlag::computeExactMatch($value, $overrideValue, $propertyMatchingVersion);
         }
 
         if ($operator == "is_not") {
-            return !FeatureFlag::computeExactMatch($value, $overrideValue);
+            return !FeatureFlag::computeExactMatch($value, $overrideValue, $propertyMatchingVersion);
         }
 
         if ($operator == "is_set") {
@@ -186,12 +187,20 @@ class FeatureFlag
      * @param array<string, array<string, mixed>>|null $flagsByKey Local feature flag definitions keyed by key.
      * @param array<string, mixed>|null $evaluationCache Cache used for flag dependency evaluation.
      * @param string|null $distinctId Distinct ID used for nested flag dependency evaluation.
+     * @param mixed $propertyMatchingVersion Definition snapshot selector; defaults to legacy matching.
      * @return bool Whether the cohort matches.
      * @throws RequiresServerEvaluationException When the cohort requires server-side data.
      * @throws InconclusiveMatchException When the cohort cannot be evaluated locally.
      */
-    public static function matchCohort($property, $propertyValues, $cohortProperties, $flagsByKey = null, $evaluationCache = null, $distinctId = null)
-    {
+    public static function matchCohort(
+        $property,
+        $propertyValues,
+        $cohortProperties,
+        $flagsByKey = null,
+        $evaluationCache = null,
+        $distinctId = null,
+        $propertyMatchingVersion = 1
+    ) {
         $cohortId = strval($property["value"]);
         if (!array_key_exists($cohortId, $cohortProperties)) {
             throw new RequiresServerEvaluationException(
@@ -201,7 +210,15 @@ class FeatureFlag
         }
 
         $propertyGroup = $cohortProperties[$cohortId];
-        return FeatureFlag::matchPropertyGroup($propertyGroup, $propertyValues, $cohortProperties, $flagsByKey, $evaluationCache, $distinctId);
+        return FeatureFlag::matchPropertyGroup(
+            $propertyGroup,
+            $propertyValues,
+            $cohortProperties,
+            $flagsByKey,
+            $evaluationCache,
+            $distinctId,
+            $propertyMatchingVersion
+        );
     }
 
     /**
@@ -213,12 +230,20 @@ class FeatureFlag
      * @param array<string, array<string, mixed>>|null $flagsByKey Local feature flag definitions keyed by key.
      * @param array<string, mixed>|null $evaluationCache Cache used for flag dependency evaluation.
      * @param string|null $distinctId Distinct ID used for nested flag dependency evaluation.
+     * @param mixed $propertyMatchingVersion Definition snapshot selector; defaults to legacy matching.
      * @return bool Whether the property group matches.
      * @throws RequiresServerEvaluationException When server-side data is required.
      * @throws InconclusiveMatchException When the group cannot be evaluated locally.
      */
-    public static function matchPropertyGroup($propertyGroup, $propertyValues, $cohortProperties, $flagsByKey = null, $evaluationCache = null, $distinctId = null)
-    {
+    public static function matchPropertyGroup(
+        $propertyGroup,
+        $propertyValues,
+        $cohortProperties,
+        $flagsByKey = null,
+        $evaluationCache = null,
+        $distinctId = null,
+        $propertyMatchingVersion = 1
+    ) {
         if (!$propertyGroup) {
             return true;
         }
@@ -237,7 +262,15 @@ class FeatureFlag
             // a nested property group
             foreach ($properties as $prop) {
                 try {
-                    $matches = FeatureFlag::matchPropertyGroup($prop, $propertyValues, $cohortProperties, $flagsByKey, $evaluationCache, $distinctId);
+                    $matches = FeatureFlag::matchPropertyGroup(
+                        $prop,
+                        $propertyValues,
+                        $cohortProperties,
+                        $flagsByKey,
+                        $evaluationCache,
+                        $distinctId,
+                        $propertyMatchingVersion
+                    );
                     if ($propertyGroupType === 'AND') {
                         if (!$matches) {
                             return false;
@@ -267,11 +300,27 @@ class FeatureFlag
                     $matches = false;
                     $propType = $prop["type"] ?? null;
                     if ($propType === 'cohort') {
-                        $matches = FeatureFlag::matchCohort($prop, $propertyValues, $cohortProperties, $flagsByKey, $evaluationCache, $distinctId);
+                        $matches = FeatureFlag::matchCohort(
+                            $prop,
+                            $propertyValues,
+                            $cohortProperties,
+                            $flagsByKey,
+                            $evaluationCache,
+                            $distinctId,
+                            $propertyMatchingVersion
+                        );
                     } elseif ($propType === 'flag') {
-                        $matches = FeatureFlag::evaluateFlagDependency($prop, $flagsByKey, $evaluationCache, $distinctId, $propertyValues, $cohortProperties);
+                        $matches = FeatureFlag::evaluateFlagDependency(
+                            $prop,
+                            $flagsByKey,
+                            $evaluationCache,
+                            $distinctId,
+                            $propertyValues,
+                            $cohortProperties,
+                            $propertyMatchingVersion
+                        );
                     } else {
-                        $matches = FeatureFlag::matchProperty($prop, $propertyValues);
+                        $matches = FeatureFlag::matchProperty($prop, $propertyValues, $propertyMatchingVersion);
                     }
 
                     $negation = $prop["negation"] ?? false;
@@ -556,10 +605,14 @@ class FeatureFlag
         }
     }
 
-    private static function computeExactMatch($value, $overrideValue)
+    private static function computeExactMatch($value, $overrideValue, $propertyMatchingVersion)
     {
-        if (FeatureFlag::isTruthyOrFalsyPropertyValue($value)) {
+        if ($propertyMatchingVersion !== 2 && FeatureFlag::isTruthyOrFalsyPropertyValue($value)) {
             return FeatureFlag::isTruthyPropertyValue($value) === FeatureFlag::isTruthyPropertyValue($overrideValue);
+        }
+
+        if ($value === []) {
+            return FeatureFlag::isTruthyPropertyValue($overrideValue);
         }
 
         $overrideString = FeatureFlag::unicodeLowercase(FeatureFlag::valueToString($overrideValue));
@@ -840,6 +893,7 @@ class FeatureFlag
      * @param array<string, mixed> $groups Group identifiers for group-based flags.
      * @param array<string, array<string, mixed>> $groupProperties Group properties for evaluation.
      * @param array<string, string> $groupTypeMapping Mapping from group type index to group type name.
+     * @param mixed $propertyMatchingVersion Definition snapshot selector; defaults to legacy matching.
      * @return bool|string False for disabled, true for enabled boolean flags, or variant key.
      * @throws RequiresServerEvaluationException When server-side data is required.
      * @throws InconclusiveMatchException When the flag cannot be evaluated locally.
@@ -853,7 +907,8 @@ class FeatureFlag
         $evaluationCache = null,
         $groups = [],
         $groupProperties = [],
-        $groupTypeMapping = []
+        $groupTypeMapping = [],
+        $propertyMatchingVersion = 1
     ) {
         $flagFilters = $flag["filters"] ?? [];
         $flagConditions = $flagFilters["groups"] ?? [];
@@ -891,7 +946,16 @@ class FeatureFlag
                     }
                 }
 
-                $matchResult = FeatureFlag::isConditionMatch($flag, $effectiveBucketing, $condition, $effectiveProperties, $cohorts, $flagsByKey, $evaluationCache);
+                $matchResult = FeatureFlag::isConditionMatch(
+                    $flag,
+                    $effectiveBucketing,
+                    $condition,
+                    $effectiveProperties,
+                    $cohorts,
+                    $flagsByKey,
+                    $evaluationCache,
+                    $propertyMatchingVersion
+                );
 
                 if ($matchResult === ConditionMatch::Match) {
                     $variantOverride = $condition["variant"] ?? null;
@@ -940,8 +1004,16 @@ class FeatureFlag
         return false;
     }
 
-    private static function isConditionMatch($featureFlag, $distinctId, $condition, $properties, $cohorts, $flagsByKey = null, $evaluationCache = null): ConditionMatch
-    {
+    private static function isConditionMatch(
+        $featureFlag,
+        $distinctId,
+        $condition,
+        $properties,
+        $cohorts,
+        $flagsByKey = null,
+        $evaluationCache = null,
+        $propertyMatchingVersion = 1
+    ): ConditionMatch {
         $rolloutPercentage = array_key_exists("rollout_percentage", $condition) ? $condition["rollout_percentage"] : null;
 
         if (count($condition['properties'] ?? []) > 0) {
@@ -949,11 +1021,27 @@ class FeatureFlag
                 $matches = false;
                 $propertyType = $property['type'] ?? null;
                 if ($propertyType == 'cohort') {
-                    $matches = FeatureFlag::matchCohort($property, $properties, $cohorts, $flagsByKey, $evaluationCache, $distinctId);
+                    $matches = FeatureFlag::matchCohort(
+                        $property,
+                        $properties,
+                        $cohorts,
+                        $flagsByKey,
+                        $evaluationCache,
+                        $distinctId,
+                        $propertyMatchingVersion
+                    );
                 } elseif ($propertyType == 'flag') {
-                    $matches = FeatureFlag::evaluateFlagDependency($property, $flagsByKey, $evaluationCache, $distinctId, $properties, $cohorts);
+                    $matches = FeatureFlag::evaluateFlagDependency(
+                        $property,
+                        $flagsByKey,
+                        $evaluationCache,
+                        $distinctId,
+                        $properties,
+                        $cohorts,
+                        $propertyMatchingVersion
+                    );
                 } else {
-                    $matches = FeatureFlag::matchProperty($property, $properties);
+                    $matches = FeatureFlag::matchProperty($property, $properties, $propertyMatchingVersion);
                 }
 
                 if (!$matches) {
@@ -1014,11 +1102,19 @@ class FeatureFlag
      * @param string $distinctId Distinct ID used for bucketing.
      * @param array<string, mixed> $properties Person or group properties for evaluation.
      * @param array<string, mixed> $cohortProperties Local cohort definitions keyed by cohort ID.
+     * @param mixed $propertyMatchingVersion Definition snapshot selector; defaults to legacy matching.
      * @return bool Whether the dependency matches.
      * @throws InconclusiveMatchException When the dependency cannot be evaluated locally.
      */
-    public static function evaluateFlagDependency($property, $flagsByKey, $evaluationCache, $distinctId, $properties, $cohortProperties)
-    {
+    public static function evaluateFlagDependency(
+        $property,
+        $flagsByKey,
+        $evaluationCache,
+        $distinctId,
+        $properties,
+        $cohortProperties,
+        $propertyMatchingVersion = 1
+    ) {
         if ($flagsByKey === null || $evaluationCache === null) {
             throw new InconclusiveMatchException(sprintf(
                 "Cannot evaluate flag dependency on '%s' without flags_by_key and evaluation_cache",
@@ -1077,7 +1173,8 @@ class FeatureFlag
                             $properties,
                             $cohortProperties,
                             $flagsByKey,
-                            $evaluationCache
+                            $evaluationCache,
+                            propertyMatchingVersion: $propertyMatchingVersion
                         );
                         $evaluationCache[$depFlagKey] = $depResult;
                     } catch (InconclusiveMatchException $e) {

--- a/lib/FlagDefinitionCacheProvider.php
+++ b/lib/FlagDefinitionCacheProvider.php
@@ -15,8 +15,11 @@ interface FlagDefinitionCacheProvider
      * Retrieve cached local-evaluation flag definitions.
      *
      * Return null when the external cache is empty or unavailable. Returned data should include the
-     * complete definition set: flags, group_type_mapping, and cohorts. groupTypeMapping is also
-     * accepted when reading cached data for integrations that prefer camelCase.
+     * complete definition set: flags, group_type_mapping, cohorts, and property_matching_version.
+     * Preserve property_matching_version together with the definitions: only 2 selects explicit
+     * property matching; missing/1 and other versions use legacy matching. Older cache entries
+     * without this field remain supported and reset matching to legacy when loaded.
+     * groupTypeMapping is also accepted for integrations that prefer camelCase.
      *
      * @return array<string, mixed>|null
      */
@@ -34,6 +37,7 @@ interface FlagDefinitionCacheProvider
 
     /**
      * Receive definitions fetched successfully from PostHog so they can be stored externally.
+     * Store the complete array, including property_matching_version, as one snapshot.
      *
      * @param array<string, mixed> $data
      * @return void

--- a/test/FlagDefinitionCacheProviderTest.php
+++ b/test/FlagDefinitionCacheProviderTest.php
@@ -331,6 +331,225 @@ class FlagDefinitionCacheProviderTest extends TestCase
         );
     }
 
+    public function testMatchingVersionSurvivesApiAndProviderRoundTrip(): void
+    {
+        $provider = new MockFlagDefinitionCacheProvider();
+        $httpClient = new MockedHttpClient(
+            host: 'app.posthog.com',
+            flagEndpointResponse: $this->versionedDefinitions(2)
+        );
+        $client = $this->createClient($provider, $httpClient);
+        $this->assertVersionedResults($client, false);
+        $this->assertSame(2, $provider->storedData['property_matching_version']);
+
+        $provider->shouldFetch = false;
+        $provider->cachedData = $provider->storedData;
+        $cacheHttp = new MockedHttpClient(host: 'app.posthog.com');
+        $cachedClient = $this->createClient($provider, $cacheHttp);
+        $this->assertVersionedResults($cachedClient, false);
+        $this->assertSame([], $cacheHttp->calls ?? []);
+        $this->assertOnlyDefinitionsRequests($httpClient);
+    }
+
+    public function testVersionOnlyApiReloadAnd304OrFailurePreserveSnapshot(): void
+    {
+        $provider = new MockFlagDefinitionCacheProvider();
+        $httpClient = new MockedHttpClient(host: 'app.posthog.com');
+        $httpClient->setFlagEndpointResponseQueue([
+            ['response' => $this->versionedDefinitions(1), 'etag' => 'legacy'],
+            ['response' => $this->versionedDefinitions(2), 'etag' => 'explicit'],
+            ['responseCode' => 304],
+            ['responseCode' => 500],
+            ['response' => $this->versionedDefinitions(1)],
+            ['response' => $this->versionedDefinitions(2)],
+            ['response' => $this->versionedDefinitions(null)],
+            ['response' => $this->versionedDefinitions(3)],
+        ]);
+        $client = $this->createClient($provider, $httpClient);
+        foreach ([true, false, false, false, true, false, true, true] as $index => $expected) {
+            if ($index > 0) {
+                $client->loadFlags();
+            }
+            $this->assertVersionedResults($client, $expected);
+            if ($index === 2 || $index === 3) {
+                $this->assertSame('explicit', $client->getFlagsEtag());
+                $this->assertSame(2, $provider->storedData['property_matching_version']);
+            }
+        }
+        $this->assertOnlyDefinitionsRequests($httpClient);
+    }
+
+    public function testVersionOnlyCacheReloadAndReadFailure(): void
+    {
+        $provider = new MockFlagDefinitionCacheProvider();
+        $provider->shouldFetch = false;
+        $provider->cachedData = $this->versionedDefinitions(1);
+        $httpClient = new MockedHttpClient(host: 'app.posthog.com');
+        $client = $this->createClient($provider, $httpClient);
+        foreach ([1, 2, 1, 2, null, 3] as $version) {
+            $provider->cachedData = $this->versionedDefinitions($version);
+            // Also cover the provider's supported camelCase projection.
+            $provider->cachedData['groupTypeMapping'] = $provider->cachedData['group_type_mapping'];
+            unset($provider->cachedData['group_type_mapping']);
+            $client->loadFlags();
+            $this->assertVersionedResults($client, $version !== 2);
+            if ($version === 2) {
+                $provider->getError = new \RuntimeException('read failed');
+                $client->loadFlags();
+                $this->assertVersionedResults($client, false);
+                $provider->getError = null;
+                $provider->cachedData = ['flags' => 'malformed'];
+                $client->loadFlags();
+                $this->assertVersionedResults($client, false);
+                $provider->cachedData = null;
+                $client->loadFlags();
+                $this->assertVersionedResults($client, false);
+            }
+        }
+        $this->assertSame([], $httpClient->calls ?? []);
+    }
+
+    public function testReloadDuringEvaluationDoesNotChangeItsDefinitionSnapshot(): void
+    {
+        foreach (['all', 'snapshot', 'single'] as $api) {
+            $provider = new MockFlagDefinitionCacheProvider();
+            $provider->shouldFetch = false;
+            $definitions = $this->versionedDefinitions(2);
+            $definitions['flags'][0]['filters']['groups'][0]['properties'] = [
+                ['key' => 'reload', 'value' => '"trigger"', 'operator' => 'exact'],
+                ['key' => 'value', 'value' => false, 'operator' => 'exact'],
+            ];
+            $provider->cachedData = $definitions;
+            $httpClient = new MockedHttpClient(host: 'app.posthog.com');
+            $client = $this->createClient($provider, $httpClient);
+            $provider->cachedData = $this->versionedDefinitions(1);
+            $reloadValue = new class ($client) implements \JsonSerializable {
+                public function __construct(private Client $client)
+                {
+                }
+
+                public function jsonSerialize(): mixed
+                {
+                    $this->client->loadFlags();
+                    return 'trigger';
+                }
+            };
+            $personProperties = ['value' => 'banana', 'reload' => $reloadValue];
+            $groups = ['company' => 'acme'];
+            $groupProperties = ['company' => ['value' => 'banana']];
+            if ($api === 'all') {
+                $results = $client->getAllFlags('user', $groups, $personProperties, $groupProperties);
+                $this->assertSame(array_fill_keys(array_column($definitions['flags'], 'key'), false), $results);
+            } elseif ($api === 'snapshot') {
+                $snapshot = $client->evaluateFlags('user', $groups, $personProperties, $groupProperties);
+                foreach (array_column($definitions['flags'], 'key') as $key) {
+                    $this->assertFalse($snapshot->getFlag($key));
+                }
+            } else {
+                set_error_handler(static fn ($errno) => $errno === E_USER_DEPRECATED, E_USER_DEPRECATED);
+                try {
+                    $this->assertFalse($client->getFeatureFlag(
+                        'person', 'user', $groups, $personProperties, $groupProperties, false, false
+                    ));
+                } finally {
+                    restore_error_handler();
+                }
+            }
+            // The reentrant reload applies to the next call, not the evaluation in progress.
+            $this->assertVersionedResults($client, true);
+            $this->assertSame([], $httpClient->calls ?? []);
+        }
+    }
+
+    public function testVersionedMissingPropertyStillFallsBackRemotely(): void
+    {
+        foreach ([1, 2] as $version) {
+            $provider = new MockFlagDefinitionCacheProvider();
+            $provider->shouldFetch = false;
+            $provider->cachedData = $this->versionedDefinitions($version);
+            $httpClient = new MockedHttpClient(
+                host: 'app.posthog.com',
+                flagsEndpointResponse: ['flags' => ['person' => ['enabled' => true, 'variant' => null]]]
+            );
+            $client = $this->createClient($provider, $httpClient);
+            $local = $client->evaluateFlags('user', onlyEvaluateLocally: true, flagKeys: ['person']);
+            $this->assertSame([], $local->getKeys());
+            $this->assertSame([], $httpClient->calls ?? []);
+            $remote = $client->evaluateFlags('user', flagKeys: ['person']);
+            $this->assertTrue($remote->getFlag('person'));
+            $this->assertCount(1, $httpClient->calls);
+            $this->assertStringStartsWith('/flags/?', $httpClient->calls[0]['path']);
+        }
+    }
+
+    private function assertVersionedResults(Client $client, bool $expected): void
+    {
+        $groups = ['company' => 'acme'];
+        $properties = ['value' => 'banana'];
+        $groupProperties = ['company' => $properties];
+        $expectedFlags = array_fill_keys(['person', 'group', 'mixed', 'cohort', 'dependency', 'cohort-dependency'], $expected);
+        $this->assertSame($expectedFlags, $client->getAllFlags('user', $groups, $properties, $groupProperties));
+        $snapshot = $client->evaluateFlags('user', $groups, $properties, $groupProperties);
+        foreach ($expectedFlags as $key => $value) {
+            $this->assertSame($value, $snapshot->getFlag($key));
+        }
+        // Exercise the legacy single-flag entry point without its intentional deprecation warning.
+        set_error_handler(static fn ($errno) => $errno === E_USER_DEPRECATED, E_USER_DEPRECATED);
+        try {
+            $this->assertSame($expected, $client->getFeatureFlag(
+                'person', 'user', $groups, $properties, $groupProperties, false, false
+            ));
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    private function assertOnlyDefinitionsRequests(MockedHttpClient $httpClient): void
+    {
+        foreach ($httpClient->calls ?? [] as $call) {
+            $this->assertStringStartsWith('/flags/definitions?', $call['path']);
+        }
+    }
+
+    private function versionedDefinitions(?int $version): array
+    {
+        $leaf = ['key' => 'value', 'type' => 'person', 'value' => false, 'operator' => 'exact'];
+        $cohort = ['key' => 'id', 'type' => 'cohort', 'value' => 1];
+        $dependency = [
+            'key' => 'person', 'type' => 'flag', 'value' => true,
+            'operator' => 'flag_evaluates_to', 'dependency_chain' => ['person'],
+        ];
+        $makeFlag = static fn ($key, $property) => [
+            'key' => $key, 'active' => true, 'version' => 2,
+            'filters' => ['groups' => [['properties' => [$property], 'rollout_percentage' => 100]]],
+        ];
+        $flags = [
+            $makeFlag('person', $leaf),
+            $makeFlag('group', $leaf),
+            $makeFlag('mixed', $leaf),
+            $makeFlag('cohort', $cohort),
+            $makeFlag('dependency', $dependency),
+            $makeFlag('cohort-dependency', ['key' => 'id', 'type' => 'cohort', 'value' => 3]),
+        ];
+        $flags[1]['filters']['aggregation_group_type_index'] = 0;
+        $flags[2]['filters']['groups'][0]['aggregation_group_type_index'] = 0;
+        $data = [
+            'flags' => $flags,
+            'group_type_mapping' => ['0' => 'company'],
+            'cohorts' => [
+                '1' => ['type' => 'AND', 'values' => [
+                    ['type' => 'OR', 'values' => [['key' => 'id', 'type' => 'cohort', 'value' => 2]]],
+                ]],
+                '2' => ['type' => 'AND', 'values' => [$leaf]],
+                '3' => ['type' => 'AND', 'values' => [$dependency]],
+            ],
+        ];
+        if ($version !== null) {
+            $data['property_matching_version'] = $version;
+        }
+        return $data;
+    }
+
     private function createClient(MockFlagDefinitionCacheProvider $provider, MockedHttpClient $httpClient): Client
     {
         return new Client(

--- a/test/VersionedPropertyMatchingTest.php
+++ b/test/VersionedPropertyMatchingTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace PostHog\Test;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use PostHog\FeatureFlag;
+use PostHog\InconclusiveMatchException;
+
+class VersionedPropertyMatchingTest extends TestCase
+{
+    public static function matchingCases(): iterable
+    {
+        $rows = [
+            'false banana' => [false, 'banana', true, false],
+            'false zero' => [false, 0, true, false],
+            'boolean list true' => [['true', 'false'], 'true', false, true],
+            'boolean list pro' => [['true', 'false'], 'pro', true, false],
+            'empty true' => [[], true, true, true],
+            'empty empty' => [[], [], true, true],
+            'true list' => [true, [true], true, false],
+            'false uppercase' => [false, 'FALSE', true, true],
+            'false null' => [false, null, true, false],
+            'false empty string' => [false, '', true, false],
+            'empty nested truthy' => [[], [true, 'TRUE', [[]]], true, true],
+            'empty nested falsy' => [[], [true, [0]], false, false],
+            'empty false' => [[], false, false, false],
+            'empty zero' => [[], 0, false, false],
+            'empty banana' => [[], 'banana', false, false],
+            'empty null' => [[], null, false, false],
+            'mixed boolean' => [[false, 'PRO'], 'FALSE', true, true],
+            'mixed string' => [[true, 'PRO'], 'pro', true, true],
+            'mixed numeric' => [[1, 'PRO'], '1', true, true],
+            'mixed null' => [[null, 'PRO'], 'null', true, true],
+            'nested normalized array' => [[[true, true], 'PRO'], [true, true], true, true],
+            'whole property array' => [[true], [true], true, false],
+            'recursive boolean filter' => [[[true, false]], 'banana', true, false],
+            'nested empty filter' => [[[]], true, true, false],
+            'nested empty member' => [[[]], [], true, true],
+            'boolean list boolean true' => [['TrUe', 'FALSE'], true, false, true],
+            'boolean list boolean false' => [['TrUe', 'FALSE'], false, true, true],
+            'null normalized' => ['null', null, true, true],
+            'unicode expansion' => ['İ', "i\u{0307}", true, true],
+            'unicode sigma' => ['ΟΣ', 'ος', true, true],
+            'normal string' => ['PRO', 'pro', true, true],
+        ];
+        foreach ($rows as $name => [$filter, $property, $legacy, $explicit]) {
+            foreach ([null, 1, 2, 0, 3, '2'] as $version) {
+                yield $name . ' version ' . json_encode($version) => [
+                    $filter, $property, $version, $version === 2 ? $explicit : $legacy,
+                ];
+            }
+        }
+    }
+
+    #[DataProvider('matchingCases')]
+    public function testExactAndIsNot($filter, $value, $version, bool $expected): void
+    {
+        foreach (['exact', 'is_not'] as $operator) {
+            $property = ['key' => 'value', 'value' => $filter, 'operator' => $operator];
+            $actual = $version === null
+                ? FeatureFlag::matchProperty($property, ['value' => $value])
+                : FeatureFlag::matchProperty($property, ['value' => $value], $version);
+            self::assertSame($operator === 'exact' ? $expected : !$expected, $actual);
+        }
+    }
+
+    public static function missingCases(): iterable
+    {
+        foreach ([1, 2] as $version) {
+            foreach (['exact', 'is_not'] as $operator) {
+                yield [$version, $operator];
+            }
+        }
+    }
+
+    #[DataProvider('missingCases')]
+    public function testMissingPropertyRemainsInconclusive(int $version, string $operator): void
+    {
+        self::expectException(InconclusiveMatchException::class);
+        FeatureFlag::matchProperty(['key' => 'missing', 'value' => false, 'operator' => $operator], [], $version);
+    }
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

Local feature flag evaluation needs to honor the matching version returned with flag definitions. This follows the backend behavior in https://github.com/PostHog/posthog/pull/90694 and shared contract in https://github.com/PostHog/sdk-specs/pull/59.

- Missing metadata, version 1, and unsupported selectors keep released legacy matching. Only integer version 2 enables explicit scalar equality and member equality for nonempty filter arrays, using existing string and Unicode normalization. Empty filters retain recursive truthiness. For known properties, `is_not` complements `exact`. Missing properties still allow remote fallback.
- The API response projection and external cache provider projection both retain `property_matching_version`. Providers receive the complete normalized snapshot for storage. Cache reads without the selector reset to legacy matching. The existing `groupTypeMapping` alias remains supported for group mapping, not for version metadata.
- Each local evaluation captures definitions, their index, group mapping, cohorts, and matching version together. Person, group, mixed-group, cohort, and dependency evaluation use that snapshot. Version-only reloads take effect on the next evaluation. Failed loads and HTTP 304 responses preserve the previous snapshot.
- Five public `FeatureFlag` evaluation helpers gain a trailing optional `propertyMatchingVersion` parameter defaulting to 1. Existing calls remain compatible, and the public API snapshot records the additions. The external cache provider contract documents preserving the metadata. The existing patch change intent is included.

Related optional harness coverage is https://github.com/PostHog/posthog-sdk-test-harness/pull/53. This PR does not opt a PHP adapter into that coverage.

## :green_heart: How did you test it?

Reran these checks on the source tree committed as `65ca15245e9c4d19b5311e285a3833fec6c0d2ad` with PHP 8.5.10 and PHPUnit 11.5.55:

```sh
./vendor/bin/phpunit --bootstrap vendor/autoload.php --configuration phpunit.xml --no-coverage --filter 'VersionedPropertyMatchingTest|testMatchingVersionSurvivesApiAndProviderRoundTrip|testVersionOnly|testReloadDuringEvaluation|testVersionedMissing'
php scripts/check-public-api.php
./vendor/bin/phpcs --standard=phpcs.xml -n lib/FeatureFlag.php lib/Client.php lib/FlagDefinitionCacheProvider.php test/VersionedPropertyMatchingTest.php test/FlagDefinitionCacheProviderTest.php
git diff --check
```

All exited successfully. The focused run passed 195 tests and 613 assertions, with 42 existing PHPUnit metadata deprecations. Tests exercise the real Client and evaluator with mocked HTTP/provider boundaries, including cache round-trips, version-only transitions, nested conditions, reentrant reloads, and remote fallback. Positive local cases permit fallback and assert that no remote flag request occurs.

Earlier implementation validation passed the broader flag suite with 471 tests and 3819 assertions. That earlier run reported four existing SDK deprecated-method notices as well as the metadata deprecations. PHPCS without `-n` previously reported 13 unchanged-line length warnings and no errors. The complete unrelated suite, coverage, and live-service integration were not run in this publication pass. Local checks are not a CI result.

The required isolated committed-branch autoreview passed for this exact commit against `origin/main` at `6da44cd256743e9ba08c14a685dc8e8c5ac1e561`, with no actionable findings.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm change` to generate a change intent file

The existing `.changeset/versioned-property-matching.md` records a patch intent. It was preserved without rerunning the generator or adding a duplicate.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi agents assisted implementation and publication under human direction. Tools used included Git, PHP, PHPUnit, PHP_CodeSniffer, GitHub CLI, and the isolated Pi autoreview helper with TruffleHog. The local agent session is not publicly shared.

The implementation preserves legacy defaults and optional helper arguments while keeping matching metadata with each definition snapshot. Publication retained the approved changes and used a new signed commit without rewriting history. Human review is required before merging.
